### PR TITLE
Fixed Confidence.make() and introduced PrettyPrinter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,82 +46,114 @@ mvn clean install
 
 There is a command line tool which takes a URL to a project on GitHub, fetches data about it,
 and calculates a security rating.
-The tool can interact with a user to get more data about the project.
 
 The tool can be run with a command like the following:
 
 ```
-java -jar target/fosstars-github-rating-calc.jar --token ${TOKEN} --url https://github.com/apache/poi
+java -jar target/fosstars-github-rating-calc.jar --token ${TOKEN} --url https://github.com/apache/poi --no-questions
 ```
 
 The `TOKEN` variable contains a token for accessing the GitHub API.
 You can create a personal token in the
 [settings/tokens](https://github.com/settings/tokens) tab in your profile on GitHub.
 
-The tool is a bit interactive, and can ask several question. The dialog looks like the following:
+The output is going to look like the following:
 
 ```
 [+] Project: https://github.com/apache/poi
-[+] Let's get info about the project and calculate a rating
-[?] Are you aware about any unpatched vulnerability in the project? (yes/no)
->>> no
-Downloading files at Wed Oct 23 13:35:52 CEST 2019
-Using local NVD cache as last update was within two hours
+[+] Let's get info about the project and calculate a security rating
+[+] Counting how many commits have been done in the last three months ...
+[+] Counting how many people contributed to the project in the last three months ...
+[+] Counting how many stars the project has ...
+[+] Counting how many watchers the project has ...
+[+] Figuring out when the first commit was done ...
+[+] Figuring out when the project started ...
+[+] Figuring out if the project has a security team ...
+[+] Figuring out if the project is supported by a company ...
+[+] Figuring out if the project has a security policy ...
+[+] Figuring out if any security review has been done for the project ...
+[+] Figuring out if the project has any unpatched vulnerability ...
+[+] Looking for vulnerabilities in NVD ...
+[+] Figuring out if the project belongs to the Apache Software Foundation ...
+[+] Figuring out if the project belongs to the Eclipse Software Foundation ...
+[+] Figuring out if the project uses OWASP Dependency Check ...
 [+] Here is what we know about the project:
 [+]    If an open-source project belongs to Eclipse Foundation: false
 [+]    If an open-source project is regularly scanned for vulnerable dependencies: false
 [+]    If an open-source project has a security team: true
 [+]    Number of watchers for a GitHub repository: 78
-[+]    Number of contributors last three months: 4
+[+]    Number of contributors in the last three months: 5
 [+]    If an open-source project has a security policy: false
 [+]    Info about vulnerabilities in open-source project: 8 vulnerabilities
-[+]    Security reviews for an OSS project: 0 security reviews
-[+]    Number of stars for a GitHub repository: 861
+[+]    Number of stars for a GitHub repository: 923
 [+]    When first commit was done: Thu Jan 31 03:22:28 CET 2002
-[+]    Number of commits last three months: 91
+[+]    Number of commits in the last three months: 143
+[+]    Security reviews for an open-source project: 0 security reviews
 [+]    When a project started: Thu Jan 31 03:22:28 CET 2002
 [+]    If an open-source project belongs to Apache Foundation: true
 [+]    If an open-source project is supported by a company: false
-[+] Rating: 5.92 out of 10.00, OKAY
+[+] Rating: 5.43 out of 10.00 -> OKAY
 [+] Confidence: 10.00 out of 10.00
+[+] Here is how the rating was calculated:
+[+]   Score:........Security score for open-source projects
+[+]   Value:........5.43  out of 10.00
+[+]   Confidence:...10.00 out of 10.00
+[+]   Based on:.....7 sub-scores:
+[+]       Score:........How well open-source community commits to support an open-source project
+[+]       Value:........7.00  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]         Based on:...3 features:
+[+]           If an open-source project is supported by a company:.......false
+[+]           If an open-source project belongs to Apache Foundation:....true
+[+]           If an open-source project belongs to Eclipse Foundation:...false
+[+]
+[+]       Score:........Open-source project activity score
+[+]       Value:........9.07  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]         Based on:...2 features:
+[+]           Number of commits in the last three months:........143
+[+]           Number of contributors in the last three months:...5
+[+]
+[+]       Score:........How well vulnerabilities are patched
+[+]       Value:........10.00 out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]         Based on:...1 features:
+[+]           Info about vulnerabilities in open-source project:...8 vulnerabilities
+[+]
+[+]       Score:........How well security testing is done for an open-source project
+[+]       Value:........0.00  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]         Based on:...2 features:
+[+]           Security reviews for an open-source project:..................................0 security reviews
+[+]           If an open-source project is regularly scanned for vulnerable dependencies:...false
+[+]
+[+]       Score:........How fast vulnerabilities are patched
+[+]       Value:........7.17  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]         Based on:...3 features:
+[+]           Info about vulnerabilities in open-source project:...8 vulnerabilities
+[+]           When a project started:..............................Thu Jan 31 03:22:28 CET 2002
+[+]           When first commit was done:..........................Thu Jan 31 03:22:28 CET 2002
+[+]
+[+]       Score:........How well open-source community is aware about security
+[+]       Value:........8.00  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]         Based on:...2 features:
+[+]           If an open-source project has a security policy:...false
+[+]           If an open-source project has a security team:.....true
+[+]
+[+]       Score:........Open-source project popularity score
+[+]       Value:........1.18  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]         Based on:...2 features:
+[+]           Number of stars for a GitHub repository:......923
+[+]           Number of watchers for a GitHub repository:...78
+[+]
 [+] Bye!
 ```
 
-A user can ask the tool to be silent by passing `--no-questions`.
-Then, the tool is going to use only data which may be collected automatically.
-Here is an example:
-
-```
-java -jar target/fosstars-github-rating-calc.jar --token ${TOKEN} --no-questions \
-        --url https://github.com/apache/poi
-```
-
-The output looks like the following:
-
-```
-[+] Project: https://github.com/apache/poi
-[+] Let's get info about the project and calculate a rating
-Downloading files at Wed Oct 23 13:41:21 CEST 2019
-Using local NVD cache as last update was within two hours
-[+] Here is what we know about the project:
-[+]    If an open-source project belongs to Eclipse Foundation: false
-[+]    If an open-source project is regularly scanned for vulnerable dependencies: false
-[+]    If an open-source project has a security team: true
-[+]    Number of watchers for a GitHub repository: 78
-[+]    Number of contributors last three months: 4
-[+]    If an open-source project has a security policy: false
-[+]    Info about vulnerabilities in open-source project: 8 vulnerabilities
-[+]    Security reviews for an OSS project: 0 security reviews
-[+]    Number of stars for a GitHub repository: 861
-[+]    When first commit was done: Thu Jan 31 03:22:28 CET 2002
-[+]    Number of commits last three months: 91
-[+]    When a project started: Thu Jan 31 03:22:28 CET 2002
-[+]    If an open-source project belongs to Apache Foundation: true
-[+]    If an open-source project is supported by a company: false
-[+] Rating: 5.92 out of 10.00, OKAY
-[+] Confidence: 10.00 out of 10.00
-[+] Bye!
-```
+If no `--no-questions` option is specified, the tool becomes a bit interactive,
+and may ask the user a couple of questions.
 
 ## Known issues
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/Confidence.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/Confidence.java
@@ -85,7 +85,7 @@ public interface Confidence {
       return MAX;
     }
 
-    return (MAX * unknown) / values.length;
+    return MAX * (values.length - unknown) / values.length;
   }
 
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/WeightedCompositeScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/WeightedCompositeScore.java
@@ -16,7 +16,6 @@ import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
 import com.sap.sgs.phosphor.fosstars.model.weight.ImmutableWeight;
 import com.sap.sgs.phosphor.fosstars.model.weight.MutableWeight;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -117,11 +116,13 @@ public class WeightedCompositeScore extends AbstractScore implements Tunable {
     double weightSum = 0.0;
     double scoreSum = 0.0;
     double confidenceSum = 0.0;
+    ScoreValue scoreValue = new ScoreValue(this);
     for (WeightedScore weightedScore : weightedScores) {
       double weight = weightedScore.weight.value();
-      ScoreValue scoreValue = calculateIfNecessary(weightedScore.score, valueSet);
-      scoreSum += weight * scoreValue.get();
-      confidenceSum += weight * scoreValue.confidence();
+      ScoreValue subScoreValue = calculateIfNecessary(weightedScore.score, valueSet);
+      scoreValue.usedValues(subScoreValue);
+      scoreSum += weight * subScoreValue.get();
+      confidenceSum += weight * subScoreValue.confidence();
       weightSum += weight;
     }
 
@@ -129,11 +130,10 @@ public class WeightedCompositeScore extends AbstractScore implements Tunable {
       throw new IllegalArgumentException("Oh no! Looks like all weights are zero!");
     }
 
-    return new ScoreValue(
-        this,
-        Score.adjust(scoreSum / weightSum),
-        Confidence.adjust(confidenceSum / weightSum),
-        Arrays.asList(values));
+    scoreValue.set(Score.adjust(scoreSum / weightSum));
+    scoreValue.confidence(Confidence.adjust(confidenceSum / weightSum));
+
+    return scoreValue;
   }
 
   @Override

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValue.java
@@ -80,10 +80,14 @@ public class ScoreValue implements Value<Double>, Confidence {
     this.usedValues = new ArrayList<>(Objects.requireNonNull(usedValues, "Values can't be null!"));
   }
 
