### PR TITLE
Introduced DependencyScanScore

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScore.java
@@ -1,0 +1,83 @@
+package com.sap.sgs.phosphor.fosstars.model.score.oss;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
+import static com.sap.sgs.phosphor.fosstars.model.other.Utils.findValue;
+
+import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures;
+import com.sap.sgs.phosphor.fosstars.model.qa.ScoreVerification;
+import com.sap.sgs.phosphor.fosstars.model.qa.TestVector;
+import com.sap.sgs.phosphor.fosstars.model.score.FeatureBasedScore;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * <p>The score just wraps the {@link OssFeatures#SCANS_FOR_VULNERABLE_DEPENDENCIES} feature.
+ * If the feature is true, then it returns {@link Score#MAX}. otherwise {@link Score#MIN}.</p>
+ * <p>The score needs to be extended with more features.</p>
+ */
+public class DependencyScanScore extends FeatureBasedScore {
+
+  /**
+   * Initializes a new {@link DependencyScanScore}.
+   */
+  DependencyScanScore() {
+    super("How a project scans its dependencies for vulnerabilities",
+        SCANS_FOR_VULNERABLE_DEPENDENCIES);
+  }
+
+  @Override
+  public ScoreValue calculate(Value... values) {
+    Value<Boolean> scansDependencies = findValue(values, SCANS_FOR_VULNERABLE_DEPENDENCIES,
+        "Hey! You have to tell me if the project scans for vulnerable dependencies!");
+
+    if (scansDependencies.isUnknown()) {
+      return scoreValue(Score.MIN, scansDependencies);
+    }
+
+    return scoreValue(
+        scansDependencies.get().equals(true) ? Score.MAX : Score.MIN,
+        scansDependencies);
+  }
+
+  /**
+   * This class implements a verification procedure for {@link DependencyScanScore}.
+   * The class loads test vectors, and provides methods to verify a {@link DependencyScanScore}
+   * against those test vectors.
+   */
+  public static class Verification extends ScoreVerification {
+
+    /**
+     * A name of a resource which contains the test vectors.
+     */
+    private static final String DEFAULT_TEST_VECTORS_CSV = "DependencyScanScoreTestVectors.csv";
+
+    /**
+     * Initializes a {@link Verification} for a {@link DependencyScanScore}.
+     *
+     * @param score A score to be verified.
+     * @param vectors A list of test vectors.
+     */
+    public Verification(DependencyScanScore score, List<TestVector> vectors) {
+      super(score, vectors);
+    }
+
+    /**
+     * Creates an instance of {@link Verification} for a specified score. The method loads test
+     * vectors from a default resource.
+     *
+     * @param score The score to be verified.
+     * @return An instance of {@link Verification}.
+     */
+    static Verification createFor(DependencyScanScore score) throws IOException {
+      try (InputStream is = Verification.class.getResourceAsStream(DEFAULT_TEST_VECTORS_CSV)) {
+
+        return new Verification(
+            score, loadTestVectorsFromCsvResource(score.features(), is));
+      }
+    }
+  }
+}

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScoreTestVectors.csv
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScoreTestVectors.csv
@@ -1,0 +1,4 @@
+,alias,score_from,score_to,label,If an open-source project is regularly scanned for vulnerable dependencies
+0,test_vector_0,0.0,1.0,,unknown
+1,test_vector_1,0.0,1.0,,False
+2,test_vector_2,9.0,10.0,,True

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScoreTest.java
@@ -1,0 +1,25 @@
+package com.sap.sgs.phosphor.fosstars.model.score.oss;
+
+import static com.sap.sgs.phosphor.fosstars.TestUtils.assertScore;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
+import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+
+import com.sap.sgs.phosphor.fosstars.model.Score;
+import org.junit.Test;
+
+public class DependencyScanScoreTest {
+
+  @Test
+  public void smokeTest() {
+    assertScore(
+        Score.INTERVAL,
+        new DependencyScanScore(),
+        setOf(SCANS_FOR_VULNERABLE_DEPENDENCIES.value(true)));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void noInfoAboutScans() {
+    new DependencyScanScore().calculate();
+  }
+
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScoreVerification.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScoreVerification.java
@@ -1,0 +1,14 @@
+package com.sap.sgs.phosphor.fosstars.model.score.oss;
+
+import com.sap.sgs.phosphor.fosstars.model.qa.VerificationFailedException;
+import java.io.IOException;
+import org.junit.Test;
+
+public class DependencyScanScoreVerification {
+
+  @Test
+  public void verify() throws IOException, VerificationFailedException {
+    DependencyScanScore.Verification.createFor(new DependencyScanScore()).run();
+  }
+
+}


### PR DESCRIPTION
Here is a list of updates:

- Added a new `DependencyScanScore` which is based on `SCANS_FOR_VULNERABLE_DEPENDENCIES` feature.
- Added a verification procedure for the new score.
- Added a new `DependencyScanScoreTest`.

The `DependencyScanScore` is necessary to make the `ProjectSecurityTestingScore` use only sub-scores in near future.

This fixes #63