### PR TITLE
Updated groupId and artifactId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.sap.sgs.phosphor.fosstars</groupId>
-  <artifactId>fosstars-model</artifactId>
-  <version>0.7.0-SNAPSHOT</version>
+  <groupId>com.sap.phosphor</groupId>
+  <artifactId>fosstars-rating-core</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
   <name>Fosstars Rating Core</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Updated `pom.xml` file:

- Updated groupId to `com.sap.phosphor`.
- Use `fosstars-rating-core` as artifactId.
- Reset the version to `0.1.0`.

Fixes #44