### PR TITLE
Implemented ScoreVerifier

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/AbstractVerifier.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/AbstractVerifier.java
@@ -1,0 +1,61 @@
+package com.sap.sgs.phosphor.fosstars.model.qa;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public abstract class AbstractVerifier {
+
+  /**
+   * A list of test vectors.
+   */
+  final List<TestVector> vectors;
+
+  /**
+   * A logger.
+   */
+  private final Logger logger = LogManager.getLogger(getClass());
+
+  /**
+   * Initialize a verifier.
+   *
+   * @param vectors A list of test vectors.
+   */
+  AbstractVerifier(List<TestVector> vectors) {
+    Objects.requireNonNull(vectors, "Vectors can't be null!");
+
+    if (vectors.isEmpty()) {
+      throw new IllegalArgumentException("No test vectors specified!");
+    }
+
+    this.vectors = Collections.unmodifiableList(vectors);
+  }
+
+  /**
+   * Check the rating against the test vectors and returns a list of failed test vectors.
+   *
+   * @return A list of failed test vectors.
+   */
+  abstract List<FailedTestVector> runImpl();
+
+  /**
+   * Check the rating against the test vectors, and throws a {@link VerificationFailedException} if
+   * at least one test vector failed.
+   *
+   * @throws VerificationFailedException If at least one test vector failed.
+   */
+  public final void run() throws VerificationFailedException {
+    List<FailedTestVector> failedVectors = runImpl();
+    for (FailedTestVector vector : failedVectors) {
+      logger.info("Test vector #{} failed", vector.index);
+      logger.info("    reason: {}", vector.reason);
+      logger.info("    alias:  {}", vector.vector.alias());
+    }
+
+    if (!failedVectors.isEmpty()) {
+      throw new VerificationFailedException();
+    }
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/RatingVerifier.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/RatingVerifier.java
@@ -3,20 +3,14 @@ package com.sap.sgs.phosphor.fosstars.model.qa;
 import com.sap.sgs.phosphor.fosstars.model.Label;
 import com.sap.sgs.phosphor.fosstars.model.Rating;
 import com.sap.sgs.phosphor.fosstars.model.RatingValue;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
- * A verifier that checks that a rating passes tests defined by test vectors.
+ * The verifier checks that a rating passes tests defined by test vectors.
  */
-public class RatingVerifier {
-
-  private static final Logger LOGGER = LogManager.getLogger(RatingVerifier.class);
+public class RatingVerifier extends AbstractVerifier {
 
   /**
    * A rating to be verified.
@@ -24,24 +18,16 @@ public class RatingVerifier {
   private final Rating rating;
 
   /**
-   * A list of test vectors.
-   */
-  private final List<TestVector> vectors;
-
-  /**
+   * Initializes a new verifier.
+   *
    * @param rating A rating to be verified.
    * @param vectors A list of test vectors.
    */
   public RatingVerifier(Rating rating, List<TestVector> vectors) {
+    super(vectors);
+
     Objects.requireNonNull(rating, "Rating can't be null!");
-    Objects.requireNonNull(vectors, "Vectors can't be null!");
-
-    if (vectors.isEmpty()) {
-      throw new IllegalArgumentException("No test vectors specified!");
-    }
-
     this.rating = rating;
-    this.vectors = Collections.unmodifiableList(vectors);
   }
 
   /**
@@ -49,19 +35,19 @@ public class RatingVerifier {
    *
    * @return A list of failed test vectors.
    */
-  public Set<FailedTestVector> failedVectors() {
-    Set<FailedTestVector> failedVectors = new HashSet<>();
+  public List<FailedTestVector> runImpl() {
+    List<FailedTestVector> failedVectors = new ArrayList<>();
 
     int index = 0;
     for (TestVector vector : vectors) {
       RatingValue ratingValue = rating.calculate(vector.values());
-      double actualScore = ratingValue.score();
-      if (!vector.expectedScore().contains(actualScore)) {
+      double score = ratingValue.score();
+      if (!vector.containsExpected(score)) {
         failedVectors.add(new FailedTestVector(
             vector,
             index,
             String.format("Expected a score in the interval %s but %s returned",
-                vector.expectedScore(), actualScore)));
+                vector.expectedScore(), score)));
       }
 
       Label actualLabel = ratingValue.label();
@@ -71,32 +57,12 @@ public class RatingVerifier {
             index,
             String.format("Expected label '%s' but '%s' returned",
                 vector.expectedLabel(), actualLabel)));
-
       }
 
       index++;
     }
 
     return failedVectors;
-  }
-
-  /**
-   * Check the rating against the test vectors, and throws a {@link VerificationFailedException}
-   * if at least one test vector failed.
-   *
-   * @throws VerificationFailedException If at least one test vector failed.
-   */
-  public void run() throws VerificationFailedException {
-    Set<FailedTestVector> failedVectors = failedVectors();
-    for (FailedTestVector vector : failedVectors) {
-      LOGGER.info("Test vector #{} failed", vector.index);
-      LOGGER.info("    reason: {}", vector.reason);
-      LOGGER.info("    alias: {}", vector.vector.alias());
-    }
-
-    if (!failedVectors.isEmpty()) {
-      throw new VerificationFailedException();
-    }
   }
 
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreVerifier.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreVerifier.java
@@ -1,0 +1,58 @@
+package com.sap.sgs.phosphor.fosstars.model.qa;
+
+import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.ScoreValue;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The verifier checks that a score passes tests defined by test vectors.
+ */
+public class ScoreVerifier extends AbstractVerifier {
+
+  /**
+   * A score to be verified.
+   */
+  private final Score score;
+
+  /**
+   * Initializes a new verifier.
+   *
+   * @param score A score to be verified.
+   * @param vectors A list of test vectors.
+   */
+  public ScoreVerifier(Score score, List<TestVector> vectors) {
+    super(vectors);
+
+    Objects.requireNonNull(score, "Score can't be null!");
+    this.score = score;
+  }
+
+  /**
+   * Check if the score produces expected score values defined by the test vectors.
+   *
+   * @return A list of failed test vectors.
+   */
+  public List<FailedTestVector> runImpl() {
+    List<FailedTestVector> failedVectors = new ArrayList<>();
+
+    int index = 0;
+    for (TestVector vector : vectors) {
+      ScoreValue scoreValue = score.calculate(vector.values());
+      double actualScore = scoreValue.score();
+      if (!vector.expectedScore().contains(actualScore)) {
+        failedVectors.add(new FailedTestVector(
+            vector,
+            index,
+            String.format("Expected a score in the interval %s but %s returned",
+                vector.expectedScore(), actualScore)));
+      }
+
+      index++;
+    }
+
+    return failedVectors;
+  }
+
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVector.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVector.java
@@ -49,6 +49,8 @@ public class TestVector {
   private final String alias;
 
   /**
+   * Initializes a new {@link TestVector}.
+   *
    * @param values A set of feature values.
    * @param expectedScore An interval for an expected score.
    * @param expectedLabel An expected label (can be null).
@@ -75,7 +77,7 @@ public class TestVector {
   }
 
   /**
-   * @return The feature values.
+   * Returns the feature values.
    */
   @JsonGetter("values")
   public final Set<Value> values() {
@@ -83,7 +85,7 @@ public class TestVector {
   }
 
   /**
-   * @return The expected score.
+   * Returns the expected score.
    */
   @JsonGetter("expectedScore")
   public final Interval expectedScore() {
@@ -91,6 +93,18 @@ public class TestVector {
   }
 
   /**
+   * Checks if a score belongs to the expected interval.
+   *
+   * @param score The score to be checked.
+   * @return True if the score belongs to the expected interval, false otherwise.
+   */
+  public boolean containsExpected(double score) {
+    return expectedScore.contains(score);
+  }
+
+  /**
+   * Checks if the test vector has a label.
+   *
    * @return True if the test vector has a label, false otherwise.
    */
   public boolean hasLabel() {
@@ -98,7 +112,7 @@ public class TestVector {
   }
 
   /**
-   * @return The expected label.
+   * Returns the expected label.
    */
   @JsonGetter("expectedLabel")
   public final Label expectedLabel() {
@@ -106,7 +120,7 @@ public class TestVector {
   }
 
   /**
-   * @return The alias.
+   * Returns the alias.
    */
   @JsonGetter("alias")
   public final String alias() {
@@ -122,10 +136,10 @@ public class TestVector {
       return false;
     }
     TestVector vector = (TestVector) o;
-    return Objects.equals(values, vector.values) &&
-        Objects.equals(expectedScore, vector.expectedScore) &&
-        Objects.equals(expectedLabel, vector.expectedLabel) &&
-        Objects.equals(alias, vector.alias);
+    return Objects.equals(values, vector.values)
+        && Objects.equals(expectedScore, vector.expectedScore)
+        && Objects.equals(expectedLabel, vector.expectedLabel)
+        && Objects.equals(alias, vector.alias);
   }
 
   @Override
@@ -151,19 +165,6 @@ public class TestVector {
     return MAPPER.readValue(
         is,
         MAPPER.getTypeFactory().constructCollectionType(List.class, TestVector.class));
-  }
-
-  /**
-   * Loads test vectors from a resource.
-   *
-   * @param name A name of the resource.
-   * @return A list of test vectors.
-   * @throws IOException If something went wrong.
-   */
-  static List<TestVector> loadFromResource(String name) throws IOException {
-    try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(name)) {
-      return TestVector.loadTestVectorsFromJson(is);
-    }
   }
 
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/tuning/AbstractWeightsOptimization.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/tuning/AbstractWeightsOptimization.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -48,6 +47,8 @@ public abstract class AbstractWeightsOptimization {
   protected final String path;
 
   /**
+   * Initialize a new instance.
+   *
    * @param rating A rating to be tuned.
    * @param vectors A list of test vectors.
    * @param path A path where a serialized rating should be stored to.
@@ -71,7 +72,8 @@ public abstract class AbstractWeightsOptimization {
   /**
    * Starts weights optimization for the specified rating.
    *
-   * @throws VerificationFailedException If some test vectors still fail after the optimization was done.
+   * @throws VerificationFailedException If some test vectors still fail
+   *                                     after the optimization was done.
    * @throws IOException If something went wrong during storing the rating to a file.
    */
   public final void run() throws VerificationFailedException, IOException {
@@ -89,7 +91,7 @@ public abstract class AbstractWeightsOptimization {
       }
     }
 
-    Set<FailedTestVector> failedVectors = new RatingVerifier(rating, vectors).failedVectors();
+    List<FailedTestVector> failedVectors = new RatingVerifier(rating, vectors).runImpl();
     for (FailedTestVector failedVector : failedVectors) {
       LOGGER.info("Test vector #{} failed", failedVector.index);
       LOGGER.info("  reason: {}", failedVector.reason);
@@ -99,7 +101,8 @@ public abstract class AbstractWeightsOptimization {
       LOGGER.info("    expected label: {}", failedVector.vector.expectedLabel());
       LOGGER.info("    features:");
       for (Value value : failedVector.vector.values()) {
-        LOGGER.info("      {}: {}", value.feature(), value.isUnknown() ? "unknown" : value.get());
+        LOGGER.info("      {}: {}",
+            value.feature(), value.isUnknown() ? "unknown" : value.get());
       }
     }
 
@@ -107,7 +110,8 @@ public abstract class AbstractWeightsOptimization {
       LOGGER.info("Gut gemacht, all test vectors passed!");
       RatingRepository.INSTANCE.store(rating, path);
     } else {
-      LOGGER.warn("{} test vector{} failed!", failedVectors.size(), failedVectors.size() == 1 ? "" : "s");
+      LOGGER.warn("{} test vector{} failed!",
+          failedVectors.size(), failedVectors.size() == 1 ? "" : "s");
       throw new VerificationFailedException("Some test vectors failed!");
     }
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/tuning/MonteCarloWeightsOptimization.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/tuning/MonteCarloWeightsOptimization.java
@@ -68,7 +68,7 @@ public class MonteCarloWeightsOptimization extends AbstractWeightsOptimization {
    * @return True if all test vector are passes, and false otherwise.
    */
   private boolean passTestVectors() {
-    Set<FailedTestVector> failedVectors = verifier.failedVectors();
+    List<FailedTestVector> failedVectors = verifier.runImpl();
     return failedVectors.isEmpty();
   }
 

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreVerifierTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreVerifierTest.java
@@ -2,14 +2,12 @@ package com.sap.sgs.phosphor.fosstars.model.qa;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.sap.sgs.phosphor.fosstars.model.RatingRepository;
 import com.sap.sgs.phosphor.fosstars.model.feature.example.ExampleFeatures;
 import com.sap.sgs.phosphor.fosstars.model.math.DoubleInterval;
 import com.sap.sgs.phosphor.fosstars.model.rating.example.SecurityRatingExample;
-import com.sap.sgs.phosphor.fosstars.model.rating.example.SecurityRatingExample.SecurityLabelExample;
 import com.sap.sgs.phosphor.fosstars.model.rating.example.SecurityRatingExampleVerification;
 import com.sap.sgs.phosphor.fosstars.model.value.BooleanValue;
 import com.sap.sgs.phosphor.fosstars.model.value.IntegerValue;
@@ -17,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
 
-public class RatingVerifierTest {
+public class ScoreVerifierTest {
 
   // an extra test vector which is supposed to fail
   private static final TestVector FAILING_TEST_VECTOR = TestVectorBuilder.newTestVector()
@@ -26,7 +24,6 @@ public class RatingVerifierTest {
       .set(new BooleanValue(ExampleFeatures.SECURITY_REVIEW_DONE_EXAMPLE, false))
       .set(new BooleanValue(ExampleFeatures.STATIC_CODE_ANALYSIS_DONE_EXAMPLE, false))
       .expectedScore(DoubleInterval.init().from(9).to(10).make())
-      .expectedLabel(SecurityLabelExample.AWESOME)
       .make();
 
   private static final List<TestVector> TEST_VECTORS = new ArrayList<>();
@@ -37,39 +34,25 @@ public class RatingVerifierTest {
 
   @Test
   public void failedVectors() {
-    RatingVerifier verifier = new RatingVerifier(
-        RatingRepository.INSTANCE.get(SecurityRatingExample.class),
+    ScoreVerifier verifier = new ScoreVerifier(
+        RatingRepository.INSTANCE.get(SecurityRatingExample.class).score(),
         TEST_VECTORS);
 
     List<FailedTestVector> failedVectors = verifier.runImpl();
 
-    assertEquals(2, failedVectors.size());
-
-    FailedTestVector failedVector = failedVectors.get(0);
+    assertEquals(1, failedVectors.size());
+    FailedTestVector failedVector = failedVectors.iterator().next();
     assertNotNull(failedVector);
     assertEquals(6, failedVector.index);
     assertNotNull(failedVector.reason);
-    String firstReason = failedVector.reason;
-    assertNotNull(firstReason);
-    assertFalse(firstReason.isEmpty());
+    assertFalse(failedVector.reason.isEmpty());
     assertEquals(FAILING_TEST_VECTOR, failedVector.vector);
-
-    failedVector = failedVectors.get(1);
-    assertNotNull(failedVector);
-    assertEquals(6, failedVector.index);
-    assertNotNull(failedVector.reason);
-    String secondReason = failedVector.reason;
-    assertNotNull(secondReason);
-    assertFalse(secondReason.isEmpty());
-    assertEquals(FAILING_TEST_VECTOR, failedVector.vector);
-
-    assertNotEquals(firstReason, secondReason);
   }
 
   @Test(expected = VerificationFailedException.class)
   public void run() throws VerificationFailedException {
-    RatingVerifier verifier = new RatingVerifier(
-        RatingRepository.INSTANCE.get(SecurityRatingExample.class),
+    ScoreVerifier verifier = new ScoreVerifier(
+        RatingRepository.INSTANCE.get(SecurityRatingExample.class).score(),
         TEST_VECTORS);
 
     verifier.run();


### PR DESCRIPTION
Here is a list of updates:

- Added `AbstractVerifier` and `ScoreVerifier` classes
- Added `ScoreVerifierTest`
- Renamed `RatingVerifier.failedVectors()` to `runImpl()`
- `runImpl()` returns a list instead of a set
- Fixed checkstyle warnings in the modified files