-  @Override
   @JsonGetter("score")
-  public Score feature() {
+  public Score score() {
     return score;
+  }
+
+  @Override
+  public Score feature() {
+    return score();
   }
 
   @Override
@@ -120,6 +124,17 @@ public class ScoreValue implements Value<Double>, Confidence {
     if (!isUnknown()) {
       processor.process(get());
     }
+    return this;
+  }
+
+  /**
+   * Set a value.
+   *
+   * @param value The value.
+   * @return The same score value.
+   */
+  public ScoreValue set(double value) {
+    this.value = Score.check(value);
     return this;
   }
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/PrettyPrinter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/PrettyPrinter.java
@@ -1,0 +1,98 @@
+package com.sap.sgs.phosphor.fosstars.tool;
+
+import com.sap.sgs.phosphor.fosstars.model.Confidence;
+import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The class print a pretty rating value.
+ */
+public class PrettyPrinter {
+
+  private static final String INDENT_STEP = "  ";
+
+  /**
+   * Print a formatted rating value.
+   *
+   * @param ratingValue The rating value to be printed.
+   */
+  public String print(RatingValue ratingValue) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(String.format("[+] Rating: %2.2f out of %2.2f -> %s%n",
+        ratingValue.score(), Score.MAX, ratingValue.label()));
+    sb.append(String.format("[+] Confidence: %2.2f out of %2.2f%n",
+        ratingValue.confidence(), Confidence.MAX));
+    sb.append(String.format("[+] Here is how the rating was calculated:%n"));
+    sb.append(print(ratingValue.scoreValue(), INDENT_STEP));
+    return sb.toString();
+  }
+
+  private String print(ScoreValue scoreValue, String indent) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(String.format("[+] %sScore:........%s%n", indent, scoreValue.score().name()));
+
+    sb.append(String.format("[+] %sValue:........%s out of %2.2f%n",
+        indent,
+        append(String.format("%.2f", scoreValue.get()), ' ', 4),
+        Score.MAX));
+    sb.append(String.format("[+] %sConfidence:...%s out of %2.2f%n",
+        indent,
+        append(String.format("%.2f", scoreValue.confidence()), ' ', 4),
+        Confidence.MAX));
+
+    List<ScoreValue> subScoreValues = new ArrayList<>();
+    List<Value> featureValues = new ArrayList<>();
+    for (Value usedValue : scoreValue.usedValues()) {
+      if (usedValue instanceof ScoreValue) {
+        subScoreValues.add((ScoreValue) usedValue);
+      } else {
+        featureValues.add(usedValue);
+      }
+    }
+
+    if (!subScoreValues.isEmpty()) {
+      sb.append(String.format(
+          "[+] %sBased on:.....%d sub-scores:%n", indent, subScoreValues.size()));
+      for (ScoreValue usedValue : subScoreValues) {
+        sb.append(print(usedValue, indent + INDENT_STEP + INDENT_STEP));
+        sb.append("[+]\n");
+      }
+    }
+
+    if (!featureValues.isEmpty()) {
+      sb.append(String.format("[+] %s  Based on:...%d features:%n", indent, featureValues.size()));
+      int maxLength = maxFeatureNameLength(featureValues) + 3;
+      for (Value usedValue : featureValues) {
+        sb.append(String.format("[+] %s  %s%s%n",
+            indent + INDENT_STEP, append(usedValue.feature().name() + ":", '.', maxLength),
+            usedValue.get()));
+      }
+    }
+
+    return sb.toString();
+  }
+
+  private static int maxFeatureNameLength(List<Value> featureValues) {
+    int maxLength = 0;
+    for (Value usedValue : featureValues) {
+      int length = usedValue.feature().name().length();
+      if (length > maxLength) {
+        maxLength = length;
+      }
+    }
+    return maxLength;
+  }
+
+  private static String append(String string, char c, int length) {
+    StringBuilder sb = new StringBuilder(string);
+    while (sb.length() <= length) {
+      sb.append(c);
+    }
+    return sb.toString();
+  }
+
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculator.java
@@ -24,9 +24,7 @@ import com.sap.sgs.phosphor.fosstars.data.github.UnpatchedVulnerabilities;
 import com.sap.sgs.phosphor.fosstars.data.github.UsesOwaspDependencyCheck;
 import com.sap.sgs.phosphor.fosstars.data.github.UsesSnykDependencyCheck;
 import com.sap.sgs.phosphor.fosstars.data.github.VulnerabilitiesFromNvd;
