### PR TITLE
Updated the demo tool to handle multiple projects

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/RatingValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/RatingValue.java
@@ -1,5 +1,8 @@
 package com.sap.sgs.phosphor.fosstars.model.value;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sap.sgs.phosphor.fosstars.model.Confidence;
 import com.sap.sgs.phosphor.fosstars.model.Label;
 import com.sap.sgs.phosphor.fosstars.model.Rating;
@@ -27,11 +30,13 @@ public class RatingValue implements Confidence {
    * @param scoreValue The score value.
    * @param label The label.
    */
-  public RatingValue(ScoreValue scoreValue, Label label) {
-    Objects.requireNonNull(scoreValue, "Hey! Score value can't be null");
-    Objects.requireNonNull(label, "Hey! Label can't be null!");
-    this.scoreValue = scoreValue;
-    this.label = label;
+  @JsonCreator
+  public RatingValue(
+      @JsonProperty("scoreValue") ScoreValue scoreValue,
+      @JsonProperty("label") Label label) {
+
+    this.scoreValue = Objects.requireNonNull(scoreValue, "Hey! Score value can't be null");
+    this.label = Objects.requireNonNull(label, "Hey! Label can't be null!");
   }
 
   /**
@@ -52,6 +57,7 @@ public class RatingValue implements Confidence {
   /**
    * Returns the label.
    */
+  @JsonGetter("label")
   public Label label() {
     return label;
   }
@@ -59,6 +65,7 @@ public class RatingValue implements Confidence {
   /**
    * Returns the score value.
    */
+  @JsonGetter("scoreValue")
   public ScoreValue scoreValue() {
     return scoreValue;
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/AbstractRatingCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/AbstractRatingCalculator.java
@@ -1,0 +1,68 @@
+package com.sap.sgs.phosphor.fosstars.tool.github;
+
+import com.sap.sgs.phosphor.fosstars.data.NoUserCallback;
+import com.sap.sgs.phosphor.fosstars.data.UserCallback;
+import java.io.IOException;
+import java.util.Objects;
+import org.kohsuke.github.GitHub;
+
+/**
+ * A base class for rating calculators.
+ */
+abstract class AbstractRatingCalculator {
+
+  /**
+   * An interface to GitHub.
+   */
+  final GitHub github;
+
+  /**
+   * A token for accessing the GitHub APIs.
+   */
+  String token;
+
+  /**
+   * An interface for interacting with a user.
+   */
+  UserCallback callback = NoUserCallback.INSTANCE;
+
+  /**
+   * Initializes a new calculator.
+   *
+   * @param github An interface to GitHub.
+   */
+  AbstractRatingCalculator(GitHub github) {
+    this.github = Objects.requireNonNull(github, "Oh no! An interface to GitHub can't be null!");
+  }
+
+  /**
+   * Sets a token for accessing the GitHub APIs.
+   *
+   * @param token The token.
+   * @return The same calculator.
+   */
+  AbstractRatingCalculator token(String token) {
+    this.token = token;
+    return this;
+  }
+
+  /**
+   * Sets an interface for interacting with a user.
+   *
+   * @param callback The interface for interacting with a user.
+   * @return The same calculator.
+   */
+  AbstractRatingCalculator set(UserCallback callback) {
+    this.callback = callback;
+    return this;
+  }
+
+  /**
+   * Calculates a rating for a specified project.
+   *
+   * @param project The project.
+   * @return The same calculator.
+   * @throws IOException If something went wrong.
+   */
+  abstract AbstractRatingCalculator calculateFor(GitHubProject project) throws IOException;
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/AbstractRatingCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/AbstractRatingCalculator.java
@@ -3,6 +3,7 @@ package com.sap.sgs.phosphor.fosstars.tool.github;
 import com.sap.sgs.phosphor.fosstars.data.NoUserCallback;
 import com.sap.sgs.phosphor.fosstars.data.UserCallback;
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 import org.kohsuke.github.GitHub;
 
@@ -58,11 +59,19 @@ abstract class AbstractRatingCalculator {
   }
 
   /**
-   * Calculates a rating for a specified project.
+   * Calculates a rating for a single project.
    *
    * @param project The project.
    * @return The same calculator.
    * @throws IOException If something went wrong.
    */
   abstract AbstractRatingCalculator calculateFor(GitHubProject project) throws IOException;
+
+  /**
+   * Calculates ratings for multiple projects.
+   *
+   * @param projects The projects.
+   * @throws IOException If something went wrong.
+   */
+  abstract AbstractRatingCalculator calculateFor(List<GitHubProject> projects) throws IOException;
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectFinder.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectFinder.java
@@ -127,6 +127,17 @@ public class GitHubProjectFinder {
   }
 
   /**
+   * Sets a config.
+   *
+   * @param config The config to be used.
+   * @return The same {@link GitHubProjectFinder}.
+   */
+  public GitHubProjectFinder set(Config config) {
+    this.config = Objects.requireNonNull(config, "Oh no! Config can't be null!");
+    return this;
+  }
+
+  /**
    * Loads a configuration form a file.
    *
    * @param filename The file name.

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MultipleSecurityRatingsCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MultipleSecurityRatingsCalculator.java
@@ -1,10 +1,49 @@
 package com.sap.sgs.phosphor.fosstars.tool.github;
 
+import java.io.IOException;
 import java.util.List;
+import org.kohsuke.github.GitHub;
 
-public class MultipleSecurityRatingsCalculator {
+/**
+ * The class calculates security ratings for multiple open-source projects.
+ */
+class MultipleSecurityRatingsCalculator extends AbstractRatingCalculator {
 
-  void process(List<GitHubProject> repositories) {
-    throw new UnsupportedOperationException("No ratings for you!");
+  /**
+   * Initializes a new calculator.
+   *
+   * @param github An interface to GitHub.
+   */
+  MultipleSecurityRatingsCalculator(GitHub github) {
+    super(github);
   }
+
+  @Override
+  MultipleSecurityRatingsCalculator calculateFor(GitHubProject project) throws IOException {
+    singleSecurityRatingCalculator().calculateFor(project);
+    return this;
+  }
+
+  /**
+   * Calculates ratings for specified projects.
+   *
+   * @param projects The projects.
+   * @throws IOException If something went wrong.
+   */
+  MultipleSecurityRatingsCalculator calculateFor(List<GitHubProject> projects) throws IOException {
+    for (GitHubProject project : projects) {
+      calculateFor(project);
+    }
+    return this;
+  }
+
+  /**
+   * Creates a {@link SingleSecurityRatingCalculator} for calculating a rating for a single project.
+   *
+   * @return An instance of {@link SingleSecurityRatingCalculator}.
+   */
+  AbstractRatingCalculator singleSecurityRatingCalculator() {
+    return new SingleSecurityRatingCalculator(github).token(token).set(callback);
+  }
+
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MultipleSecurityRatingsCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MultipleSecurityRatingsCalculator.java
@@ -24,12 +24,7 @@ class MultipleSecurityRatingsCalculator extends AbstractRatingCalculator {
     return this;
   }
 
-  /**
-   * Calculates ratings for specified projects.
-   *
-   * @param projects The projects.
-   * @throws IOException If something went wrong.
-   */
+  @Override
   MultipleSecurityRatingsCalculator calculateFor(List<GitHubProject> projects) throws IOException {
     for (GitHubProject project : projects) {
       calculateFor(project);

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculator.java
@@ -17,6 +17,10 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.kohsuke.github.GitHub;
 
+/**
+ * This is a command line tool for calculating security ratings for one
+ * of multiple open-source projects.
+ */
 public class SecurityRatingCalculator {
 
   /**
@@ -76,7 +80,7 @@ public class SecurityRatingCalculator {
     new SingleSecurityRatingCalculator(github)
         .token(commandLine.getOptionValue("token"))
         .set(callback)
-        .process(project);
+        .calculateFor(project);
 
     RatingValue ratingValue = project.ratingValue()
         .orElseThrow(() -> new IOException("Could not calculate a rating!"));
@@ -103,6 +107,7 @@ public class SecurityRatingCalculator {
       System.out.println("    5. Click the 'Generate token' button");
       System.out.println("    6. Copy your new token");
       System.out.println("    7. Paste the token here");
+
       Answer answer = new YesNoQuestion(callback, "Would you like to create a token now?").ask();
       switch (answer) {
         case YES:
@@ -123,6 +128,7 @@ public class SecurityRatingCalculator {
               String.format("Not sure what I can do with '%s'", answer));
       }
     }
+
     if (token != null) {
       try {
         return GitHub.connectUsingOAuth(token);
@@ -132,11 +138,13 @@ public class SecurityRatingCalculator {
     } else {
       System.out.printf("[!] No token provided%n");
     }
+
     try {
       return GitHub.connect();
     } catch (IOException e) {
       System.out.printf("[x] Something went wrong: %s%n", e);
     }
+
     try {
       GitHub github = GitHub.connectAnonymously();
       System.out.println("[!] We have established only an anonymous connection to GitHub ...");
@@ -144,6 +152,7 @@ public class SecurityRatingCalculator {
     } catch (IOException e) {
       System.out.printf("[x] Something went wrong: %s%n", e);
     }
+
     return null;
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SingleSecurityRatingCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SingleSecurityRatingCalculator.java
@@ -61,7 +61,13 @@ class SingleSecurityRatingCalculator extends AbstractRatingCalculator {
     System.out.printf("[+] Let's get info about the project and calculate a security rating%n");
     ValueSet values = ValueHashSet.unknown(rating.allFeatures());
     for (DataProvider provider : dataProviders(where, name)) {
-      provider.set(callback).update(values);
+      try {
+        provider.set(callback).update(values);
+      } catch (Exception e) {
+        System.out.printf("[!] Holy Moly, one of the data providers failed!%n");
+        System.out.printf("[!] The last thing that it said was: %s%n", e.getMessage());
+        System.out.printf("[!] But we don't give up!%n");
+      }
     }
 
     System.out.println("[+] Here is what we know about the project:");
@@ -76,6 +82,11 @@ class SingleSecurityRatingCalculator extends AbstractRatingCalculator {
     project.set(rating.calculate(values));
 
     return this;
+  }
+
+  @Override
+  AbstractRatingCalculator calculateFor(List<GitHubProject> projects) throws IOException {
+    throw new UnsupportedOperationException("I can't handle multiple projects!");
   }
 
   /**

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/RatingValueTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/RatingValueTest.java
@@ -4,8 +4,12 @@ import static com.sap.sgs.phosphor.fosstars.model.score.example.ExampleScores.PR
 import static com.sap.sgs.phosphor.fosstars.model.score.example.ExampleScores.SECURITY_TESTING_SCORE_EXAMPLE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.sgs.phosphor.fosstars.model.rating.example.SecurityRatingExample.SecurityLabelExample;
+import java.io.IOException;
 import java.util.Collections;
 import org.junit.Test;
 
@@ -50,6 +54,21 @@ public class RatingValueTest {
     RatingValue ratingValueAnotherLabel = new RatingValue(scoreValue, SecurityLabelExample.AWFUL);
     assertNotEquals(ratingValue, ratingValueAnotherLabel);
     assertNotEquals(ratingValue.hashCode(), ratingValueAnotherLabel.hashCode());
+  }
+
+  @Test
+  public void serializeAndDeserialize() throws IOException {
+    ScoreValue scoreValue = new ScoreValue(
+        PROJECT_ACTIVITY_SCORE_EXAMPLE, 5.1, 0.8, 9.0, Collections.emptyList());
+    RatingValue ratingValue = new RatingValue(scoreValue, SecurityLabelExample.OKAY);
+    ObjectMapper mapper = new ObjectMapper();
+    byte[] bytes = mapper.writeValueAsBytes(ratingValue);
+    assertNotNull(bytes);
+    assertTrue(bytes.length > 0);
+    RatingValue clone = mapper.readValue(bytes, RatingValue.class);
+    assertNotNull(clone);
+    assertEquals(ratingValue, clone);
+    assertEquals(ratingValue.hashCode(), clone.hashCode());
   }
 
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/MultipleSecurityRatingsCalculatorTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/MultipleSecurityRatingsCalculatorTest.java
@@ -1,0 +1,65 @@
+package com.sap.sgs.phosphor.fosstars.tool.github;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import com.sap.sgs.phosphor.fosstars.data.NoUserCallback;
+import com.sap.sgs.phosphor.fosstars.model.math.DoubleInterval;
+import com.sap.sgs.phosphor.fosstars.model.rating.oss.OssSecurityRating.SecurityLabel;
+import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import org.kohsuke.github.GitHub;
+
+public class MultipleSecurityRatingsCalculatorTest {
+
+  @Test
+  public void calculateFor() throws IOException {
+    GitHub github = mock(GitHub.class);
+
+    SingleSecurityRatingCalculator singleRatingCalculator
+        = new SingleSecurityRatingCalculator(github);
+    singleRatingCalculator = spy(singleRatingCalculator);
+    when(singleRatingCalculator.dataProviders(anyString(), anyString()))
+        .thenReturn(Collections.emptyList());
+
+    MultipleSecurityRatingsCalculator multipleRatingsCalculator
+        = new MultipleSecurityRatingsCalculator(github);
+    multipleRatingsCalculator.token("test");
+    multipleRatingsCalculator.set(NoUserCallback.INSTANCE);
+    multipleRatingsCalculator = spy(multipleRatingsCalculator);
+    when(multipleRatingsCalculator.singleSecurityRatingCalculator())
+        .thenReturn(singleRatingCalculator);
+
+    final String apache = "apache";
+    final String eclipse = "eclipse";
+
+    GitHubProject apacheNiFi = new GitHubProject(new GitHubOrganization(apache), "nifi");
+    GitHubProject eclipseSteady = new GitHubProject(new GitHubOrganization(eclipse), "steady");
+
+    assertFalse(apacheNiFi.ratingValue().isPresent());
+    assertFalse(eclipseSteady.ratingValue().isPresent());
+
+    List<GitHubProject> projects = Arrays.asList(apacheNiFi, eclipseSteady);
+    multipleRatingsCalculator.calculateFor(projects);
+
+    assertTrue(apacheNiFi.ratingValue().isPresent());
+    check(apacheNiFi.ratingValue().get());
+
+    assertTrue(eclipseSteady.ratingValue().isPresent());
+    check(eclipseSteady.ratingValue().get());
+  }
+
+  private static void check(RatingValue ratingValue) {
+    assertEquals(SecurityLabel.BAD, ratingValue.label());
+    assertTrue(DoubleInterval.closed(0, 3).contains(ratingValue.scoreValue().get()));
+  }
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/SingleSecurityRatingCalculatorTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/SingleSecurityRatingCalculatorTest.java
@@ -1,0 +1,49 @@
+package com.sap.sgs.phosphor.fosstars.tool.github;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import com.sap.sgs.phosphor.fosstars.data.IsApache;
+import com.sap.sgs.phosphor.fosstars.data.IsEclipse;
+import com.sap.sgs.phosphor.fosstars.data.NoUserCallback;
+import com.sap.sgs.phosphor.fosstars.model.math.DoubleInterval;
+import com.sap.sgs.phosphor.fosstars.model.rating.oss.OssSecurityRating.SecurityLabel;
+import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
+import java.io.IOException;
+import java.util.Arrays;
+import org.junit.Test;
+import org.kohsuke.github.GitHub;
+
+public class SingleSecurityRatingCalculatorTest {
+
+  @Test
+  public void calculateFor() throws IOException {
+    GitHub github = mock(GitHub.class);
+
+    final String organization = "apache";
+    final String project = "nifi";
+
+    SingleSecurityRatingCalculator calculator = new SingleSecurityRatingCalculator(github);
+    calculator.token("test");
+    calculator.set(NoUserCallback.INSTANCE);
+    calculator = spy(calculator);
+
+    when(calculator.dataProviders(anyString(), anyString()))
+        .thenReturn(Arrays.asList(new IsApache(organization), new IsEclipse(organization)));
+
+    GitHubProject apacheNiFi = new GitHubProject(new GitHubOrganization(organization), project);
+    assertFalse(apacheNiFi.ratingValue().isPresent());
+
+    calculator.calculateFor(apacheNiFi);
+
+    assertTrue(apacheNiFi.ratingValue().isPresent());
+    RatingValue ratingValue = apacheNiFi.ratingValue().get();
+    assertEquals(SecurityLabel.BAD, ratingValue.label());
+    assertTrue(DoubleInterval.closed(0, 3).contains(ratingValue.scoreValue().get()));
+  }
+}

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/tool/github/ValidSecurityRatingCalculatorConfig.yml
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/tool/github/ValidSecurityRatingCalculatorConfig.yml
@@ -1,0 +1,16 @@
+# this is a test configuration for the SecurityRatingCalculator class
+finder:
+  organizations:
+    - name: apache
+      exclude:
+        - incubator
+        - incubating
+    - name: eclipse
+      exclude:
+        - incubator
+    - name: spring-projects
+  repositories:
+    - organization: FasterXML
+      name: jackson-databind
+    - organization: FasterXML
+      name: jackson-dataformat-xml


### PR DESCRIPTION
This is the next update for #72 

- Implemented the `MultipleSecurityRatingsCalculator` class.
- Introduced a new option `--config` which allows setting a configuration.
- Updated `SecurityRatingCalculator` to use `GitHubProjectFinder` and `MultipleSecurityRatingsCalculator` if the `--config` option is set.
- Re-worked error handling in the `SecurityRatingCalculator` class.
- Make the `RatingValue` class serializable via Jackson. This fixes #79 
- Updated the tests.
- Fixed #10