-import com.sap.sgs.phosphor.fosstars.model.Confidence;
 import com.sap.sgs.phosphor.fosstars.model.RatingRepository;
-import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.model.rating.oss.OssSecurityRating;
@@ -35,6 +33,7 @@ import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
 import com.sap.sgs.phosphor.fosstars.model.value.VulnerabilitiesValue;
 import com.sap.sgs.phosphor.fosstars.tool.InputString;
+import com.sap.sgs.phosphor.fosstars.tool.PrettyPrinter;
 import com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion;
 import com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion.Answer;
 import java.io.IOException;
@@ -147,11 +146,7 @@ public class SecurityRatingCalculator {
     }
 
     RatingValue ratingValue = rating.calculate(values);
-
-    System.out.printf("[+] Rating: %2.2f out of %2.2f, %s%n",
-        ratingValue.score(), Score.MAX, ratingValue.label());
-    System.out.printf("[+] Confidence: %2.2f out of %2.2f%n",
-        ratingValue.confidence(), Confidence.MAX);
+    System.out.print(new PrettyPrinter().print(ratingValue));
     System.out.printf("[+] Bye!%n");
 
     // store the default value cache

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/ConfidenceTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/ConfidenceTest.java
@@ -1,0 +1,60 @@
+package com.sap.sgs.phosphor.fosstars.model;
+
+import static org.junit.Assert.assertEquals;
+
+import com.sap.sgs.phosphor.fosstars.model.feature.example.ExampleFeatures;
+import org.junit.Test;
+
+public class ConfidenceTest {
+
+  private static final double DELTA = 0.01;
+
+  @Test
+  public void checkValid() {
+    Confidence.check(5.0);
+    Confidence.check(0.0);
+    Confidence.check(10.0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void checkNegative() {
+    Confidence.check(-1);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void checkToBig() {
+    Confidence.check(11);
+  }
+
+  @Test
+  public void adjust() {
+    assertEquals(Confidence.MIN, Confidence.adjust(-1), DELTA);
+    assertEquals(Confidence.MIN, Confidence.adjust(0), DELTA);
+    assertEquals(Confidence.MAX, Confidence.adjust(11), DELTA);
+    assertEquals(5.0, Confidence.adjust(5.0), DELTA);
+  }
+
+  @Test
+  public void make() {
+    assertEquals(Confidence.MIN,
+        Confidence.make(
+            ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.unknown(),
+            ExampleFeatures.NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.unknown()),
+        DELTA);
+    assertEquals((Confidence.MAX - Confidence.MIN) / 2,
+        Confidence.make(
+            ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
+            ExampleFeatures.NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.unknown()),
+        DELTA);
+    assertEquals(Confidence.MAX,
+        Confidence.make(
+            ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
+            ExampleFeatures.NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(3)),
+        DELTA);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void makeWithNoValues() {
+    Confidence.make();
+  }
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/WeightedCompositeScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/WeightedCompositeScoreTest.java
@@ -1,7 +1,5 @@
 package com.sap.sgs.phosphor.fosstars.model.score;
 
-import static com.sap.sgs.phosphor.fosstars.TestUtils.assertScore;
-import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -43,12 +41,28 @@ public class WeightedCompositeScoreTest {
     Value<Double> firstValue = FirstScore.FEATURE.value(FirstScore.VALUE);
     Value<Double> secondValue = SecondScore.FEATURE.value(SecondScore.VALUE);
 
-    double weightedFirstScore = 0.8 * new FirstScore().calculate(firstValue).get();
-    double weightedSecondScore = 0.3 * new SecondScore().calculate(secondValue).get();
+    double firstScoreValue = new FirstScore().calculate(firstValue).get();
+    double secondScoreValue = new SecondScore().calculate(secondValue).get();
+    double weightedFirstScore = 0.8 * firstScoreValue;
+    double weightedSecondScore = 0.3 * secondScoreValue;
     double weightSum = 0.8 + 0.3;
     double expectedScore = (weightedFirstScore + weightedSecondScore) / weightSum;
 
-    assertScore(expectedScore, score, setOf(firstValue, secondValue));
+    ScoreValue scoreValue = score.calculate(firstValue, secondValue);
+    assertEquals(expectedScore, scoreValue.get(), 0.01);
+    assertEquals(Confidence.MAX, scoreValue.confidence(), 0.01);
+    assertEquals(2, scoreValue.usedValues().size());
+    for (Value value : scoreValue.usedValues()) {
+      if (value.feature() instanceof FirstScore) {
+        assertEquals(firstScoreValue, value.get());
+        continue;
+      }
+      if (value.feature() instanceof SecondScore) {
+        assertEquals(secondScoreValue, value.get());
+        continue;
+      }
+      fail("Unexpected score: " + value.feature().name());
+    }
   }
 
   @Test

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
@@ -1,6 +1,5 @@
 package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
-import static com.sap.sgs.phosphor.fosstars.TestUtils.assertScore;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.FIRST_COMMIT_DATE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_POLICY;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_TEAM;
@@ -19,11 +18,14 @@ import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.sgs.phosphor.fosstars.model.Confidence;
 import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.other.Utils;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import com.sap.sgs.phosphor.fosstars.model.value.SecurityReviews;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
 import java.io.IOException;
@@ -32,6 +34,8 @@ import java.util.Set;
 import org.junit.Test;
 
 public class OssSecurityScoreTest {
+
+  private static final double DELTA = 0.01;
 
   @Test
   public void serializeAndDeserialize() throws IOException {
@@ -47,7 +51,10 @@ public class OssSecurityScoreTest {
   @Test
   public void calculateForAllUnknown() {
     Score score = new OssSecurityScore();
-    assertScore(Score.MIN, score, Utils.allUnknown(score.allFeatures()));
+    ScoreValue scoreValue = score.calculate(Utils.allUnknown(score.allFeatures()));
+    assertEquals(Score.MIN, scoreValue.get(), 0.01);
+    assertEquals(Confidence.MIN, scoreValue.confidence(), DELTA);
+    checkUsedValues(scoreValue);
   }
 
   @Test
@@ -68,7 +75,25 @@ public class OssSecurityScoreTest {
         VULNERABILITIES.value(new Vulnerabilities()),
         PROJECT_START_DATE.value(new Date()),
         FIRST_COMMIT_DATE.value(new Date()));
-    assertScore(Score.INTERVAL, score, values);
+    ScoreValue scoreValue = score.calculate(values);
+    assertTrue(Score.INTERVAL.contains(scoreValue.get()));
+    assertEquals(Confidence.MAX, scoreValue.confidence(), DELTA);
+    checkUsedValues(scoreValue);
+  }
+
+  private static void checkUsedValues(ScoreValue scoreValue) {
+    assertEquals(scoreValue.score().subScores().size(), scoreValue.usedValues().size());
+    for (Value value : scoreValue.usedValues()) {
+      boolean found = false;
+      for (Score subScore : scoreValue.score().subScores()) {
+        if (value.feature().getClass() == subScore.getClass()) {
+          found = true;
+        }
+      }
+      if (!found) {
+        fail("Unexpected value: " + value.feature().getClass());
+      }
+    }
   }
 
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/PrettyPrinterTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/PrettyPrinterTest.java
@@ -1,0 +1,69 @@
+package com.sap.sgs.phosphor.fosstars.tool;
+
+import static com.sap.sgs.phosphor.fosstars.model.Version.OSS_SECURITY_RATING_1_0;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.FIRST_COMMIT_DATE;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_POLICY;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_TEAM;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.IS_APACHE;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.IS_ECLIPSE;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_COMMITS_LAST_THREE_MONTHS;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_WATCHERS_ON_GITHUB;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SECURITY_REVIEWS_DONE;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
+import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.rating.oss.OssSecurityRating;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.OssSecurityScore;
+import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
+import com.sap.sgs.phosphor.fosstars.model.value.SecurityReviews;
+import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
+import java.util.Date;
+import java.util.Set;
+import org.junit.Test;
+
+public class PrettyPrinterTest {
+
+  @Test
+  public void print() {
+    OssSecurityScore score = new OssSecurityScore();
+    OssSecurityRating rating = new OssSecurityRating(score, OSS_SECURITY_RATING_1_0);
+    Set<Value> values = setOf(
+        SUPPORTED_BY_COMPANY.value(false),
+        IS_APACHE.value(true),
+        IS_ECLIPSE.value(false),
+        NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(50),
+        NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS.value(3),
+        NUMBER_OF_GITHUB_STARS.value(10),
+        NUMBER_OF_WATCHERS_ON_GITHUB.value(5),
+        HAS_SECURITY_TEAM.value(false),
+        HAS_SECURITY_POLICY.value(false),
+        SECURITY_REVIEWS_DONE.value(SecurityReviews.NO_REVIEWS),
+        SCANS_FOR_VULNERABLE_DEPENDENCIES.value(false),
+        VULNERABILITIES.value(new Vulnerabilities()),
+        PROJECT_START_DATE.value(new Date()),
+        FIRST_COMMIT_DATE.value(new Date()));
+    RatingValue ratingValue = rating.calculate(values);
+
+    PrettyPrinter printer = new PrettyPrinter();
+    String text = printer.print(ratingValue);
+    assertNotNull(text);
+    assertFalse(text.isEmpty());
+    System.out.println(text);
+    for (Value value : ratingValue.scoreValue().usedValues()) {
+      assertTrue(text.contains(value.feature().name()));
+    }
+    for (Feature feature : rating.allFeatures()) {
+      assertTrue(text.contains(feature.name()));
+    }
+  }
+}


### PR DESCRIPTION
Here is a list of main updates:

- Fixed #53 
- Updated the `WeightedCompositeScore` class to use sub-score values as used values in a `ScoreValue` instance which it returns.
- Added a new `PrettyPrinter` class which makes output of `SecurityRatingCalculator` more verbose.
- Added tests.

This is a part of #48