### PR TITLE
Updated the demo tool to generate a report for multiple projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 .fosstars_model
 src/main/jupyter/oss/security/.ipynb_checkpoints
 src/main/jupyter/oss/security/__pycache__/
+src/test/shell/tool/github/*.log

--- a/docs/oss/security/FasterXML/jackson-databind.md
+++ b/docs/oss/security/FasterXML/jackson-databind.md
@@ -1,0 +1,97 @@
+# FasterXML/jackson-databind
+
+```
+[+] Here is how the rating was calculated:
+[+]   Score:........Security of project
+[+]   Value:........5.43  out of 10.00
+[+]   Confidence:...8.67  out of 10.00
+[+]   Based on:.....7 sub-scores:
+[+]       Sub-score:....Unpatched vulnerabilities
+[+]       Importance:...High (weight 0.84 out of 1.00)
+[+]       Value:........10.00 out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...1 features:
+[+]           Info about vulnerabilities:...36 vulnerabilities
+[+]       Explanation:..No unpatched vulnerabilities found which is good
+[+]
+[+]       Sub-score:....Project activity
+[+]       Description:..The score is based on number of commits and contributors.
+[+]                     Here is how the number of commits contributes to the score (up to 5.10):
+[+]                     0 -> 0.10, 200 -> 2.55, 310 -> 4.59
+[+]                     Here is how the number of contributors contributes to the score (up to 5.10):
+[+]                     0 -> 0.10, 5 -> 2.55, 10 -> 4.59
+[+]       Importance:...Medium (weight 0.63 out of 1.00)
+[+]       Value:........9.84  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...2 features:
+[+]           Number of commits in the last three months:........270
+[+]           Number of contributors in the last three months:...11
+[+]
+[+]       Sub-score:....Security testing
+[+]       Importance:...Medium (weight 0.63 out of 1.00)
+[+]       Value:........5.00  out of 10.00
+[+]       Confidence:...5.00  out of 10.00
+[+]       Based on:.....2 sub-scores:
+[+]           Sub-score:....How a project scans its dependencies for vulnerabilities
+[+]           Importance:...High (weight 1.00 out of 1.00)
+[+]           Value:........0.00  out of 10.00
+[+]           Confidence:...0.00  out of 10.00
+[+]           Based on:...1 features:
+[+]               Does it scan for vulnerable dependencies?....unknown
+[+]
+[+]           Sub-score:....How a project addresses issues reported by LGTM
+[+]           Importance:...High (weight 1.00 out of 1.00)
+[+]           Value:........10.00 out of 10.00
+[+]           Confidence:...10.00 out of 10.00
+[+]           Based on:...2 features:
+[+]               If a project uses LGTM:..............true
+[+]               The worst LGTM grade of a project:...A
+[+]
+[+]
+[+]       Sub-score:....Community commitment
+[+]       Importance:...Medium (weight 0.55 out of 1.00)
+[+]       Value:........0.00  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...3 features:
+[+]           Does it belong to Apache?........false
+[+]           Does it belong to Eclipse?.......false
+[+]           Is it supported by a company?....false
+[+]
+[+]       Sub-score:....Security awareness
+[+]       Description:..The score checks if a project has a security policy and a security team.
+[+]                     If the project has a security policy, then the score adds 3.00.
+[+]                     If the project has a security team, then the score adds 5.00.
+[+]                     If the project uses verified signed commits, then the score adds 2.00.
+[+]       Importance:...Medium (weight 0.54 out of 1.00)
+[+]       Value:........3.00  out of 10.00
+[+]       Confidence:...6.67  out of 10.00
+[+]       Based on:...3 features:
+[+]           Does it have a security policy?.........true
+[+]           Does it have a security team?...........unknown
+[+]           Does it use verified signed commits?....false
+[+]
+[+]       Sub-score:....Project popularity
+[+]       Description:..The score is based on number of stars and watchers.
+[+]                     Here is how a number of stars contributes to the score:
+[+]                     0 -> 0.00 (min), 2500 -> 2.50, 5000 -> 5.00, 10000 -> 10.00 (max)
+[+]                     Here is how a number of watchers contributes to the score:
+[+]                     0 -> 0.00 (min), 450 -> 1.50, 750 -> 2.50, 3000 -> 10.00 (max)
+[+]       Importance:...Medium (weight 0.31 out of 1.00)
+[+]       Value:........2.94  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...2 features:
+[+]           Number of stars for a GitHub repository:......2421
+[+]           Number of watchers for a GitHub repository:...156
+[+]
+[+]       Sub-score:....Vulnerability lifetime
+[+]       Importance:...Low (weight 0.23 out of 1.00)
+[+]       Value:........0.00  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...2 features:
+[+]           Info about vulnerabilities:...36 vulnerabilities
+[+]           When a project started:.......Fri Dec 23 08:17:41 CET 2011
+[+]
+[+] Rating: 5.43 out of 10.00 -> MODERATE
+[+] Confidence: 8.67 out of 10.00
+
+```

--- a/docs/oss/security/FasterXML/jackson-dataformat-xml.md
+++ b/docs/oss/security/FasterXML/jackson-dataformat-xml.md
@@ -1,0 +1,97 @@
+# FasterXML/jackson-dataformat-xml
+
+```
+[+] Here is how the rating was calculated:
+[+]   Score:........Security of project
+[+]   Value:........3.70  out of 10.00
+[+]   Confidence:...8.67  out of 10.00
+[+]   Based on:.....7 sub-scores:
+[+]       Sub-score:....Unpatched vulnerabilities
+[+]       Importance:...High (weight 0.84 out of 1.00)
+[+]       Value:........10.00 out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...1 features:
+[+]           Info about vulnerabilities:...2 vulnerabilities
+[+]       Explanation:..No unpatched vulnerabilities found which is good
+[+]
+[+]       Sub-score:....Project activity
+[+]       Description:..The score is based on number of commits and contributors.
+[+]                     Here is how the number of commits contributes to the score (up to 5.10):
+[+]                     0 -> 0.10, 200 -> 2.55, 310 -> 4.59
+[+]                     Here is how the number of contributors contributes to the score (up to 5.10):
+[+]                     0 -> 0.10, 5 -> 2.55, 10 -> 4.59
+[+]       Importance:...Medium (weight 0.63 out of 1.00)
+[+]       Value:........2.10  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...2 features:
+[+]           Number of commits in the last three months:........42
+[+]           Number of contributors in the last three months:...2
+[+]
+[+]       Sub-score:....Security testing
+[+]       Importance:...Medium (weight 0.63 out of 1.00)
+[+]       Value:........4.00  out of 10.00
+[+]       Confidence:...5.00  out of 10.00
+[+]       Based on:.....2 sub-scores:
+[+]           Sub-score:....How a project scans its dependencies for vulnerabilities
+[+]           Importance:...High (weight 1.00 out of 1.00)
+[+]           Value:........0.00  out of 10.00
+[+]           Confidence:...0.00  out of 10.00
+[+]           Based on:...1 features:
+[+]               Does it scan for vulnerable dependencies?....unknown
+[+]
+[+]           Sub-score:....How a project addresses issues reported by LGTM
+[+]           Importance:...High (weight 1.00 out of 1.00)
+[+]           Value:........8.00  out of 10.00
+[+]           Confidence:...10.00 out of 10.00
+[+]           Based on:...2 features:
+[+]               If a project uses LGTM:..............true
+[+]               The worst LGTM grade of a project:...B
+[+]
+[+]
+[+]       Sub-score:....Community commitment
+[+]       Importance:...Medium (weight 0.55 out of 1.00)
+[+]       Value:........0.00  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...3 features:
+[+]           Does it belong to Apache?........false
+[+]           Does it belong to Eclipse?.......false
+[+]           Is it supported by a company?....false
+[+]
+[+]       Sub-score:....Security awareness
+[+]       Description:..The score checks if a project has a security policy and a security team.
+[+]                     If the project has a security policy, then the score adds 3.00.
+[+]                     If the project has a security team, then the score adds 5.00.
+[+]                     If the project uses verified signed commits, then the score adds 2.00.
+[+]       Importance:...Medium (weight 0.54 out of 1.00)
+[+]       Value:........0.00  out of 10.00
+[+]       Confidence:...6.67  out of 10.00
+[+]       Based on:...3 features:
+[+]           Does it have a security policy?.........false
+[+]           Does it have a security team?...........unknown
+[+]           Does it use verified signed commits?....false
+[+]
+[+]       Sub-score:....Project popularity
+[+]       Description:..The score is based on number of stars and watchers.
+[+]                     Here is how a number of stars contributes to the score:
+[+]                     0 -> 0.00 (min), 2500 -> 2.50, 5000 -> 5.00, 10000 -> 10.00 (max)
+[+]                     Here is how a number of watchers contributes to the score:
+[+]                     0 -> 0.00 (min), 450 -> 1.50, 750 -> 2.50, 3000 -> 10.00 (max)
+[+]       Importance:...Medium (weight 0.31 out of 1.00)
+[+]       Value:........0.50  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...2 features:
+[+]           Number of stars for a GitHub repository:......392
+[+]           Number of watchers for a GitHub repository:...32
+[+]
+[+]       Sub-score:....Vulnerability lifetime
+[+]       Importance:...Low (weight 0.23 out of 1.00)
+[+]       Value:........6.25  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...2 features:
+[+]           Info about vulnerabilities:...2 vulnerabilities
+[+]           When a project started:.......Fri Dec 31 06:00:50 CET 2010
+[+]
+[+] Rating: 3.70 out of 10.00 -> BAD
+[+] Confidence: 8.67 out of 10.00
+
+```

--- a/docs/oss/security/FasterXML/jackson-dataformats-text.md
+++ b/docs/oss/security/FasterXML/jackson-dataformats-text.md
@@ -1,0 +1,97 @@
+# FasterXML/jackson-dataformats-text
+
+```
+[+] Here is how the rating was calculated:
+[+]   Score:........Security of project
+[+]   Value:........4.39  out of 10.00
+[+]   Confidence:...8.67  out of 10.00
+[+]   Based on:.....7 sub-scores:
+[+]       Sub-score:....Unpatched vulnerabilities
+[+]       Importance:...High (weight 0.84 out of 1.00)
+[+]       Value:........10.00 out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...1 features:
+[+]           Info about vulnerabilities:...0 vulnerabilities
+[+]       Explanation:..No unpatched vulnerabilities found which is good
+[+]
+[+]       Sub-score:....Project activity
+[+]       Description:..The score is based on number of commits and contributors.
+[+]                     Here is how the number of commits contributes to the score (up to 5.10):
+[+]                     0 -> 0.10, 200 -> 2.55, 310 -> 4.59
+[+]                     Here is how the number of contributors contributes to the score (up to 5.10):
+[+]                     0 -> 0.10, 5 -> 2.55, 10 -> 4.59
+[+]       Importance:...Medium (weight 0.63 out of 1.00)
+[+]       Value:........3.89  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...2 features:
+[+]           Number of commits in the last three months:........49
+[+]           Number of contributors in the last three months:...5
+[+]
+[+]       Sub-score:....Security testing
+[+]       Importance:...Medium (weight 0.63 out of 1.00)
+[+]       Value:........5.00  out of 10.00
+[+]       Confidence:...5.00  out of 10.00
+[+]       Based on:.....2 sub-scores:
+[+]           Sub-score:....How a project scans its dependencies for vulnerabilities
+[+]           Importance:...High (weight 1.00 out of 1.00)
+[+]           Value:........0.00  out of 10.00
+[+]           Confidence:...0.00  out of 10.00
+[+]           Based on:...1 features:
+[+]               Does it scan for vulnerable dependencies?....unknown
+[+]
+[+]           Sub-score:....How a project addresses issues reported by LGTM
+[+]           Importance:...High (weight 1.00 out of 1.00)
+[+]           Value:........10.00 out of 10.00
+[+]           Confidence:...10.00 out of 10.00
+[+]           Based on:...2 features:
+[+]               If a project uses LGTM:..............true
+[+]               The worst LGTM grade of a project:...A
+[+]
+[+]
+[+]       Sub-score:....Community commitment
+[+]       Importance:...Medium (weight 0.55 out of 1.00)
+[+]       Value:........0.00  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...3 features:
+[+]           Does it belong to Apache?........false
+[+]           Does it belong to Eclipse?.......false
+[+]           Is it supported by a company?....false
+[+]
+[+]       Sub-score:....Security awareness
+[+]       Description:..The score checks if a project has a security policy and a security team.
+[+]                     If the project has a security policy, then the score adds 3.00.
+[+]                     If the project has a security team, then the score adds 5.00.
+[+]                     If the project uses verified signed commits, then the score adds 2.00.
+[+]       Importance:...Medium (weight 0.54 out of 1.00)
+[+]       Value:........0.00  out of 10.00
+[+]       Confidence:...6.67  out of 10.00
+[+]       Based on:...3 features:
+[+]           Does it have a security policy?.........false
+[+]           Does it have a security team?...........unknown
+[+]           Does it use verified signed commits?....false
+[+]
+[+]       Sub-score:....Project popularity
+[+]       Description:..The score is based on number of stars and watchers.
+[+]                     Here is how a number of stars contributes to the score:
+[+]                     0 -> 0.00 (min), 2500 -> 2.50, 5000 -> 5.00, 10000 -> 10.00 (max)
+[+]                     Here is how a number of watchers contributes to the score:
+[+]                     0 -> 0.00 (min), 450 -> 1.50, 750 -> 2.50, 3000 -> 10.00 (max)
+[+]       Importance:...Medium (weight 0.31 out of 1.00)
+[+]       Value:........0.25  out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...2 features:
+[+]           Number of stars for a GitHub repository:......202
+[+]           Number of watchers for a GitHub repository:...15
+[+]
+[+]       Sub-score:....Vulnerability lifetime
+[+]       Importance:...Low (weight 0.23 out of 1.00)
+[+]       Value:........10.00 out of 10.00
+[+]       Confidence:...10.00 out of 10.00
+[+]       Based on:...2 features:
+[+]           Info about vulnerabilities:...0 vulnerabilities
+[+]           When a project started:.......Sun Mar 19 20:57:44 CET 2017
+[+]
+[+] Rating: 4.39 out of 10.00 -> BAD
+[+] Confidence: 8.67 out of 10.00
+
+```

--- a/docs/oss/security/README.md
+++ b/docs/oss/security/README.md
@@ -1,0 +1,8 @@
+# Projects
+
+| Project | Score | Rating | Confidence | Last updated |
+| ------- | ----- | ------ | ---------- | ------------ |
+| [FasterXML/jackson-databind](https://github.com/FasterXML/jackson-databind) | 5.43 | [MODERATE](FasterXML/jackson-databind.md) | 8.67 | Mar 27, 2020 |
+| [FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml) | 3.70 | [BAD](FasterXML/jackson-dataformat-xml.md) | 8.67 | Mar 27, 2020 |
+| [FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text) | 4.39 | [BAD](FasterXML/jackson-dataformats-text.md) | 8.67 | Mar 27, 2020 |
+

--- a/docs/oss/security/github_projects.json
+++ b/docs/oss/security/github_projects.json
@@ -1,0 +1,6960 @@
+[ {
+  "organization" : {
+    "name" : "FasterXML"
+  },
+  "name" : "jackson-databind",
+  "url" : "https://github.com/FasterXML/jackson-databind",
+  "ratingValue" : {
+    "scoreValue" : {
+      "type" : "ScoreValue",
+      "score" : {
+        "type" : "OssSecurityScore",
+        "name" : "Security score for open-source projects",
+        "weightedScores" : [ {
+          "score" : {
+            "type" : "ProjectSecurityTestingScore",
+            "name" : "How well security testing is done for an open-source project",
+            "subScores" : [ {
+              "type" : "DependencyScanScore",
+              "name" : "How a project scans its dependencies for vulnerabilities"
+            }, {
+              "type" : "LgtmScore",
+              "name" : "How a project addresses issues reported by LGTM"
+            } ]
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.6283118906878548
+          }
+        }, {
+          "score" : {
+            "type" : "UnpatchedVulnerabilitiesScore",
+            "name" : "How well vulnerabilities are patched"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.8362090433439393
+          }
+        }, {
+          "score" : {
+            "type" : "ProjectActivityScore",
+            "name" : "Open-source project activity score"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.6300785405632551
+          }
+        }, {
+          "score" : {
+            "type" : "CommunityCommitmentScore",
+            "name" : "How well open-source community commits to support an open-source project"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.5529742430404292
+          }
+        }, {
+          "score" : {
+            "type" : "ProjectSecurityAwarenessScore",
+            "name" : "How well open-source community is aware about security"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.5383270608555468
+          }
+        }, {
+          "score" : {
+            "type" : "VulnerabilityLifetimeScore",
+            "name" : "How fast vulnerabilities are patched"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.22939855566110368
+          }
+        }, {
+          "score" : {
+            "type" : "ProjectPopularityScore",
+            "name" : "Open-source project popularity score"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.30515788031015273
+          }
+        } ]
+      },
+      "value" : 5.434007760295833,
+      "weight" : 1.0,
+      "confidence" : 8.673285914850164,
+      "usedValues" : [ {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "ProjectSecurityTestingScore",
+          "name" : "How well security testing is done for an open-source project",
+          "subScores" : [ {
+            "type" : "DependencyScanScore",
+            "name" : "How a project scans its dependencies for vulnerabilities"
+          }, {
+            "type" : "LgtmScore",
+            "name" : "How a project addresses issues reported by LGTM"
+          } ]
+        },
+        "value" : 5.0,
+        "weight" : 0.6283118906878548,
+        "confidence" : 5.0,
+        "usedValues" : [ {
+          "type" : "ScoreValue",
+          "score" : {
+            "type" : "DependencyScanScore",
+            "name" : "How a project scans its dependencies for vulnerabilities"
+          },
+          "value" : 0.0,
+          "weight" : 1.0,
+          "confidence" : 0.0,
+          "usedValues" : [ {
+            "type" : "UnknownValue",
+            "feature" : {
+              "type" : "BooleanFeature",
+              "name" : "If an open-source project is regularly scanned for vulnerable dependencies"
+            }
+          } ],
+          "explanation" : [ ]
+        }, {
+          "type" : "ScoreValue",
+          "score" : {
+            "type" : "LgtmScore",
+            "name" : "How a project addresses issues reported by LGTM"
+          },
+          "value" : 10.0,
+          "weight" : 1.0,
+          "confidence" : 10.0,
+          "usedValues" : [ {
+            "type" : "BooleanValue",
+            "feature" : {
+              "type" : "BooleanFeature",
+              "name" : "If a project uses LGTM"
+            },
+            "flag" : true
+          }, {
+            "type" : "LgtmGradeValue",
+            "feature" : {
+              "type" : "LgtmGradeFeature",
+              "name" : "The worst LGTM grade of a project"
+            },
+            "value" : "A"
+          } ],
+          "explanation" : [ ]
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "UnpatchedVulnerabilitiesScore",
+          "name" : "How well vulnerabilities are patched"
+        },
+        "value" : 10.0,
+        "weight" : 0.8362090433439393,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "VulnerabilitiesValue",
+          "vulnerabilities" : {
+            "entries" : [ {
+              "id" : "CVE-2019-12384",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 4.3
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:1820",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1820"
+              }, {
+                "description" : "RHSA-2019:2720",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2720"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:2935",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+              }, {
+                "description" : "RHSA-2019:2936",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+              }, {
+                "description" : "RHSA-2019:2937",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+              }, {
+                "description" : "RHSA-2019:2938",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+              }, {
+                "description" : "RHSA-2019:2998",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2998"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "RHSA-2019:3292",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3292"
+              }, {
+                "description" : "RHSA-2019:3297",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3297"
+              }, {
+                "description" : "RHSA-2019:3901",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+              }, {
+                "description" : "RHSA-2019:4352",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4352"
+              }, {
+                "description" : "https://blog.doyensec.com/2019/07/22/jackson-gadgets.html",
+                "url" : "https://blog.doyensec.com/2019/07/22/jackson-gadgets.html"
+              }, {
+                "description" : "https://doyensec.com/research.html",
+                "url" : "https://doyensec.com/research.html"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/compare/74b90a4...a977aad",
+                "url" : "https://github.com/FasterXML/jackson-databind/compare/74b90a4...a977aad"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[geode-notifications] 20191007 [GitHub] [geode] jmelchio commented on issue #4102: Fix for GEODE-7255: Pickup Jackson CVE fix",
+                "url" : "https://lists.apache.org/thread.html/e0733058c0366b703e6757d8d2a7a04b943581f659e9c271f0841dfe@%3Cnotifications.geode.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "https://lists.debian.org/debian-lts-announce/2019/06/msg00019.html",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/06/msg00019.html"
+              }, {
+                "description" : "FEDORA-2019-ae6a703b8f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+              }, {
+                "description" : "FEDORA-2019-fb23eccc03",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+              }, {
+                "description" : "FEDORA-2019-99ff6aa32c",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+              }, {
+                "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190703-0002/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190703-0002/"
+              }, {
+                "description" : "DSA-4542",
+                "url" : "https://www.debian.org/security/2019/dsa-4542"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-14540",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "RHSA-2020:0159",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+              }, {
+                "description" : "RHSA-2020:0160",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+              }, {
+                "description" : "RHSA-2020:0161",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+              }, {
+                "description" : "RHSA-2020:0164",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+              }, {
+                "description" : "RHSA-2020:0445",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/blob/master/release-notes/VERSION-2.x",
+                "url" : "https://github.com/FasterXML/jackson-databind/blob/master/release-notes/VERSION-2.x"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2410",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2410"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2449",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2449"
+              }, {
+                "description" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch opened a new pull request #1200: Upgrade jackson due to CVE issues",
+                "url" : "https://lists.apache.org/thread.html/0fcef7321095ce0bc597d468d150cff3d647f4cb3aef3bd4d20e1c69@%3Ccommits.tinkerpop.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190925 [GitHub] [hbase] SteNicholas opened a new pull request #660: HBASE-23075 Upgrade jackson version",
+                "url" : "https://lists.apache.org/thread.html/40c00861b53bb611dee7d6f35f864aa7d1c1bd77df28db597cbf27e1@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190926 [GitHub] [hbase-connectors] SteNicholas opened a new pull request #45: HBASE-23075 Upgrade jackson version",
+                "url" : "https://lists.apache.org/thread.html/a360b46061c91c5cad789b6c3190aef9b9f223a2b75c9c9f046fe016@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190925 [GitHub] [zookeeper] maoling commented on issue #1097: ZOOKEEPER-3559 - Update Jackson to 2.9.10",
+                "url" : "https://lists.apache.org/thread.html/a4f2c9fb36642a48912cdec6836ec00e497427717c5d377f8d7ccce6@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190926 [jira] [Commented] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                "url" : "https://lists.apache.org/thread.html/ad0d238e97a7da5eca47a014f0f7e81f440ed6bf74a93183825e18b9@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190926 [jira] [Updated] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                "url" : "https://lists.apache.org/thread.html/dc6b5cad721a4f6b3b62ed1163894941140d9d5656140fb757505ca0@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[hbase-commits] 20190927 [hbase-connectors] 02/02: HBASE-23075 Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                "url" : "https://lists.apache.org/thread.html/e90c3feb21702e68a8c08afce37045adb3870f2bf8223fa403fb93fb@%3Ccommits.hbase.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+              }, {
+                "description" : "FEDORA-2019-cf87377f5f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+              }, {
+                "description" : "FEDORA-2019-b171554877",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+              }, {
+                "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20191004-0002/",
+                "url" : "https://security.netapp.com/advisory/ntap-20191004-0002/"
+              }, {
+                "description" : "DSA-4542",
+                "url" : "https://www.debian.org/security/2019/dsa-4542"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-16942",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:3901",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+              }, {
+                "description" : "RHSA-2020:0159",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+              }, {
+                "description" : "RHSA-2020:0160",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+              }, {
+                "description" : "RHSA-2020:0161",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+              }, {
+                "description" : "RHSA-2020:0164",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+              }, {
+                "description" : "RHSA-2020:0445",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2478",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2478"
+              }, {
+                "description" : "https://issues.apache.org/jira/browse/GEODE-7255",
+                "url" : "https://issues.apache.org/jira/browse/GEODE-7255"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[geode-issues] 20191011 [jira] [Commented] (GEODE-7255) Need to pick up CVE-2019-16942",
+                "url" : "https://lists.apache.org/thread.html/7782a937c9259a58337ee36b2961f00e2d744feafc13084e176d0df5@%3Cissues.geode.apache.org%3E"
+              }, {
+                "description" : "[geode-issues] 20191230 [jira] [Closed] (GEODE-7255) Need to pick up CVE-2019-16942",
+                "url" : "https://lists.apache.org/thread.html/a430dbc9be874c41314cc69e697384567a9a24025e819d9485547954@%3Cissues.geode.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[geode-issues] 20191008 [jira] [Commented] (GEODE-7255) Need to pick up CVE-2019-16942",
+                "url" : "https://lists.apache.org/thread.html/b2e23c94f9dfef53e04c492e5d02e5c75201734be7adc73a49ef2370@%3Cissues.geode.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+              }, {
+                "description" : "FEDORA-2019-cf87377f5f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+              }, {
+                "description" : "FEDORA-2019-b171554877",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              }, {
+                "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20191017-0006/",
+                "url" : "https://security.netapp.com/advisory/ntap-20191017-0006/"
+              }, {
+                "description" : "DSA-4542",
+                "url" : "https://www.debian.org/security/2019/dsa-4542"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2020-8840",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2620",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2620"
+              }, {
+                "description" : "[druid-commits] 20200219 [GitHub] [druid] ccaominh opened a new pull request #9379: Suppress CVE-2020-8840 for htrace-core-4.0.1",
+                "url" : "https://lists.apache.org/thread.html/r078e68a926ea6be12e8404e47f45aabf04bb4668e8265c0de41db6db@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20200313 Re: CVE-2020-8840 on TomEE 8.0.1",
+                "url" : "https://lists.apache.org/thread.html/r1c09b9551f6953dbeca190a4c4b78198cdbb9825fce36f96fe3d8218@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200219 [GitHub] [druid] suneet-s commented on issue #9379: Suppress CVE-2020-8840 for htrace-core-4.0.1",
+                "url" : "https://lists.apache.org/thread.html/r319f19c74e06c201b9d4e8b282a4e4b2da6dcda022fb46f007dd00d3@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200223 [GitHub] [zookeeper] eolivelli opened a new pull request #1262: ZOOKEEPER-3734 upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r3539bd3a377991217d724879d239e16e86001c54160076408574e1da@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200221 [GitHub] [druid] ccaominh merged pull request #9379: Suppress CVE-2020-8840 for htrace-core-4.0.1",
+                "url" : "https://lists.apache.org/thread.html/r3d20a2660b36551fd8257d479941782af4a7169582449fac1704bde2@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200223 [GitHub] [zookeeper] phunt commented on issue #1262: ZOOKEEPER-3734 upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r428d068b2a4923f1a5a4f5fc6381b95205cfe7620169d16db78e9c71@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200223 [zookeeper] branch master updated: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r46bebdeb59b8b7212d63a010ca445a9f5c4e9d64dcf693cab6f399d3@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200225 [jira] [Updated] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r65ee95fa09c831843bac81eaa582fdddc2b6119912a72d1c83a9b882@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200223 [jira] [Updated] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r6fdd4c61a09a0c89f581b4ddb3dc6f154ab0c705fcfd0a7358b2e4e5@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200223 [jira] [Resolved] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r8170007fd9b263d65b37d92a7b5d7bc357aedbb113a32838bc4a9485@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200222 [jira] [Created] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r9ecf211c22760b00967ebe158c6ed7dba9142078e2a630ab8904a5b7@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200223 [GitHub] [zookeeper] asfgit closed pull request #1262: ZOOKEEPER-3734 upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/rac5ee5d686818be7e7c430d35108ee01a88aae54f832d32f62431fd1@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200222 [jira] [Created] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/rb43f9a65150948a6bebd3cb77ee3e105d40db2820fd547528f4e7f89@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200224 [zookeeper] 01/02: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/rb5eedf90ba3633e171a2ffdfe484651c9490dc5df74c8a29244cbc0e@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20200311 CVE-2020-8840 on TomEE 8.0.1",
+                "url" : "https://lists.apache.org/thread.html/rb99c7321eba5d4c907beec46675d52827528b738cfafd48eb4d862f1@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20200316 RE: CVE-2020-8840 on TomEE 8.0.1",
+                "url" : "https://lists.apache.org/thread.html/rc068e824654c4b8bd4f2490bec869e29edbfcd5dfe02d47cbf7433b2@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20200311 Re: CVE-2020-8840 on TomEE 8.0.1",
+                "url" : "https://lists.apache.org/thread.html/rdea588d4a0ebf9cb7ce8c3a8f18d0d306507c4f8ba178dd3d20207b8@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200223 [zookeeper] branch branch-3.6 updated: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/rdf8d389271a291dde3b2f99c36918d6cb1e796958af626cc140fee23@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200223 [jira] [Assigned] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/re7326b8655eab931f2a9ce074fd9a1a51b5db11456bee9b48e1e170c@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200223 [zookeeper] branch branch-3.5 updated: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/re8ae2670ec456ef1c5a2a661a2838ab2cd00e9efa1e88c069f546f21@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200220 [SECURITY] [DLA 2111-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00020.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-12086",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 5.0
+              },
+              "references" : [ {
+                "description" : "http://russiansecurity.expert/2016/04/20/mysql-connect-file-read/",
+                "url" : "http://russiansecurity.expert/2016/04/20/mysql-connect-file-read/"
+              }, {
+                "description" : "109227",
+                "url" : "http://www.securityfocus.com/bid/109227"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:2935",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+              }, {
+                "description" : "RHSA-2019:2936",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+              }, {
+                "description" : "RHSA-2019:2937",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+              }, {
+                "description" : "RHSA-2019:2938",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+              }, {
+                "description" : "RHSA-2019:2998",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2998"
+              }, {
+                "description" : "RHSA-2019:3044",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3044"
+              }, {
+                "description" : "RHSA-2019:3045",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3045"
+              }, {
+                "description" : "RHSA-2019:3046",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3046"
+              }, {
+                "description" : "RHSA-2019:3050",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3050"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2326",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2326"
+              }, {
+                "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[spark-reviews] 20190520 [GitHub] [spark] Fokko opened a new pull request #24646: Spark 27757",
+                "url" : "https://lists.apache.org/thread.html/88cd25375805950ae7337e669b0cb0eeda98b9604c1b8d806dccbad2@%3Creviews.spark.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-solr-user] 20200320 CVEs (vulnerabilities) that apply to Solr 8.4.1",
+                "url" : "https://lists.apache.org/thread.html/r204ba2a9ea750f38d789d2bb429cc0925ad6133deea7cbc3001d96b5@%3Csolr-user.lucene.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190521 [SECURITY] [DLA 1798-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/05/msg00030.html"
+              }, {
+                "description" : "FEDORA-2019-ae6a703b8f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+              }, {
+                "description" : "FEDORA-2019-fb23eccc03",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+              }, {
+                "description" : "FEDORA-2019-99ff6aa32c",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-16943",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2020:0159",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+              }, {
+                "description" : "RHSA-2020:0160",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+              }, {
+                "description" : "RHSA-2020:0161",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+              }, {
+                "description" : "RHSA-2020:0164",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+              }, {
+                "description" : "RHSA-2020:0445",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2478",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2478"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[iceberg-commits] 20191028 [incubator-iceberg] branch master updated: Update Jackson to 2.10.0 for CVE-2019-16943 (#583)",
+                "url" : "https://lists.apache.org/thread.html/5ec8d8d485c2c8ac55ea425f4cd96596ef37312532712639712ebcdd@%3Ccommits.iceberg.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191027 [GitHub] [incubator-iceberg] rdsr commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/6788e4c991f75b89d290ad06b463fcd30bcae99fee610345a35b7bc6@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+              }, {
+                "description" : "FEDORA-2019-cf87377f5f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+              }, {
+                "description" : "FEDORA-2019-b171554877",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              }, {
+                "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20191017-0006/",
+                "url" : "https://security.netapp.com/advisory/ntap-20191017-0006/"
+              }, {
+                "description" : "DSA-4542",
+                "url" : "https://www.debian.org/security/2019/dsa-4542"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-17531",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:4192",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4192"
+              }, {
+                "description" : "RHSA-2020:0159",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+              }, {
+                "description" : "RHSA-2020:0160",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+              }, {
+                "description" : "RHSA-2020:0161",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+              }, {
+                "description" : "RHSA-2020:0164",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+              }, {
+                "description" : "RHSA-2020:0445",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2498",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2498"
+              }, {
+                "description" : "[pulsar-commits] 20191127 [GitHub] [pulsar] massakam opened a new pull request #5758: Bump jackson libraries to 2.10.1",
+                "url" : "https://lists.apache.org/thread.html/b3c90d38f99db546de60fea65f99a924d540fae2285f014b79606ca5@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20191210 [SECURITY] [DLA 2030-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/12/msg00013.html"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20191024-0005/",
+                "url" : "https://security.netapp.com/advisory/ntap-20191024-0005/"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-19362",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "107985",
+                "url" : "http://www.securityfocus.com/bid/107985"
+              }, {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2186",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2186"
+              }, {
+                "description" : "https://issues.apache.org/jira/browse/TINKERPOP-2121",
+                "url" : "https://issues.apache.org/jira/browse/TINKERPOP-2121"
+              }, {
+                "description" : "[infra-devnull] 20190329 [GitHub] [pulsar] massakam opened pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/37e1ed724a1b0e5d191d98c822c426670bdfde83804567131847d2a3@%3Cdevnull.infra.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190329 [GitHub] [pulsar] massakam opened a new pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/c70da3cb6e3f03e0ad8013e38b6959419d866c4a7c80fdd34b73f25c@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-19361",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "107985",
+                "url" : "http://www.securityfocus.com/bid/107985"
+              }, {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2186",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2186"
+              }, {
+                "description" : "https://issues.apache.org/jira/browse/TINKERPOP-2121",
+                "url" : "https://issues.apache.org/jira/browse/TINKERPOP-2121"
+              }, {
+                "description" : "[infra-devnull] 20190329 [GitHub] [pulsar] massakam opened pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/37e1ed724a1b0e5d191d98c822c426670bdfde83804567131847d2a3@%3Cdevnull.infra.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190329 [GitHub] [pulsar] massakam opened a new pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/c70da3cb6e3f03e0ad8013e38b6959419d866c4a7c80fdd34b73f25c@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-19360",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "107985",
+                "url" : "http://www.securityfocus.com/bid/107985"
+              }, {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2186",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2186"
+              }, {
+                "description" : "https://issues.apache.org/jira/browse/TINKERPOP-2121",
+                "url" : "https://issues.apache.org/jira/browse/TINKERPOP-2121"
+              }, {
+                "description" : "[infra-devnull] 20190329 [GitHub] [pulsar] massakam opened pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/37e1ed724a1b0e5d191d98c822c426670bdfde83804567131847d2a3@%3Cdevnull.infra.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190329 [GitHub] [pulsar] massakam opened a new pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/c70da3cb6e3f03e0ad8013e38b6959419d866c4a7c80fdd34b73f25c@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2017-15095",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html"
+              }, {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html"
+              }, {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+              }, {
+                "description" : "103880",
+                "url" : "http://www.securityfocus.com/bid/103880"
+              }, {
+                "description" : "1039769",
+                "url" : "http://www.securitytracker.com/id/1039769"
+              }, {
+                "description" : "RHSA-2017:3189",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3189"
+              }, {
+                "description" : "RHSA-2017:3190",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3190"
+              }, {
+                "description" : "RHSA-2018:0342",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0342"
+              }, {
+                "description" : "RHSA-2018:0478",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0478"
+              }, {
+                "description" : "RHSA-2018:0479",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0479"
+              }, {
+                "description" : "RHSA-2018:0480",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0480"
+              }, {
+                "description" : "RHSA-2018:0481",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0481"
+              }, {
+                "description" : "RHSA-2018:0576",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0576"
+              }, {
+                "description" : "RHSA-2018:0577",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0577"
+              }, {
+                "description" : "RHSA-2018:1447",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1447"
+              }, {
+                "description" : "RHSA-2018:1448",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1448"
+              }, {
+                "description" : "RHSA-2018:1449",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+              }, {
+                "description" : "RHSA-2018:1450",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+              }, {
+                "description" : "RHSA-2018:1451",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1451"
+              }, {
+                "description" : "RHSA-2018:2927",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2927"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1680",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1680"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1737",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1737"
+              }, {
+                "description" : "[lucene-solr-user] 20191219 Re: CVE-2017-7525 fix for Solr 7.7.x",
+                "url" : "https://lists.apache.org/thread.html/f095a791bda6c0595f691eddd0febb2d396987eec5cbd29120d8c629@%3Csolr-user.lucene.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200131 [SECURITY] [DLA 2091-1] libjackson-json-java security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/01/msg00037.html"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20171214-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20171214-0003/"
+              }, {
+                "description" : "DSA-4037",
+                "url" : "https://www.debian.org/security/2017/dsa-4037"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2017-7525",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html"
+              }, {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html"
+              }, {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+              }, {
+                "description" : "99623",
+                "url" : "http://www.securityfocus.com/bid/99623"
+              }, {
+                "description" : "1039744",
+                "url" : "http://www.securitytracker.com/id/1039744"
+              }, {
+                "description" : "1039947",
+                "url" : "http://www.securitytracker.com/id/1039947"
+              }, {
+                "description" : "1040360",
+                "url" : "http://www.securitytracker.com/id/1040360"
+              }, {
+                "description" : "RHSA-2017:1834",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:1834"
+              }, {
+                "description" : "RHSA-2017:1835",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:1835"
+              }, {
+                "description" : "RHSA-2017:1836",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:1836"
+              }, {
+                "description" : "RHSA-2017:1837",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:1837"
+              }, {
+                "description" : "RHSA-2017:1839",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:1839"
+              }, {
+                "description" : "RHSA-2017:1840",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:1840"
+              }, {
+                "description" : "RHSA-2017:2477",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2477"
+              }, {
+                "description" : "RHSA-2017:2546",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2546"
+              }, {
+                "description" : "RHSA-2017:2547",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2547"
+              }, {
+                "description" : "RHSA-2017:2633",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2633"
+              }, {
+                "description" : "RHSA-2017:2635",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2635"
+              }, {
+                "description" : "RHSA-2017:2636",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2636"
+              }, {
+                "description" : "RHSA-2017:2637",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2637"
+              }, {
+                "description" : "RHSA-2017:2638",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2638"
+              }, {
+                "description" : "RHSA-2017:3141",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3141"
+              }, {
+                "description" : "RHSA-2017:3454",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3454"
+              }, {
+                "description" : "RHSA-2017:3455",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3455"
+              }, {
+                "description" : "RHSA-2017:3456",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3456"
+              }, {
+                "description" : "RHSA-2017:3458",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3458"
+              }, {
+                "description" : "RHSA-2018:0294",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0294"
+              }, {
+                "description" : "RHSA-2018:0342",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0342"
+              }, {
+                "description" : "RHSA-2018:1449",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+              }, {
+                "description" : "RHSA-2018:1450",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+              }, {
+                "description" : "RHSA-2019:0910",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0910"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1462702",
+                "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1462702"
+              }, {
+                "description" : "https://cwiki.apache.org/confluence/display/WW/S2-055",
+                "url" : "https://cwiki.apache.org/confluence/display/WW/S2-055"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1599",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1599"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1723",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1723"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                "url" : "https://lists.apache.org/thread.html/3c87dc8bca99a2b3b4743713b33d1de05b1d6b761fdf316224e9c81f@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[cassandra-commits] 20191113 [jira] [Created] (CASSANDRA-15416) CVE-2017-7525 ( jackson-databind is vulnerable to Remote Code Execution) on version 3.11.4",
+                "url" : "https://lists.apache.org/thread.html/4641ed8616ccc2c1fbddac2c3dc9900c96387bc226eaf0232d61909b@%3Ccommits.cassandra.apache.org%3E"
+              }, {
+                "description" : "[lucene-solr-user] 20191218 CVE-2017-7525 fix for Solr 7.7.x",
+                "url" : "https://lists.apache.org/thread.html/5008bcbd45ee65ce39e4220b6ac53d28a24d6bc67d5804e9773a7399@%3Csolr-user.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-solr-user] 20190104 Re: SOLR v7 Security Issues Caused Denial of Use - Sonatype Application Composition Report",
+                "url" : "https://lists.apache.org/thread.html/708d94141126eac03011144a971a6411fcac16d9c248d1d535a39451@%3Csolr-user.lucene.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20191115 [GitHub] [incubator-druid] ccaominh opened a new pull request #8878: Address security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/9317fd092b257a0815434b116a8af8daea6e920b6673f4fd5583d5fe@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                "url" : "https://lists.apache.org/thread.html/b1f33fe5ade396bb903fdcabe9f243f7692c7dfce5418d3743c2d346@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Resolved] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                "url" : "https://lists.apache.org/thread.html/c10a2bf0fdc3d25faf17bd191d6ec46b29a353fa9c97bebd7c4e5913@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Assigned] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                "url" : "https://lists.apache.org/thread.html/c2ed4c0126b43e324cf740012a0edd371fd36096fd777be7bfe7a2a6@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-solr-user] 20191218 Re: CVE-2017-7525 fix for Solr 7.7.x",
+                "url" : "https://lists.apache.org/thread.html/c9d5ff20929e8a3c8794facf4c4b326a9c10618812eec356caa20b87@%3Csolr-user.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-solr-user] 20191219 Re: CVE-2017-7525 fix for Solr 7.7.x",
+                "url" : "https://lists.apache.org/thread.html/f095a791bda6c0595f691eddd0febb2d396987eec5cbd29120d8c629@%3Csolr-user.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Closed] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                "url" : "https://lists.apache.org/thread.html/f60afd3c7e9ebaaf70fad4a4beb75cf8740ac959017a31e7006c7486@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200131 [SECURITY] [DLA 2091-1] libjackson-json-java security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/01/msg00037.html"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20171214-0002/",
+                "url" : "https://security.netapp.com/advisory/ntap-20171214-0002/"
+              }, {
+                "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+              }, {
+                "description" : "DSA-4004",
+                "url" : "https://www.debian.org/security/2017/dsa-4004"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-14720",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:1106",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+              }, {
+                "description" : "RHSA-2019:1107",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+              }, {
+                "description" : "RHSA-2019:1108",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+              }, {
+                "description" : "RHSA-2019:1140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Assigned] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                "url" : "https://lists.apache.org/thread.html/6a78f88716c3c57aa74ec05764a37ab3874769a347805903b393b286@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                "url" : "https://lists.apache.org/thread.html/82b01bfb6787097427ce97cec6a7127e93718bc05d1efd5eaffc228f@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                "url" : "https://lists.apache.org/thread.html/ba973114605d936be276ee6ce09dfbdbf78aa56f6cdc6e79bfa7b8df@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-14721",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:1106",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+              }, {
+                "description" : "RHSA-2019:1107",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+              }, {
+                "description" : "RHSA-2019:1108",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+              }, {
+                "description" : "RHSA-2019:1140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-12022",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 5.1
+              },
+              "references" : [ {
+                "description" : "107585",
+                "url" : "http://www.securityfocus.com/bid/107585"
+              }, {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1106",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+              }, {
+                "description" : "RHSA-2019:1107",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+              }, {
+                "description" : "RHSA-2019:1108",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+              }, {
+                "description" : "RHSA-2019:1140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1671098",
+                "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1671098"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2052",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2052"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-issues] 20191004 [GitHub] [lucene-solr] marungo opened a new pull request #925: SOLR-13818: Upgrade jackson to 2.10.0",
+                "url" : "https://lists.apache.org/thread.html/7fcf88aff0d1deaa5c3c7be8d58c05ad7ad5da94b59065d8e7c50c5d@%3Cissues.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf",
+                "url" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-12023",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 5.1
+              },
+              "references" : [ {
+                "description" : "http://www.securityfocus.com/bid/105659",
+                "url" : "http://www.securityfocus.com/bid/105659"
+              }, {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1106",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+              }, {
+                "description" : "RHSA-2019:1107",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+              }, {
+                "description" : "RHSA-2019:1108",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+              }, {
+                "description" : "RHSA-2019:1140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2058",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2058"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-issues] 20191004 [GitHub] [lucene-solr] marungo opened a new pull request #925: SOLR-13818: Upgrade jackson to 2.10.0",
+                "url" : "https://lists.apache.org/thread.html/7fcf88aff0d1deaa5c3c7be8d58c05ad7ad5da94b59065d8e7c50c5d@%3Cissues.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf",
+                "url" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-14893",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2020:0729",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0729"
+              }, {
+                "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14893",
+                "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14893"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2469",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2469"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-16335",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "RHSA-2020:0159",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+              }, {
+                "description" : "RHSA-2020:0160",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+              }, {
+                "description" : "RHSA-2020:0161",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+              }, {
+                "description" : "RHSA-2020:0164",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+              }, {
+                "description" : "RHSA-2020:0445",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+              }, {
+                "description" : "RHSA-2020:0729",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0729"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2449",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2449"
+              }, {
+                "description" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch opened a new pull request #1200: Upgrade jackson due to CVE issues",
+                "url" : "https://lists.apache.org/thread.html/0fcef7321095ce0bc597d468d150cff3d647f4cb3aef3bd4d20e1c69@%3Ccommits.tinkerpop.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190925 [GitHub] [hbase] SteNicholas opened a new pull request #660: HBASE-23075 Upgrade jackson version",
+                "url" : "https://lists.apache.org/thread.html/40c00861b53bb611dee7d6f35f864aa7d1c1bd77df28db597cbf27e1@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190926 [GitHub] [hbase-connectors] SteNicholas opened a new pull request #45: HBASE-23075 Upgrade jackson version",
+                "url" : "https://lists.apache.org/thread.html/a360b46061c91c5cad789b6c3190aef9b9f223a2b75c9c9f046fe016@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190926 [jira] [Commented] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                "url" : "https://lists.apache.org/thread.html/ad0d238e97a7da5eca47a014f0f7e81f440ed6bf74a93183825e18b9@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190926 [jira] [Updated] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                "url" : "https://lists.apache.org/thread.html/dc6b5cad721a4f6b3b62ed1163894941140d9d5656140fb757505ca0@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[hbase-commits] 20190927 [hbase-connectors] 02/02: HBASE-23075 Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                "url" : "https://lists.apache.org/thread.html/e90c3feb21702e68a8c08afce37045adb3870f2bf8223fa403fb93fb@%3Ccommits.hbase.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+              }, {
+                "description" : "FEDORA-2019-cf87377f5f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+              }, {
+                "description" : "FEDORA-2019-b171554877",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+              }, {
+                "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20191004-0002/",
+                "url" : "https://security.netapp.com/advisory/ntap-20191004-0002/"
+              }, {
+                "description" : "DSA-4542",
+                "url" : "https://www.debian.org/security/2019/dsa-4542"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-14892",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2020:0729",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0729"
+              }, {
+                "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14892",
+                "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14892"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2462",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2462"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2020-9546",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 6.8
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2631",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2631"
+              }, {
+                "description" : "[zookeeper-issues] 20200308 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r35d30db00440ef63b791c4b7f7acb036e14d4a23afa2a249cb66c0fd@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r9464a40d25c3ba1a55622db72f113eb494a889656962d098c70c5bb1@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200319 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r98c9b6e4c9e17792e2cd1ec3e4aa20b61a791939046d3f10888176bb@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rb6fecb5e96a6d61e175ff49f33f2713798dd05cf03067c169d195596@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200319 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rd5a4457be4623038c3989294429bc063eec433a2e55995d81591e2ca@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200307 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rdd49ab9565bec436a896bc00c4b9fc9dce1598e106c318524fbdfec6@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200305 [SECURITY] [DLA 2135-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00008.html"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-14379",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHBA-2019:2824",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:2824"
+              }, {
+                "description" : "RHSA-2019:2743",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2743"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:2935",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+              }, {
+                "description" : "RHSA-2019:2936",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+              }, {
+                "description" : "RHSA-2019:2937",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+              }, {
+                "description" : "RHSA-2019:2938",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+              }, {
+                "description" : "RHSA-2019:2998",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2998"
+              }, {
+                "description" : "RHSA-2019:3044",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3044"
+              }, {
+                "description" : "RHSA-2019:3045",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3045"
+              }, {
+                "description" : "RHSA-2019:3046",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3046"
+              }, {
+                "description" : "RHSA-2019:3050",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3050"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "RHSA-2019:3292",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3292"
+              }, {
+                "description" : "RHSA-2019:3297",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3297"
+              }, {
+                "description" : "RHSA-2019:3901",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+              }, {
+                "description" : "RHSA-2020:0727",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0727"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2",
+                "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2387",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2387"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch opened a new pull request #1200: Upgrade jackson due to CVE issues",
+                "url" : "https://lists.apache.org/thread.html/0fcef7321095ce0bc597d468d150cff3d647f4cb3aef3bd4d20e1c69@%3Ccommits.tinkerpop.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/2766188be238a446a250ef76801037d452979152d85bce5e46805815@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190822 [GitHub] [pulsar] massakam opened a new pull request #5011: [security] Upgrade jackson-databind",
+                "url" : "https://lists.apache.org/thread.html/525bcf949a4b0da87a375cbad2680b8beccde749522f24c49befe7fb@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191027 [GitHub] [incubator-iceberg] rdsr commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/6788e4c991f75b89d290ad06b463fcd30bcae99fee610345a35b7bc6@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] mccheah opened a new pull request #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/689c6bcc6c7612eee71e453a115a4c8581e7b718537025d4b265783d@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] mccheah commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/75f482fdc84abe6d0c8f438a76437c335a7bbeb5cddd4d70b4bc0cbf@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue opened a new pull request #533: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/859815b2e9f1575acbb2b260b73861c16ca49bca627fa0c46419051f@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue merged pull request #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/8723b52c2544e6cb804bc8a36622c584acd1bd6c53f2b6034c9fea54@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue closed pull request #533: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/99944f86abefde389da9b4040ea2327c6aa0b53a2ff9352bd4cfec17@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue commented on issue #533: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/d161ff3d59c5a8213400dd6afb1cce1fac4f687c32d1e0c0bfbfaa2d@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[ambari-commits] 20190813 [ambari] branch branch-2.7 updated: AMBARI-25352 : Upgrade fasterxml jackson dependency due to CVE-2019-14379 (#3066)",
+                "url" : "https://lists.apache.org/thread.html/e25e734c315f70d8876a846926cfe3bfa1a4888044f146e844caf72f@%3Ccommits.ambari.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[ambari-commits] 20190813 [ambari] branch trunk updated: AMBARI-25352 : Upgrade fasterxml jackson dependency due to CVE-2019-14379(trunk) (#3067)",
+                "url" : "https://lists.apache.org/thread.html/f17f63b0f8a57e4a5759e01d25cffc0548f0b61ff5c6bfd704ad2f2a@%3Ccommits.ambari.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190812 [SECURITY] [DLA 1879-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/08/msg00011.html"
+              }, {
+                "description" : "FEDORA-2019-ae6a703b8f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+              }, {
+                "description" : "FEDORA-2019-fb23eccc03",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+              }, {
+                "description" : "FEDORA-2019-99ff6aa32c",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190814-0001/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190814-0001/"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-17267",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "RHSA-2020:0159",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+              }, {
+                "description" : "RHSA-2020:0160",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+              }, {
+                "description" : "RHSA-2020:0161",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+              }, {
+                "description" : "RHSA-2020:0164",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+              }, {
+                "description" : "RHSA-2020:0445",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.3...jackson-databind-2.9.10",
+                "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.3...jackson-databind-2.9.10"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2460",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2460"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[skywalking-dev] 20200324 [CVE-2019-17267] Upgrade jackson-databind version to 2.9.10",
+                "url" : "https://lists.apache.org/thread.html/r9d727fc681fb3828794acbefcaee31393742b4d73a29461ccd9597a8@%3Cdev.skywalking.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20191210 [SECURITY] [DLA 2030-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/12/msg00013.html"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20191017-0006/",
+                "url" : "https://security.netapp.com/advisory/ntap-20191017-0006/"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2017-17485",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "20180109 CVE-2017-17485: one more way of rce in jackson-databind when defaultTyping+objects are used",
+                "url" : "http://www.securityfocus.com/archive/1/541652/100/0/threaded"
+              }, {
+                "description" : "RHSA-2018:0116",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0116"
+              }, {
+                "description" : "RHSA-2018:0342",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0342"
+              }, {
+                "description" : "RHSA-2018:0478",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0478"
+              }, {
+                "description" : "RHSA-2018:0479",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0479"
+              }, {
+                "description" : "RHSA-2018:0480",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0480"
+              }, {
+                "description" : "RHSA-2018:0481",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0481"
+              }, {
+                "description" : "RHSA-2018:1447",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1447"
+              }, {
+                "description" : "RHSA-2018:1448",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1448"
+              }, {
+                "description" : "RHSA-2018:1449",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+              }, {
+                "description" : "RHSA-2018:1450",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+              }, {
+                "description" : "RHSA-2018:1451",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1451"
+              }, {
+                "description" : "RHSA-2018:2930",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2930"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1855",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1855"
+              }, {
+                "description" : "https://github.com/irsl/jackson-rce-via-spel/",
+                "url" : "https://github.com/irsl/jackson-rce-via-spel/"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20180201-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20180201-0003/"
+              }, {
+                "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+              }, {
+                "description" : "DSA-4114",
+                "url" : "https://www.debian.org/security/2018/dsa-4114"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2020-9547",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 6.8
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2634",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2634"
+              }, {
+                "description" : "[zookeeper-issues] 20200308 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r35d30db00440ef63b791c4b7f7acb036e14d4a23afa2a249cb66c0fd@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/r4accb2e0de9679174efd3d113a059bab71ff3ec53e882790d21c1cc1@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/r4accb2e0de9679174efd3d113a059bab71ff3ec53e882790d21c1cc1@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/r742ef70d126548dcf7de5be5779355c9d76a9aec71d7a9ef02c6398a@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/r742ef70d126548dcf7de5be5779355c9d76a9aec71d7a9ef02c6398a@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r9464a40d25c3ba1a55622db72f113eb494a889656962d098c70c5bb1@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200319 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r98c9b6e4c9e17792e2cd1ec3e4aa20b61a791939046d3f10888176bb@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/ra3e90712f2d59f8cef03fa796f5adf163d32b81fe7b95385f21790e6@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/ra3e90712f2d59f8cef03fa796f5adf163d32b81fe7b95385f21790e6@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rb6fecb5e96a6d61e175ff49f33f2713798dd05cf03067c169d195596@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/rc0d5d0f72da1ed6fc5e438b1ddb3fa090c73006b55f873cf845375ab@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/rc0d5d0f72da1ed6fc5e438b1ddb3fa090c73006b55f873cf845375ab@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200307 Build failed in Jenkins: PreCommit-ZOOKEEPER-github-pr-build-maven #1898",
+                "url" : "https://lists.apache.org/thread.html/rd0e958d6d5c5ee16efed73314cd0e445c8dbb4bdcc80fc9d1d6c11fc@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200319 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rd5a4457be4623038c3989294429bc063eec433a2e55995d81591e2ca@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200307 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rdd49ab9565bec436a896bc00c4b9fc9dce1598e106c318524fbdfec6@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/redbe4f1e21bf080f637cf9fbec47729750a2f443a919765360337428@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/redbe4f1e21bf080f637cf9fbec47729750a2f443a919765360337428@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200305 [SECURITY] [DLA 2135-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00008.html"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2020-9548",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 6.8
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2634",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2634"
+              }, {
+                "description" : "[zookeeper-issues] 20200308 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r35d30db00440ef63b791c4b7f7acb036e14d4a23afa2a249cb66c0fd@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r9464a40d25c3ba1a55622db72f113eb494a889656962d098c70c5bb1@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200319 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r98c9b6e4c9e17792e2cd1ec3e4aa20b61a791939046d3f10888176bb@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rb6fecb5e96a6d61e175ff49f33f2713798dd05cf03067c169d195596@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200319 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rd5a4457be4623038c3989294429bc063eec433a2e55995d81591e2ca@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200307 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rdd49ab9565bec436a896bc00c4b9fc9dce1598e106c318524fbdfec6@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200305 [SECURITY] [DLA 2135-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00008.html"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-14439",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 5.0
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/ad418eeb974e357f2797aef64aa0e3ffaaa6125b",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/ad418eeb974e357f2797aef64aa0e3ffaaa6125b"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2",
+                "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2389",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2389"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190812 [SECURITY] [DLA 1879-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/08/msg00011.html"
+              }, {
+                "description" : "FEDORA-2019-ae6a703b8f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+              }, {
+                "description" : "FEDORA-2019-fb23eccc03",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+              }, {
+                "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190814-0001/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190814-0001/"
+              }, {
+                "description" : "DSA-4542",
+                "url" : "https://www.debian.org/security/2019/dsa-4542"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-20330",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.10.1...jackson-databind-2.9.10.2",
+                "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.10.1...jackson-databind-2.9.10.2"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2526",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2526"
+              }, {
+                "description" : "[zookeeper-dev] 20200118 Build failed in Jenkins: zookeeper-master-maven-owasp #329",
+                "url" : "https://lists.apache.org/thread.html/r107c8737db39ec9ec4f4e7147b249e29be79170b9ef4b80528105a2d@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200123 [GitHub] [zookeeper] nkalmar commented on issue #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r2c77dd6ab8344285bd8e481b57cf3029965a4b0036eefccef74cdd44@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200123 [jira] [Updated] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r3f8180d0d25a7c6473ebb9714b0c1d19a73f455ae70d0c5fefc17e6c@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200122 [jira] [Updated] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r428735963bee7cb99877b88d3228e28ec28af64646455c4f3e7a3c94@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200122 [jira] [Commented] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r50f513772f12e1babf65c7c2b9c16425bac2d945351879e2e267517f@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200118 [jira] [Created] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r5c14fdcabdeaba258857bcb67198652e4dce1d33ddc590cd81d82393@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [GitHub] [druid] ccaominh opened a new pull request #9191: [Backport] Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189)",
+                "url" : "https://lists.apache.org/thread.html/r5c3644c97f0434d1ceb48ff48897a67bdbf3baf7efbe7d04625425b3@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200118 [jira] [Commented] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r5d3d10fdf28110da3f9ac1b7d08d7e252f98d7d37ce0a6bd139a2e4f@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200123 [zookeeper] branch branch-3.5 updated: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r67f4d4c48197454b83d62afbed8bebbda3764e6e3a6e26a848961764@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200123 [jira] [Resolved] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r707d23bb9ee245f50aa909add0da6e8d8f24719b1278ddd99d2428b2@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200123 [zookeeper] branch branch-3.6 updated: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r7a0821b44247a1e6c6fe5f2943b90ebc4f80a8d1fb0aa9a8b29a59a2@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [GitHub] [druid] clintropolis merged pull request #9191: [Backport] Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189)",
+                "url" : "https://lists.apache.org/thread.html/r7fb123e7dad49af5886cfec7135c0fd5b74e4c67af029e1dc91ba744@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200123 [zookeeper] branch master updated: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r8831b7fa5ca87a1cf23ee08d6dedb7877a964c1d2bd869af24056a63@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200118 [jira] [Created] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r909c822409a276ba04dc2ae31179b16f6864ba02c4f9911bdffebf95@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200122 [GitHub] [zookeeper] phunt commented on issue #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/ra2e572f568de8df5ba151e6aebb225a0629faaf0476bf7c7ed877af8@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200122 [GitHub] [zookeeper] phunt opened a new pull request #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/ra5ce96faec37c26b0aa15b4b6a8b1cbb145a748653e56ae83e9685d0@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200122 Re: 3.5.7",
+                "url" : "https://lists.apache.org/thread.html/ra8a80dbc7319916946397823aec0d893d24713cbf7b5aee0e957298c@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [GitHub] [druid] clintropolis merged pull request #9189: Suppress CVE-2019-20330 for htrace-core-4.0.1",
+                "url" : "https://lists.apache.org/thread.html/rb532fed78d031fff477fd840b81946f6d1200f93a63698dae65aa528@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200123 [jira] [Commented] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/rd1f346227e11fc515914f3a7b20d81543e51e5822ba71baa0452634a@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200123 [GitHub] [zookeeper] asfgit closed pull request #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/rd49cfa41bbb71ef33b53736a6af2aa8ba88c2106e30f2a34902a87d2@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200114 [GitHub] [druid] ccaominh opened a new pull request #9189: Suppress CVE-2019-20330 for htrace-core-4.0.1",
+                "url" : "https://lists.apache.org/thread.html/rd6c6fef14944f3dcfb58d35f9317eb1c32a700e86c1b5231e45d3d0b@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200122 [jira] [Assigned] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/rfa57d9c2a27d3af14c69607fb1a3da00e758b2092aa88eb6a51b6e99@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200220 [SECURITY] [DLA 2111-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00020.html"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20200127-0004/",
+                "url" : "https://security.netapp.com/advisory/ntap-20200127-0004/"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-12814",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 4.3
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:2935",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+              }, {
+                "description" : "RHSA-2019:2936",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+              }, {
+                "description" : "RHSA-2019:2937",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+              }, {
+                "description" : "RHSA-2019:2938",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+              }, {
+                "description" : "RHSA-2019:3044",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3044"
+              }, {
+                "description" : "RHSA-2019:3045",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3045"
+              }, {
+                "description" : "RHSA-2019:3046",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3046"
+              }, {
+                "description" : "RHSA-2019:3050",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3050"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "RHSA-2019:3292",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3292"
+              }, {
+                "description" : "RHSA-2019:3297",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3297"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2341",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2341"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20190623 [jira] [Created] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/129da0204c876f746636018751a086cc581e0e07bcdeb3ee22ff5731@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190623 [jira] [Created] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/15a55e1d837fa686db493137cc0330c7ee1089ed9a9eea7ae7151ef1@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190623 [GitHub] [zookeeper] eolivelli opened a new pull request #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/1e04d9381c801b31ab28dec813c31c304b2a596b2a3707fa5462c5c0@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190712 [jira] [Resolved] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/28be28ffd6471d230943a255c36fe196a54ef5afc494a4781d16e37c@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190712 [jira] [Commented] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/2ff264b6a94c5363a35c4c88fa93216f60ec54d1d973ed6b76a9f560@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190624 [GitHub] [zookeeper] eolivelli closed pull request #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/4b832d1327703d6b287a6d223307f8f884d798821209a10647e93324@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190712 [jira] [Assigned] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/71f9ffd92410a889e27b95a219eaa843fd820f8550898633d85d4ea3@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190624 [GitHub] [zookeeper] eolivelli commented on issue #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/8fe2983f6d9fee0aa737e4bd24483f8f5cf9b938b9adad0c4e79b2a4@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190708 [jira] [Commented] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/a3ae8a8c5e32c413cd27071d3a204166050bf79ce7f1299f6866338f@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190624 [GitHub] [zookeeper] phunt commented on a change in pull request #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/a62aa2706105d68f1c02023fe24aaa3c13b4d8a1826181fed07d9682@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190623 [jira] [Updated] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/a78239b1f11cddfa86e4edee19064c40b6272214630bfef070c37957@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190713 [jira] [Updated] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/b0a2b2cca072650dbd5882719976c3d353972c44f6736ddf0ba95209@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190710 [GitHub] [zookeeper] phunt closed pull request #1013: ZOOKEEPER-3441: OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/b148fa2e9ef468c4de00de255dd728b74e2a97d935f8ced31eb41ba2@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[accumulo-commits] 20190723 [accumulo] branch 2.0 updated: Fix CVE-2019-12814 Use jackson-databind 2.9.9.1",
+                "url" : "https://lists.apache.org/thread.html/bf20574dbc2db255f1fd489942b5720f675e32a2c4f44eb6a36060cd@%3Ccommits.accumulo.apache.org%3E"
+              }, {
+                "description" : "[geode-notifications] 20191007 [GitHub] [geode] jmelchio commented on issue #4102: Fix for GEODE-7255: Pickup Jackson CVE fix",
+                "url" : "https://lists.apache.org/thread.html/e0733058c0366b703e6757d8d2a7a04b943581f659e9c271f0841dfe@%3Cnotifications.geode.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190710 [GitHub] [zookeeper] phunt opened a new pull request #1013: ZOOKEEPER-3441: OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/eff7280055fc717ea8129cd28a9dd57b8446d00b36260c1caee10b87@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190621 [SECURITY] [DLA 1831-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/06/msg00019.html"
+              }, {
+                "description" : "FEDORA-2019-ae6a703b8f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+              }, {
+                "description" : "FEDORA-2019-fb23eccc03",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+              }, {
+                "description" : "FEDORA-2019-99ff6aa32c",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190625-0006/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190625-0006/"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-11307",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "https://access.redhat.com/errata/RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2032",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2032"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-issues] 20191004 [GitHub] [lucene-solr] marungo opened a new pull request #925: SOLR-13818: Upgrade jackson to 2.10.0",
+                "url" : "https://lists.apache.org/thread.html/7fcf88aff0d1deaa5c3c7be8d58c05ad7ad5da94b59065d8e7c50c5d@%3Cissues.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              }, {
+                "description" : "https://nvd.nist.gov/vuln/detail/CVE-2017-7525",
+                "url" : "https://nvd.nist.gov/vuln/detail/CVE-2017-7525"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-14719",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-14718",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "106601",
+                "url" : "http://www.securityfocus.com/bid/106601"
+              }, {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Assigned] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                "url" : "https://lists.apache.org/thread.html/6a78f88716c3c57aa74ec05764a37ab3874769a347805903b393b286@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                "url" : "https://lists.apache.org/thread.html/82b01bfb6787097427ce97cec6a7127e93718bc05d1efd5eaffc228f@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                "url" : "https://lists.apache.org/thread.html/ba973114605d936be276ee6ce09dfbdbf78aa56f6cdc6e79bfa7b8df@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2020-10672",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 6.8
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2659",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2659"
+              }, {
+                "description" : "[debian-lts-announce] 20200322 [SECURITY] [DLA 2153-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00027.html"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2020-10673",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 6.8
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2660",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2660"
+              }, {
+                "description" : "[debian-lts-announce] 20200322 [SECURITY] [DLA 2153-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00027.html"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-7489",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html"
+              }, {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html"
+              }, {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+              }, {
+                "description" : "103203",
+                "url" : "http://www.securityfocus.com/bid/103203"
+              }, {
+                "description" : "1040693",
+                "url" : "http://www.securitytracker.com/id/1040693"
+              }, {
+                "description" : "1041890",
+                "url" : "http://www.securitytracker.com/id/1041890"
+              }, {
+                "description" : "RHSA-2018:1447",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1447"
+              }, {
+                "description" : "RHSA-2018:1448",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1448"
+              }, {
+                "description" : "RHSA-2018:1449",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+              }, {
+                "description" : "RHSA-2018:1450",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+              }, {
+                "description" : "RHSA-2018:1451",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1451"
+              }, {
+                "description" : "RHSA-2018:1786",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1786"
+              }, {
+                "description" : "RHSA-2018:2088",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2088"
+              }, {
+                "description" : "RHSA-2018:2089",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2089"
+              }, {
+                "description" : "RHSA-2018:2090",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2090"
+              }, {
+                "description" : "RHSA-2018:2938",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2938"
+              }, {
+                "description" : "RHSA-2018:2939",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2939"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1931",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1931"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20180328-0001/",
+                "url" : "https://security.netapp.com/advisory/ntap-20180328-0001/"
+              }, {
+                "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+              }, {
+                "description" : "DSA-4190",
+                "url" : "https://www.debian.org/security/2018/dsa-4190"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-5968",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 5.1
+              },
+              "references" : [ {
+                "description" : "RHSA-2018:0478",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0478"
+              }, {
+                "description" : "RHSA-2018:0479",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0479"
+              }, {
+                "description" : "RHSA-2018:0480",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0480"
+              }, {
+                "description" : "RHSA-2018:0481",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0481"
+              }, {
+                "description" : "RHSA-2018:1525",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1525"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1899",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1899"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20180423-0002/",
+                "url" : "https://security.netapp.com/advisory/ntap-20180423-0002/"
+              }, {
+                "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+              }, {
+                "description" : "DSA-4114",
+                "url" : "https://www.debian.org/security/2018/dsa-4114"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-1000873",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 4.3
+              },
+              "references" : [ {
+                "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1665601",
+                "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1665601"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-modules-java8/issues/90",
+                "url" : "https://github.com/FasterXML/jackson-modules-java8/issues/90"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-modules-java8/pull/87",
+                "url" : "https://github.com/FasterXML/jackson-modules-java8/pull/87"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            } ]
+          },
+          "feature" : {
+            "type" : "VulnerabilitiesInProject",
+            "name" : "Info about vulnerabilities in open-source project"
+          }
+        } ],
+        "explanation" : [ "No unpatched vulnerabilities found which is good" ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "ProjectActivityScore",
+          "name" : "Open-source project activity score"
+        },
+        "value" : 9.841460358665667,
+        "weight" : 0.6300785405632551,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "ExpiringValue",
+          "value" : {
+            "type" : "IntegerValue",
+            "feature" : {
+              "type" : "PositiveIntegerFeature",
+              "name" : "Number of commits in the last three months"
+            },
+            "number" : 270
+          },
+          "expiration" : 1585306315391
+        }, {
+          "type" : "ExpiringValue",
+          "value" : {
+            "type" : "IntegerValue",
+            "feature" : {
+              "type" : "PositiveIntegerFeature",
+              "name" : "Number of contributors in the last three months"
+            },
+            "number" : 11
+          },
+          "expiration" : 1585306320816
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "CommunityCommitmentScore",
+          "name" : "How well open-source community commits to support an open-source project"
+        },
+        "value" : 0.0,
+        "weight" : 0.5529742430404292,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project is supported by a company"
+          },
+          "flag" : false
+        }, {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project belongs to Apache Foundation"
+          },
+          "flag" : false
+        }, {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project belongs to Eclipse Foundation"
+          },
+          "flag" : false
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "ProjectSecurityAwarenessScore",
+          "name" : "How well open-source community is aware about security"
+        },
+        "value" : 3.0,
+        "weight" : 0.5383270608555468,
+        "confidence" : 6.666666666666667,
+        "usedValues" : [ {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project has a security policy"
+          },
+          "flag" : true
+        }, {
+          "type" : "UnknownValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project has a security team"
+          }
+        }, {
+          "type" : "ExpiringValue",
+          "value" : {
+            "type" : "BooleanValue",
+            "feature" : {
+              "type" : "BooleanFeature",
+              "name" : "If a project uses verified signed commits"
+            },
+            "flag" : false
+          },
+          "expiration" : 1585306340828
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "VulnerabilityLifetimeScore",
+          "name" : "How fast vulnerabilities are patched"
+        },
+        "value" : 0.0,
+        "weight" : 0.22939855566110368,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "VulnerabilitiesValue",
+          "vulnerabilities" : {
+            "entries" : [ {
+              "id" : "CVE-2019-12384",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 4.3
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:1820",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1820"
+              }, {
+                "description" : "RHSA-2019:2720",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2720"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:2935",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+              }, {
+                "description" : "RHSA-2019:2936",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+              }, {
+                "description" : "RHSA-2019:2937",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+              }, {
+                "description" : "RHSA-2019:2938",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+              }, {
+                "description" : "RHSA-2019:2998",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2998"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "RHSA-2019:3292",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3292"
+              }, {
+                "description" : "RHSA-2019:3297",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3297"
+              }, {
+                "description" : "RHSA-2019:3901",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+              }, {
+                "description" : "RHSA-2019:4352",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4352"
+              }, {
+                "description" : "https://blog.doyensec.com/2019/07/22/jackson-gadgets.html",
+                "url" : "https://blog.doyensec.com/2019/07/22/jackson-gadgets.html"
+              }, {
+                "description" : "https://doyensec.com/research.html",
+                "url" : "https://doyensec.com/research.html"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/compare/74b90a4...a977aad",
+                "url" : "https://github.com/FasterXML/jackson-databind/compare/74b90a4...a977aad"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[geode-notifications] 20191007 [GitHub] [geode] jmelchio commented on issue #4102: Fix for GEODE-7255: Pickup Jackson CVE fix",
+                "url" : "https://lists.apache.org/thread.html/e0733058c0366b703e6757d8d2a7a04b943581f659e9c271f0841dfe@%3Cnotifications.geode.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "https://lists.debian.org/debian-lts-announce/2019/06/msg00019.html",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/06/msg00019.html"
+              }, {
+                "description" : "FEDORA-2019-ae6a703b8f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+              }, {
+                "description" : "FEDORA-2019-fb23eccc03",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+              }, {
+                "description" : "FEDORA-2019-99ff6aa32c",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+              }, {
+                "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190703-0002/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190703-0002/"
+              }, {
+                "description" : "DSA-4542",
+                "url" : "https://www.debian.org/security/2019/dsa-4542"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-14540",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "RHSA-2020:0159",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+              }, {
+                "description" : "RHSA-2020:0160",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+              }, {
+                "description" : "RHSA-2020:0161",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+              }, {
+                "description" : "RHSA-2020:0164",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+              }, {
+                "description" : "RHSA-2020:0445",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/blob/master/release-notes/VERSION-2.x",
+                "url" : "https://github.com/FasterXML/jackson-databind/blob/master/release-notes/VERSION-2.x"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2410",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2410"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2449",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2449"
+              }, {
+                "description" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch opened a new pull request #1200: Upgrade jackson due to CVE issues",
+                "url" : "https://lists.apache.org/thread.html/0fcef7321095ce0bc597d468d150cff3d647f4cb3aef3bd4d20e1c69@%3Ccommits.tinkerpop.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190925 [GitHub] [hbase] SteNicholas opened a new pull request #660: HBASE-23075 Upgrade jackson version",
+                "url" : "https://lists.apache.org/thread.html/40c00861b53bb611dee7d6f35f864aa7d1c1bd77df28db597cbf27e1@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190926 [GitHub] [hbase-connectors] SteNicholas opened a new pull request #45: HBASE-23075 Upgrade jackson version",
+                "url" : "https://lists.apache.org/thread.html/a360b46061c91c5cad789b6c3190aef9b9f223a2b75c9c9f046fe016@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190925 [GitHub] [zookeeper] maoling commented on issue #1097: ZOOKEEPER-3559 - Update Jackson to 2.9.10",
+                "url" : "https://lists.apache.org/thread.html/a4f2c9fb36642a48912cdec6836ec00e497427717c5d377f8d7ccce6@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190926 [jira] [Commented] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                "url" : "https://lists.apache.org/thread.html/ad0d238e97a7da5eca47a014f0f7e81f440ed6bf74a93183825e18b9@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190926 [jira] [Updated] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                "url" : "https://lists.apache.org/thread.html/dc6b5cad721a4f6b3b62ed1163894941140d9d5656140fb757505ca0@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[hbase-commits] 20190927 [hbase-connectors] 02/02: HBASE-23075 Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                "url" : "https://lists.apache.org/thread.html/e90c3feb21702e68a8c08afce37045adb3870f2bf8223fa403fb93fb@%3Ccommits.hbase.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+              }, {
+                "description" : "FEDORA-2019-cf87377f5f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+              }, {
+                "description" : "FEDORA-2019-b171554877",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+              }, {
+                "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20191004-0002/",
+                "url" : "https://security.netapp.com/advisory/ntap-20191004-0002/"
+              }, {
+                "description" : "DSA-4542",
+                "url" : "https://www.debian.org/security/2019/dsa-4542"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-16942",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:3901",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+              }, {
+                "description" : "RHSA-2020:0159",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+              }, {
+                "description" : "RHSA-2020:0160",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+              }, {
+                "description" : "RHSA-2020:0161",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+              }, {
+                "description" : "RHSA-2020:0164",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+              }, {
+                "description" : "RHSA-2020:0445",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2478",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2478"
+              }, {
+                "description" : "https://issues.apache.org/jira/browse/GEODE-7255",
+                "url" : "https://issues.apache.org/jira/browse/GEODE-7255"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[geode-issues] 20191011 [jira] [Commented] (GEODE-7255) Need to pick up CVE-2019-16942",
+                "url" : "https://lists.apache.org/thread.html/7782a937c9259a58337ee36b2961f00e2d744feafc13084e176d0df5@%3Cissues.geode.apache.org%3E"
+              }, {
+                "description" : "[geode-issues] 20191230 [jira] [Closed] (GEODE-7255) Need to pick up CVE-2019-16942",
+                "url" : "https://lists.apache.org/thread.html/a430dbc9be874c41314cc69e697384567a9a24025e819d9485547954@%3Cissues.geode.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[geode-issues] 20191008 [jira] [Commented] (GEODE-7255) Need to pick up CVE-2019-16942",
+                "url" : "https://lists.apache.org/thread.html/b2e23c94f9dfef53e04c492e5d02e5c75201734be7adc73a49ef2370@%3Cissues.geode.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+              }, {
+                "description" : "FEDORA-2019-cf87377f5f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+              }, {
+                "description" : "FEDORA-2019-b171554877",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              }, {
+                "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20191017-0006/",
+                "url" : "https://security.netapp.com/advisory/ntap-20191017-0006/"
+              }, {
+                "description" : "DSA-4542",
+                "url" : "https://www.debian.org/security/2019/dsa-4542"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2020-8840",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2620",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2620"
+              }, {
+                "description" : "[druid-commits] 20200219 [GitHub] [druid] ccaominh opened a new pull request #9379: Suppress CVE-2020-8840 for htrace-core-4.0.1",
+                "url" : "https://lists.apache.org/thread.html/r078e68a926ea6be12e8404e47f45aabf04bb4668e8265c0de41db6db@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20200313 Re: CVE-2020-8840 on TomEE 8.0.1",
+                "url" : "https://lists.apache.org/thread.html/r1c09b9551f6953dbeca190a4c4b78198cdbb9825fce36f96fe3d8218@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200219 [GitHub] [druid] suneet-s commented on issue #9379: Suppress CVE-2020-8840 for htrace-core-4.0.1",
+                "url" : "https://lists.apache.org/thread.html/r319f19c74e06c201b9d4e8b282a4e4b2da6dcda022fb46f007dd00d3@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200223 [GitHub] [zookeeper] eolivelli opened a new pull request #1262: ZOOKEEPER-3734 upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r3539bd3a377991217d724879d239e16e86001c54160076408574e1da@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200221 [GitHub] [druid] ccaominh merged pull request #9379: Suppress CVE-2020-8840 for htrace-core-4.0.1",
+                "url" : "https://lists.apache.org/thread.html/r3d20a2660b36551fd8257d479941782af4a7169582449fac1704bde2@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200223 [GitHub] [zookeeper] phunt commented on issue #1262: ZOOKEEPER-3734 upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r428d068b2a4923f1a5a4f5fc6381b95205cfe7620169d16db78e9c71@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200223 [zookeeper] branch master updated: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r46bebdeb59b8b7212d63a010ca445a9f5c4e9d64dcf693cab6f399d3@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200225 [jira] [Updated] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r65ee95fa09c831843bac81eaa582fdddc2b6119912a72d1c83a9b882@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200223 [jira] [Updated] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r6fdd4c61a09a0c89f581b4ddb3dc6f154ab0c705fcfd0a7358b2e4e5@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200223 [jira] [Resolved] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r8170007fd9b263d65b37d92a7b5d7bc357aedbb113a32838bc4a9485@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200222 [jira] [Created] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/r9ecf211c22760b00967ebe158c6ed7dba9142078e2a630ab8904a5b7@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200223 [GitHub] [zookeeper] asfgit closed pull request #1262: ZOOKEEPER-3734 upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/rac5ee5d686818be7e7c430d35108ee01a88aae54f832d32f62431fd1@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200222 [jira] [Created] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/rb43f9a65150948a6bebd3cb77ee3e105d40db2820fd547528f4e7f89@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200224 [zookeeper] 01/02: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/rb5eedf90ba3633e171a2ffdfe484651c9490dc5df74c8a29244cbc0e@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20200311 CVE-2020-8840 on TomEE 8.0.1",
+                "url" : "https://lists.apache.org/thread.html/rb99c7321eba5d4c907beec46675d52827528b738cfafd48eb4d862f1@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20200316 RE: CVE-2020-8840 on TomEE 8.0.1",
+                "url" : "https://lists.apache.org/thread.html/rc068e824654c4b8bd4f2490bec869e29edbfcd5dfe02d47cbf7433b2@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20200311 Re: CVE-2020-8840 on TomEE 8.0.1",
+                "url" : "https://lists.apache.org/thread.html/rdea588d4a0ebf9cb7ce8c3a8f18d0d306507c4f8ba178dd3d20207b8@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200223 [zookeeper] branch branch-3.6 updated: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/rdf8d389271a291dde3b2f99c36918d6cb1e796958af626cc140fee23@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200223 [jira] [Assigned] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/re7326b8655eab931f2a9ce074fd9a1a51b5db11456bee9b48e1e170c@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200223 [zookeeper] branch branch-3.5 updated: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                "url" : "https://lists.apache.org/thread.html/re8ae2670ec456ef1c5a2a661a2838ab2cd00e9efa1e88c069f546f21@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200220 [SECURITY] [DLA 2111-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00020.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-12086",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 5.0
+              },
+              "references" : [ {
+                "description" : "http://russiansecurity.expert/2016/04/20/mysql-connect-file-read/",
+                "url" : "http://russiansecurity.expert/2016/04/20/mysql-connect-file-read/"
+              }, {
+                "description" : "109227",
+                "url" : "http://www.securityfocus.com/bid/109227"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:2935",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+              }, {
+                "description" : "RHSA-2019:2936",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+              }, {
+                "description" : "RHSA-2019:2937",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+              }, {
+                "description" : "RHSA-2019:2938",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+              }, {
+                "description" : "RHSA-2019:2998",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2998"
+              }, {
+                "description" : "RHSA-2019:3044",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3044"
+              }, {
+                "description" : "RHSA-2019:3045",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3045"
+              }, {
+                "description" : "RHSA-2019:3046",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3046"
+              }, {
+                "description" : "RHSA-2019:3050",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3050"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2326",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2326"
+              }, {
+                "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[spark-reviews] 20190520 [GitHub] [spark] Fokko opened a new pull request #24646: Spark 27757",
+                "url" : "https://lists.apache.org/thread.html/88cd25375805950ae7337e669b0cb0eeda98b9604c1b8d806dccbad2@%3Creviews.spark.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-solr-user] 20200320 CVEs (vulnerabilities) that apply to Solr 8.4.1",
+                "url" : "https://lists.apache.org/thread.html/r204ba2a9ea750f38d789d2bb429cc0925ad6133deea7cbc3001d96b5@%3Csolr-user.lucene.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190521 [SECURITY] [DLA 1798-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/05/msg00030.html"
+              }, {
+                "description" : "FEDORA-2019-ae6a703b8f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+              }, {
+                "description" : "FEDORA-2019-fb23eccc03",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+              }, {
+                "description" : "FEDORA-2019-99ff6aa32c",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-16943",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2020:0159",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+              }, {
+                "description" : "RHSA-2020:0160",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+              }, {
+                "description" : "RHSA-2020:0161",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+              }, {
+                "description" : "RHSA-2020:0164",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+              }, {
+                "description" : "RHSA-2020:0445",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2478",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2478"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[iceberg-commits] 20191028 [incubator-iceberg] branch master updated: Update Jackson to 2.10.0 for CVE-2019-16943 (#583)",
+                "url" : "https://lists.apache.org/thread.html/5ec8d8d485c2c8ac55ea425f4cd96596ef37312532712639712ebcdd@%3Ccommits.iceberg.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191027 [GitHub] [incubator-iceberg] rdsr commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/6788e4c991f75b89d290ad06b463fcd30bcae99fee610345a35b7bc6@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+              }, {
+                "description" : "FEDORA-2019-cf87377f5f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+              }, {
+                "description" : "FEDORA-2019-b171554877",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              }, {
+                "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20191017-0006/",
+                "url" : "https://security.netapp.com/advisory/ntap-20191017-0006/"
+              }, {
+                "description" : "DSA-4542",
+                "url" : "https://www.debian.org/security/2019/dsa-4542"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-17531",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:4192",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4192"
+              }, {
+                "description" : "RHSA-2020:0159",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+              }, {
+                "description" : "RHSA-2020:0160",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+              }, {
+                "description" : "RHSA-2020:0161",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+              }, {
+                "description" : "RHSA-2020:0164",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+              }, {
+                "description" : "RHSA-2020:0445",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2498",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2498"
+              }, {
+                "description" : "[pulsar-commits] 20191127 [GitHub] [pulsar] massakam opened a new pull request #5758: Bump jackson libraries to 2.10.1",
+                "url" : "https://lists.apache.org/thread.html/b3c90d38f99db546de60fea65f99a924d540fae2285f014b79606ca5@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20191210 [SECURITY] [DLA 2030-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/12/msg00013.html"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20191024-0005/",
+                "url" : "https://security.netapp.com/advisory/ntap-20191024-0005/"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-19362",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "107985",
+                "url" : "http://www.securityfocus.com/bid/107985"
+              }, {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2186",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2186"
+              }, {
+                "description" : "https://issues.apache.org/jira/browse/TINKERPOP-2121",
+                "url" : "https://issues.apache.org/jira/browse/TINKERPOP-2121"
+              }, {
+                "description" : "[infra-devnull] 20190329 [GitHub] [pulsar] massakam opened pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/37e1ed724a1b0e5d191d98c822c426670bdfde83804567131847d2a3@%3Cdevnull.infra.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190329 [GitHub] [pulsar] massakam opened a new pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/c70da3cb6e3f03e0ad8013e38b6959419d866c4a7c80fdd34b73f25c@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-19361",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "107985",
+                "url" : "http://www.securityfocus.com/bid/107985"
+              }, {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2186",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2186"
+              }, {
+                "description" : "https://issues.apache.org/jira/browse/TINKERPOP-2121",
+                "url" : "https://issues.apache.org/jira/browse/TINKERPOP-2121"
+              }, {
+                "description" : "[infra-devnull] 20190329 [GitHub] [pulsar] massakam opened pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/37e1ed724a1b0e5d191d98c822c426670bdfde83804567131847d2a3@%3Cdevnull.infra.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190329 [GitHub] [pulsar] massakam opened a new pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/c70da3cb6e3f03e0ad8013e38b6959419d866c4a7c80fdd34b73f25c@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-19360",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "107985",
+                "url" : "http://www.securityfocus.com/bid/107985"
+              }, {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2186",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2186"
+              }, {
+                "description" : "https://issues.apache.org/jira/browse/TINKERPOP-2121",
+                "url" : "https://issues.apache.org/jira/browse/TINKERPOP-2121"
+              }, {
+                "description" : "[infra-devnull] 20190329 [GitHub] [pulsar] massakam opened pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/37e1ed724a1b0e5d191d98c822c426670bdfde83804567131847d2a3@%3Cdevnull.infra.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190329 [GitHub] [pulsar] massakam opened a new pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/c70da3cb6e3f03e0ad8013e38b6959419d866c4a7c80fdd34b73f25c@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2017-15095",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html"
+              }, {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html"
+              }, {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+              }, {
+                "description" : "103880",
+                "url" : "http://www.securityfocus.com/bid/103880"
+              }, {
+                "description" : "1039769",
+                "url" : "http://www.securitytracker.com/id/1039769"
+              }, {
+                "description" : "RHSA-2017:3189",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3189"
+              }, {
+                "description" : "RHSA-2017:3190",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3190"
+              }, {
+                "description" : "RHSA-2018:0342",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0342"
+              }, {
+                "description" : "RHSA-2018:0478",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0478"
+              }, {
+                "description" : "RHSA-2018:0479",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0479"
+              }, {
+                "description" : "RHSA-2018:0480",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0480"
+              }, {
+                "description" : "RHSA-2018:0481",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0481"
+              }, {
+                "description" : "RHSA-2018:0576",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0576"
+              }, {
+                "description" : "RHSA-2018:0577",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0577"
+              }, {
+                "description" : "RHSA-2018:1447",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1447"
+              }, {
+                "description" : "RHSA-2018:1448",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1448"
+              }, {
+                "description" : "RHSA-2018:1449",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+              }, {
+                "description" : "RHSA-2018:1450",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+              }, {
+                "description" : "RHSA-2018:1451",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1451"
+              }, {
+                "description" : "RHSA-2018:2927",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2927"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1680",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1680"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1737",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1737"
+              }, {
+                "description" : "[lucene-solr-user] 20191219 Re: CVE-2017-7525 fix for Solr 7.7.x",
+                "url" : "https://lists.apache.org/thread.html/f095a791bda6c0595f691eddd0febb2d396987eec5cbd29120d8c629@%3Csolr-user.lucene.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200131 [SECURITY] [DLA 2091-1] libjackson-json-java security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/01/msg00037.html"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20171214-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20171214-0003/"
+              }, {
+                "description" : "DSA-4037",
+                "url" : "https://www.debian.org/security/2017/dsa-4037"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2017-7525",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html"
+              }, {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html"
+              }, {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+              }, {
+                "description" : "99623",
+                "url" : "http://www.securityfocus.com/bid/99623"
+              }, {
+                "description" : "1039744",
+                "url" : "http://www.securitytracker.com/id/1039744"
+              }, {
+                "description" : "1039947",
+                "url" : "http://www.securitytracker.com/id/1039947"
+              }, {
+                "description" : "1040360",
+                "url" : "http://www.securitytracker.com/id/1040360"
+              }, {
+                "description" : "RHSA-2017:1834",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:1834"
+              }, {
+                "description" : "RHSA-2017:1835",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:1835"
+              }, {
+                "description" : "RHSA-2017:1836",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:1836"
+              }, {
+                "description" : "RHSA-2017:1837",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:1837"
+              }, {
+                "description" : "RHSA-2017:1839",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:1839"
+              }, {
+                "description" : "RHSA-2017:1840",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:1840"
+              }, {
+                "description" : "RHSA-2017:2477",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2477"
+              }, {
+                "description" : "RHSA-2017:2546",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2546"
+              }, {
+                "description" : "RHSA-2017:2547",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2547"
+              }, {
+                "description" : "RHSA-2017:2633",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2633"
+              }, {
+                "description" : "RHSA-2017:2635",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2635"
+              }, {
+                "description" : "RHSA-2017:2636",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2636"
+              }, {
+                "description" : "RHSA-2017:2637",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2637"
+              }, {
+                "description" : "RHSA-2017:2638",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:2638"
+              }, {
+                "description" : "RHSA-2017:3141",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3141"
+              }, {
+                "description" : "RHSA-2017:3454",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3454"
+              }, {
+                "description" : "RHSA-2017:3455",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3455"
+              }, {
+                "description" : "RHSA-2017:3456",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3456"
+              }, {
+                "description" : "RHSA-2017:3458",
+                "url" : "https://access.redhat.com/errata/RHSA-2017:3458"
+              }, {
+                "description" : "RHSA-2018:0294",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0294"
+              }, {
+                "description" : "RHSA-2018:0342",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0342"
+              }, {
+                "description" : "RHSA-2018:1449",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+              }, {
+                "description" : "RHSA-2018:1450",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+              }, {
+                "description" : "RHSA-2019:0910",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0910"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1462702",
+                "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1462702"
+              }, {
+                "description" : "https://cwiki.apache.org/confluence/display/WW/S2-055",
+                "url" : "https://cwiki.apache.org/confluence/display/WW/S2-055"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1599",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1599"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1723",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1723"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                "url" : "https://lists.apache.org/thread.html/3c87dc8bca99a2b3b4743713b33d1de05b1d6b761fdf316224e9c81f@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[cassandra-commits] 20191113 [jira] [Created] (CASSANDRA-15416) CVE-2017-7525 ( jackson-databind is vulnerable to Remote Code Execution) on version 3.11.4",
+                "url" : "https://lists.apache.org/thread.html/4641ed8616ccc2c1fbddac2c3dc9900c96387bc226eaf0232d61909b@%3Ccommits.cassandra.apache.org%3E"
+              }, {
+                "description" : "[lucene-solr-user] 20191218 CVE-2017-7525 fix for Solr 7.7.x",
+                "url" : "https://lists.apache.org/thread.html/5008bcbd45ee65ce39e4220b6ac53d28a24d6bc67d5804e9773a7399@%3Csolr-user.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-solr-user] 20190104 Re: SOLR v7 Security Issues Caused Denial of Use - Sonatype Application Composition Report",
+                "url" : "https://lists.apache.org/thread.html/708d94141126eac03011144a971a6411fcac16d9c248d1d535a39451@%3Csolr-user.lucene.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20191115 [GitHub] [incubator-druid] ccaominh opened a new pull request #8878: Address security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/9317fd092b257a0815434b116a8af8daea6e920b6673f4fd5583d5fe@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                "url" : "https://lists.apache.org/thread.html/b1f33fe5ade396bb903fdcabe9f243f7692c7dfce5418d3743c2d346@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Resolved] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                "url" : "https://lists.apache.org/thread.html/c10a2bf0fdc3d25faf17bd191d6ec46b29a353fa9c97bebd7c4e5913@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Assigned] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                "url" : "https://lists.apache.org/thread.html/c2ed4c0126b43e324cf740012a0edd371fd36096fd777be7bfe7a2a6@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-solr-user] 20191218 Re: CVE-2017-7525 fix for Solr 7.7.x",
+                "url" : "https://lists.apache.org/thread.html/c9d5ff20929e8a3c8794facf4c4b326a9c10618812eec356caa20b87@%3Csolr-user.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-solr-user] 20191219 Re: CVE-2017-7525 fix for Solr 7.7.x",
+                "url" : "https://lists.apache.org/thread.html/f095a791bda6c0595f691eddd0febb2d396987eec5cbd29120d8c629@%3Csolr-user.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Closed] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                "url" : "https://lists.apache.org/thread.html/f60afd3c7e9ebaaf70fad4a4beb75cf8740ac959017a31e7006c7486@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200131 [SECURITY] [DLA 2091-1] libjackson-json-java security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/01/msg00037.html"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20171214-0002/",
+                "url" : "https://security.netapp.com/advisory/ntap-20171214-0002/"
+              }, {
+                "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+              }, {
+                "description" : "DSA-4004",
+                "url" : "https://www.debian.org/security/2017/dsa-4004"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-14720",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:1106",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+              }, {
+                "description" : "RHSA-2019:1107",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+              }, {
+                "description" : "RHSA-2019:1108",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+              }, {
+                "description" : "RHSA-2019:1140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Assigned] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                "url" : "https://lists.apache.org/thread.html/6a78f88716c3c57aa74ec05764a37ab3874769a347805903b393b286@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                "url" : "https://lists.apache.org/thread.html/82b01bfb6787097427ce97cec6a7127e93718bc05d1efd5eaffc228f@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                "url" : "https://lists.apache.org/thread.html/ba973114605d936be276ee6ce09dfbdbf78aa56f6cdc6e79bfa7b8df@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-14721",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:1106",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+              }, {
+                "description" : "RHSA-2019:1107",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+              }, {
+                "description" : "RHSA-2019:1108",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+              }, {
+                "description" : "RHSA-2019:1140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-12022",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 5.1
+              },
+              "references" : [ {
+                "description" : "107585",
+                "url" : "http://www.securityfocus.com/bid/107585"
+              }, {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1106",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+              }, {
+                "description" : "RHSA-2019:1107",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+              }, {
+                "description" : "RHSA-2019:1108",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+              }, {
+                "description" : "RHSA-2019:1140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1671098",
+                "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1671098"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2052",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2052"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-issues] 20191004 [GitHub] [lucene-solr] marungo opened a new pull request #925: SOLR-13818: Upgrade jackson to 2.10.0",
+                "url" : "https://lists.apache.org/thread.html/7fcf88aff0d1deaa5c3c7be8d58c05ad7ad5da94b59065d8e7c50c5d@%3Cissues.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf",
+                "url" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-12023",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 5.1
+              },
+              "references" : [ {
+                "description" : "http://www.securityfocus.com/bid/105659",
+                "url" : "http://www.securityfocus.com/bid/105659"
+              }, {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1106",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+              }, {
+                "description" : "RHSA-2019:1107",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+              }, {
+                "description" : "RHSA-2019:1108",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+              }, {
+                "description" : "RHSA-2019:1140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2058",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2058"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-issues] 20191004 [GitHub] [lucene-solr] marungo opened a new pull request #925: SOLR-13818: Upgrade jackson to 2.10.0",
+                "url" : "https://lists.apache.org/thread.html/7fcf88aff0d1deaa5c3c7be8d58c05ad7ad5da94b59065d8e7c50c5d@%3Cissues.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf",
+                "url" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-14893",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2020:0729",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0729"
+              }, {
+                "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14893",
+                "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14893"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2469",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2469"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-16335",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "RHSA-2020:0159",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+              }, {
+                "description" : "RHSA-2020:0160",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+              }, {
+                "description" : "RHSA-2020:0161",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+              }, {
+                "description" : "RHSA-2020:0164",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+              }, {
+                "description" : "RHSA-2020:0445",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+              }, {
+                "description" : "RHSA-2020:0729",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0729"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2449",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2449"
+              }, {
+                "description" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch opened a new pull request #1200: Upgrade jackson due to CVE issues",
+                "url" : "https://lists.apache.org/thread.html/0fcef7321095ce0bc597d468d150cff3d647f4cb3aef3bd4d20e1c69@%3Ccommits.tinkerpop.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190925 [GitHub] [hbase] SteNicholas opened a new pull request #660: HBASE-23075 Upgrade jackson version",
+                "url" : "https://lists.apache.org/thread.html/40c00861b53bb611dee7d6f35f864aa7d1c1bd77df28db597cbf27e1@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190926 [GitHub] [hbase-connectors] SteNicholas opened a new pull request #45: HBASE-23075 Upgrade jackson version",
+                "url" : "https://lists.apache.org/thread.html/a360b46061c91c5cad789b6c3190aef9b9f223a2b75c9c9f046fe016@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190926 [jira] [Commented] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                "url" : "https://lists.apache.org/thread.html/ad0d238e97a7da5eca47a014f0f7e81f440ed6bf74a93183825e18b9@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[hbase-issues] 20190926 [jira] [Updated] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                "url" : "https://lists.apache.org/thread.html/dc6b5cad721a4f6b3b62ed1163894941140d9d5656140fb757505ca0@%3Cissues.hbase.apache.org%3E"
+              }, {
+                "description" : "[hbase-commits] 20190927 [hbase-connectors] 02/02: HBASE-23075 Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                "url" : "https://lists.apache.org/thread.html/e90c3feb21702e68a8c08afce37045adb3870f2bf8223fa403fb93fb@%3Ccommits.hbase.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+              }, {
+                "description" : "FEDORA-2019-cf87377f5f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+              }, {
+                "description" : "FEDORA-2019-b171554877",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+              }, {
+                "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20191004-0002/",
+                "url" : "https://security.netapp.com/advisory/ntap-20191004-0002/"
+              }, {
+                "description" : "DSA-4542",
+                "url" : "https://www.debian.org/security/2019/dsa-4542"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-14892",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2020:0729",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0729"
+              }, {
+                "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14892",
+                "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14892"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2462",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2462"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2020-9546",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 6.8
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2631",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2631"
+              }, {
+                "description" : "[zookeeper-issues] 20200308 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r35d30db00440ef63b791c4b7f7acb036e14d4a23afa2a249cb66c0fd@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r9464a40d25c3ba1a55622db72f113eb494a889656962d098c70c5bb1@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200319 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r98c9b6e4c9e17792e2cd1ec3e4aa20b61a791939046d3f10888176bb@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rb6fecb5e96a6d61e175ff49f33f2713798dd05cf03067c169d195596@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200319 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rd5a4457be4623038c3989294429bc063eec433a2e55995d81591e2ca@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200307 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rdd49ab9565bec436a896bc00c4b9fc9dce1598e106c318524fbdfec6@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200305 [SECURITY] [DLA 2135-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00008.html"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-14379",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHBA-2019:2824",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:2824"
+              }, {
+                "description" : "RHSA-2019:2743",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2743"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:2935",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+              }, {
+                "description" : "RHSA-2019:2936",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+              }, {
+                "description" : "RHSA-2019:2937",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+              }, {
+                "description" : "RHSA-2019:2938",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+              }, {
+                "description" : "RHSA-2019:2998",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2998"
+              }, {
+                "description" : "RHSA-2019:3044",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3044"
+              }, {
+                "description" : "RHSA-2019:3045",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3045"
+              }, {
+                "description" : "RHSA-2019:3046",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3046"
+              }, {
+                "description" : "RHSA-2019:3050",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3050"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "RHSA-2019:3292",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3292"
+              }, {
+                "description" : "RHSA-2019:3297",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3297"
+              }, {
+                "description" : "RHSA-2019:3901",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+              }, {
+                "description" : "RHSA-2020:0727",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0727"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2",
+                "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2387",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2387"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch opened a new pull request #1200: Upgrade jackson due to CVE issues",
+                "url" : "https://lists.apache.org/thread.html/0fcef7321095ce0bc597d468d150cff3d647f4cb3aef3bd4d20e1c69@%3Ccommits.tinkerpop.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/2766188be238a446a250ef76801037d452979152d85bce5e46805815@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190822 [GitHub] [pulsar] massakam opened a new pull request #5011: [security] Upgrade jackson-databind",
+                "url" : "https://lists.apache.org/thread.html/525bcf949a4b0da87a375cbad2680b8beccde749522f24c49befe7fb@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191027 [GitHub] [incubator-iceberg] rdsr commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/6788e4c991f75b89d290ad06b463fcd30bcae99fee610345a35b7bc6@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] mccheah opened a new pull request #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/689c6bcc6c7612eee71e453a115a4c8581e7b718537025d4b265783d@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] mccheah commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/75f482fdc84abe6d0c8f438a76437c335a7bbeb5cddd4d70b4bc0cbf@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue opened a new pull request #533: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/859815b2e9f1575acbb2b260b73861c16ca49bca627fa0c46419051f@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue merged pull request #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/8723b52c2544e6cb804bc8a36622c584acd1bd6c53f2b6034c9fea54@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue closed pull request #533: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/99944f86abefde389da9b4040ea2327c6aa0b53a2ff9352bd4cfec17@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue commented on issue #533: Update Jackson to 2.9.10 for CVE-2019-14379",
+                "url" : "https://lists.apache.org/thread.html/d161ff3d59c5a8213400dd6afb1cce1fac4f687c32d1e0c0bfbfaa2d@%3Cissues.iceberg.apache.org%3E"
+              }, {
+                "description" : "[ambari-commits] 20190813 [ambari] branch branch-2.7 updated: AMBARI-25352 : Upgrade fasterxml jackson dependency due to CVE-2019-14379 (#3066)",
+                "url" : "https://lists.apache.org/thread.html/e25e734c315f70d8876a846926cfe3bfa1a4888044f146e844caf72f@%3Ccommits.ambari.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[ambari-commits] 20190813 [ambari] branch trunk updated: AMBARI-25352 : Upgrade fasterxml jackson dependency due to CVE-2019-14379(trunk) (#3067)",
+                "url" : "https://lists.apache.org/thread.html/f17f63b0f8a57e4a5759e01d25cffc0548f0b61ff5c6bfd704ad2f2a@%3Ccommits.ambari.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190812 [SECURITY] [DLA 1879-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/08/msg00011.html"
+              }, {
+                "description" : "FEDORA-2019-ae6a703b8f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+              }, {
+                "description" : "FEDORA-2019-fb23eccc03",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+              }, {
+                "description" : "FEDORA-2019-99ff6aa32c",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190814-0001/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190814-0001/"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-17267",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "RHSA-2020:0159",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+              }, {
+                "description" : "RHSA-2020:0160",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+              }, {
+                "description" : "RHSA-2020:0161",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+              }, {
+                "description" : "RHSA-2020:0164",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+              }, {
+                "description" : "RHSA-2020:0445",
+                "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.3...jackson-databind-2.9.10",
+                "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.3...jackson-databind-2.9.10"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2460",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2460"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[skywalking-dev] 20200324 [CVE-2019-17267] Upgrade jackson-databind version to 2.9.10",
+                "url" : "https://lists.apache.org/thread.html/r9d727fc681fb3828794acbefcaee31393742b4d73a29461ccd9597a8@%3Cdev.skywalking.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20191210 [SECURITY] [DLA 2030-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/12/msg00013.html"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20191017-0006/",
+                "url" : "https://security.netapp.com/advisory/ntap-20191017-0006/"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2017-17485",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "20180109 CVE-2017-17485: one more way of rce in jackson-databind when defaultTyping+objects are used",
+                "url" : "http://www.securityfocus.com/archive/1/541652/100/0/threaded"
+              }, {
+                "description" : "RHSA-2018:0116",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0116"
+              }, {
+                "description" : "RHSA-2018:0342",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0342"
+              }, {
+                "description" : "RHSA-2018:0478",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0478"
+              }, {
+                "description" : "RHSA-2018:0479",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0479"
+              }, {
+                "description" : "RHSA-2018:0480",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0480"
+              }, {
+                "description" : "RHSA-2018:0481",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0481"
+              }, {
+                "description" : "RHSA-2018:1447",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1447"
+              }, {
+                "description" : "RHSA-2018:1448",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1448"
+              }, {
+                "description" : "RHSA-2018:1449",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+              }, {
+                "description" : "RHSA-2018:1450",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+              }, {
+                "description" : "RHSA-2018:1451",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1451"
+              }, {
+                "description" : "RHSA-2018:2930",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2930"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1855",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1855"
+              }, {
+                "description" : "https://github.com/irsl/jackson-rce-via-spel/",
+                "url" : "https://github.com/irsl/jackson-rce-via-spel/"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20180201-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20180201-0003/"
+              }, {
+                "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+              }, {
+                "description" : "DSA-4114",
+                "url" : "https://www.debian.org/security/2018/dsa-4114"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2020-9547",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 6.8
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2634",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2634"
+              }, {
+                "description" : "[zookeeper-issues] 20200308 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r35d30db00440ef63b791c4b7f7acb036e14d4a23afa2a249cb66c0fd@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/r4accb2e0de9679174efd3d113a059bab71ff3ec53e882790d21c1cc1@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/r4accb2e0de9679174efd3d113a059bab71ff3ec53e882790d21c1cc1@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/r742ef70d126548dcf7de5be5779355c9d76a9aec71d7a9ef02c6398a@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/r742ef70d126548dcf7de5be5779355c9d76a9aec71d7a9ef02c6398a@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r9464a40d25c3ba1a55622db72f113eb494a889656962d098c70c5bb1@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200319 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r98c9b6e4c9e17792e2cd1ec3e4aa20b61a791939046d3f10888176bb@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/ra3e90712f2d59f8cef03fa796f5adf163d32b81fe7b95385f21790e6@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/ra3e90712f2d59f8cef03fa796f5adf163d32b81fe7b95385f21790e6@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rb6fecb5e96a6d61e175ff49f33f2713798dd05cf03067c169d195596@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/rc0d5d0f72da1ed6fc5e438b1ddb3fa090c73006b55f873cf845375ab@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/rc0d5d0f72da1ed6fc5e438b1ddb3fa090c73006b55f873cf845375ab@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200307 Build failed in Jenkins: PreCommit-ZOOKEEPER-github-pr-build-maven #1898",
+                "url" : "https://lists.apache.org/thread.html/rd0e958d6d5c5ee16efed73314cd0e445c8dbb4bdcc80fc9d1d6c11fc@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200319 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rd5a4457be4623038c3989294429bc063eec433a2e55995d81591e2ca@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200307 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rdd49ab9565bec436a896bc00c4b9fc9dce1598e106c318524fbdfec6@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "https://lists.apache.org/thread.html/redbe4f1e21bf080f637cf9fbec47729750a2f443a919765360337428@%3Cnotifications.zookeeper.apache.org%3E",
+                "url" : "https://lists.apache.org/thread.html/redbe4f1e21bf080f637cf9fbec47729750a2f443a919765360337428@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200305 [SECURITY] [DLA 2135-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00008.html"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2020-9548",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 6.8
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2634",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2634"
+              }, {
+                "description" : "[zookeeper-issues] 20200308 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r35d30db00440ef63b791c4b7f7acb036e14d4a23afa2a249cb66c0fd@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r9464a40d25c3ba1a55622db72f113eb494a889656962d098c70c5bb1@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200319 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/r98c9b6e4c9e17792e2cd1ec3e4aa20b61a791939046d3f10888176bb@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rb6fecb5e96a6d61e175ff49f33f2713798dd05cf03067c169d195596@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200319 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rd5a4457be4623038c3989294429bc063eec433a2e55995d81591e2ca@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200307 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                "url" : "https://lists.apache.org/thread.html/rdd49ab9565bec436a896bc00c4b9fc9dce1598e106c318524fbdfec6@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200305 [SECURITY] [DLA 2135-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00008.html"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-14439",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 5.0
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/ad418eeb974e357f2797aef64aa0e3ffaaa6125b",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/ad418eeb974e357f2797aef64aa0e3ffaaa6125b"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2",
+                "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2389",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2389"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190812 [SECURITY] [DLA 1879-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/08/msg00011.html"
+              }, {
+                "description" : "FEDORA-2019-ae6a703b8f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+              }, {
+                "description" : "FEDORA-2019-fb23eccc03",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+              }, {
+                "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190814-0001/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190814-0001/"
+              }, {
+                "description" : "DSA-4542",
+                "url" : "https://www.debian.org/security/2019/dsa-4542"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-20330",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.10.1...jackson-databind-2.9.10.2",
+                "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.10.1...jackson-databind-2.9.10.2"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2526",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2526"
+              }, {
+                "description" : "[zookeeper-dev] 20200118 Build failed in Jenkins: zookeeper-master-maven-owasp #329",
+                "url" : "https://lists.apache.org/thread.html/r107c8737db39ec9ec4f4e7147b249e29be79170b9ef4b80528105a2d@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200123 [GitHub] [zookeeper] nkalmar commented on issue #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r2c77dd6ab8344285bd8e481b57cf3029965a4b0036eefccef74cdd44@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200123 [jira] [Updated] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r3f8180d0d25a7c6473ebb9714b0c1d19a73f455ae70d0c5fefc17e6c@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200122 [jira] [Updated] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r428735963bee7cb99877b88d3228e28ec28af64646455c4f3e7a3c94@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200122 [jira] [Commented] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r50f513772f12e1babf65c7c2b9c16425bac2d945351879e2e267517f@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200118 [jira] [Created] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r5c14fdcabdeaba258857bcb67198652e4dce1d33ddc590cd81d82393@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [GitHub] [druid] ccaominh opened a new pull request #9191: [Backport] Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189)",
+                "url" : "https://lists.apache.org/thread.html/r5c3644c97f0434d1ceb48ff48897a67bdbf3baf7efbe7d04625425b3@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200118 [jira] [Commented] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r5d3d10fdf28110da3f9ac1b7d08d7e252f98d7d37ce0a6bd139a2e4f@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200123 [zookeeper] branch branch-3.5 updated: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r67f4d4c48197454b83d62afbed8bebbda3764e6e3a6e26a848961764@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200123 [jira] [Resolved] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r707d23bb9ee245f50aa909add0da6e8d8f24719b1278ddd99d2428b2@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200123 [zookeeper] branch branch-3.6 updated: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r7a0821b44247a1e6c6fe5f2943b90ebc4f80a8d1fb0aa9a8b29a59a2@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [GitHub] [druid] clintropolis merged pull request #9191: [Backport] Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189)",
+                "url" : "https://lists.apache.org/thread.html/r7fb123e7dad49af5886cfec7135c0fd5b74e4c67af029e1dc91ba744@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-commits] 20200123 [zookeeper] branch master updated: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r8831b7fa5ca87a1cf23ee08d6dedb7877a964c1d2bd869af24056a63@%3Ccommits.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200118 [jira] [Created] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/r909c822409a276ba04dc2ae31179b16f6864ba02c4f9911bdffebf95@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200122 [GitHub] [zookeeper] phunt commented on issue #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/ra2e572f568de8df5ba151e6aebb225a0629faaf0476bf7c7ed877af8@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200122 [GitHub] [zookeeper] phunt opened a new pull request #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/ra5ce96faec37c26b0aa15b4b6a8b1cbb145a748653e56ae83e9685d0@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20200122 Re: 3.5.7",
+                "url" : "https://lists.apache.org/thread.html/ra8a80dbc7319916946397823aec0d893d24713cbf7b5aee0e957298c@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200115 [GitHub] [druid] clintropolis merged pull request #9189: Suppress CVE-2019-20330 for htrace-core-4.0.1",
+                "url" : "https://lists.apache.org/thread.html/rb532fed78d031fff477fd840b81946f6d1200f93a63698dae65aa528@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200123 [jira] [Commented] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/rd1f346227e11fc515914f3a7b20d81543e51e5822ba71baa0452634a@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20200123 [GitHub] [zookeeper] asfgit closed pull request #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/rd49cfa41bbb71ef33b53736a6af2aa8ba88c2106e30f2a34902a87d2@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[druid-commits] 20200114 [GitHub] [druid] ccaominh opened a new pull request #9189: Suppress CVE-2019-20330 for htrace-core-4.0.1",
+                "url" : "https://lists.apache.org/thread.html/rd6c6fef14944f3dcfb58d35f9317eb1c32a700e86c1b5231e45d3d0b@%3Ccommits.druid.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20200122 [jira] [Assigned] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                "url" : "https://lists.apache.org/thread.html/rfa57d9c2a27d3af14c69607fb1a3da00e758b2092aa88eb6a51b6e99@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20200220 [SECURITY] [DLA 2111-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00020.html"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20200127-0004/",
+                "url" : "https://security.netapp.com/advisory/ntap-20200127-0004/"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2019-12814",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 4.3
+              },
+              "references" : [ {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:2935",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+              }, {
+                "description" : "RHSA-2019:2936",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+              }, {
+                "description" : "RHSA-2019:2937",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+              }, {
+                "description" : "RHSA-2019:2938",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+              }, {
+                "description" : "RHSA-2019:3044",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3044"
+              }, {
+                "description" : "RHSA-2019:3045",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3045"
+              }, {
+                "description" : "RHSA-2019:3046",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3046"
+              }, {
+                "description" : "RHSA-2019:3050",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3050"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3200",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+              }, {
+                "description" : "RHSA-2019:3292",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3292"
+              }, {
+                "description" : "RHSA-2019:3297",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3297"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2341",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2341"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-dev] 20190623 [jira] [Created] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/129da0204c876f746636018751a086cc581e0e07bcdeb3ee22ff5731@%3Cdev.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190623 [jira] [Created] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/15a55e1d837fa686db493137cc0330c7ee1089ed9a9eea7ae7151ef1@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190623 [GitHub] [zookeeper] eolivelli opened a new pull request #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/1e04d9381c801b31ab28dec813c31c304b2a596b2a3707fa5462c5c0@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190712 [jira] [Resolved] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/28be28ffd6471d230943a255c36fe196a54ef5afc494a4781d16e37c@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190712 [jira] [Commented] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/2ff264b6a94c5363a35c4c88fa93216f60ec54d1d973ed6b76a9f560@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190624 [GitHub] [zookeeper] eolivelli closed pull request #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/4b832d1327703d6b287a6d223307f8f884d798821209a10647e93324@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190712 [jira] [Assigned] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/71f9ffd92410a889e27b95a219eaa843fd820f8550898633d85d4ea3@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190624 [GitHub] [zookeeper] eolivelli commented on issue #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/8fe2983f6d9fee0aa737e4bd24483f8f5cf9b938b9adad0c4e79b2a4@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190708 [jira] [Commented] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/a3ae8a8c5e32c413cd27071d3a204166050bf79ce7f1299f6866338f@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190624 [GitHub] [zookeeper] phunt commented on a change in pull request #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/a62aa2706105d68f1c02023fe24aaa3c13b4d8a1826181fed07d9682@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190623 [jira] [Updated] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/a78239b1f11cddfa86e4edee19064c40b6272214630bfef070c37957@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-issues] 20190713 [jira] [Updated] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/b0a2b2cca072650dbd5882719976c3d353972c44f6736ddf0ba95209@%3Cissues.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190710 [GitHub] [zookeeper] phunt closed pull request #1013: ZOOKEEPER-3441: OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/b148fa2e9ef468c4de00de255dd728b74e2a97d935f8ced31eb41ba2@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[accumulo-commits] 20190723 [accumulo] branch 2.0 updated: Fix CVE-2019-12814 Use jackson-databind 2.9.9.1",
+                "url" : "https://lists.apache.org/thread.html/bf20574dbc2db255f1fd489942b5720f675e32a2c4f44eb6a36060cd@%3Ccommits.accumulo.apache.org%3E"
+              }, {
+                "description" : "[geode-notifications] 20191007 [GitHub] [geode] jmelchio commented on issue #4102: Fix for GEODE-7255: Pickup Jackson CVE fix",
+                "url" : "https://lists.apache.org/thread.html/e0733058c0366b703e6757d8d2a7a04b943581f659e9c271f0841dfe@%3Cnotifications.geode.apache.org%3E"
+              }, {
+                "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+              }, {
+                "description" : "[zookeeper-notifications] 20190710 [GitHub] [zookeeper] phunt opened a new pull request #1013: ZOOKEEPER-3441: OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                "url" : "https://lists.apache.org/thread.html/eff7280055fc717ea8129cd28a9dd57b8446d00b36260c1caee10b87@%3Cnotifications.zookeeper.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190621 [SECURITY] [DLA 1831-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/06/msg00019.html"
+              }, {
+                "description" : "FEDORA-2019-ae6a703b8f",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+              }, {
+                "description" : "FEDORA-2019-fb23eccc03",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+              }, {
+                "description" : "FEDORA-2019-99ff6aa32c",
+                "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190625-0006/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190625-0006/"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-11307",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "https://access.redhat.com/errata/RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2032",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2032"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-issues] 20191004 [GitHub] [lucene-solr] marungo opened a new pull request #925: SOLR-13818: Upgrade jackson to 2.10.0",
+                "url" : "https://lists.apache.org/thread.html/7fcf88aff0d1deaa5c3c7be8d58c05ad7ad5da94b59065d8e7c50c5d@%3Cissues.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              }, {
+                "description" : "https://nvd.nist.gov/vuln/detail/CVE-2017-7525",
+                "url" : "https://nvd.nist.gov/vuln/detail/CVE-2017-7525"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-14719",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-14718",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "106601",
+                "url" : "http://www.securityfocus.com/bid/106601"
+              }, {
+                "description" : "RHBA-2019:0959",
+                "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+              }, {
+                "description" : "RHSA-2019:0782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+              }, {
+                "description" : "RHSA-2019:0877",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+              }, {
+                "description" : "RHSA-2019:1782",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+              }, {
+                "description" : "RHSA-2019:1797",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+              }, {
+                "description" : "RHSA-2019:1822",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+              }, {
+                "description" : "RHSA-2019:1823",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+              }, {
+                "description" : "RHSA-2019:2804",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3002",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+              }, {
+                "description" : "RHSA-2019:3140",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "RHSA-2019:3892",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+              }, {
+                "description" : "RHSA-2019:4037",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Assigned] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                "url" : "https://lists.apache.org/thread.html/6a78f88716c3c57aa74ec05764a37ab3874769a347805903b393b286@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                "url" : "https://lists.apache.org/thread.html/82b01bfb6787097427ce97cec6a7127e93718bc05d1efd5eaffc228f@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                "url" : "https://lists.apache.org/thread.html/ba973114605d936be276ee6ce09dfbdbf78aa56f6cdc6e79bfa7b8df@%3Cdev.lucene.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+              }, {
+                "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                "url" : "https://seclists.org/bugtraq/2019/May/68"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+              }, {
+                "description" : "DSA-4452",
+                "url" : "https://www.debian.org/security/2019/dsa-4452"
+              }, {
+                "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2020-10672",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 6.8
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2659",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2659"
+              }, {
+                "description" : "[debian-lts-announce] 20200322 [SECURITY] [DLA 2153-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00027.html"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2020-10673",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 6.8
+              },
+              "references" : [ {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/2660",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/2660"
+              }, {
+                "description" : "[debian-lts-announce] 20200322 [SECURITY] [DLA 2153-1] jackson-databind security update",
+                "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00027.html"
+              }, {
+                "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-7489",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html"
+              }, {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html"
+              }, {
+                "description" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+              }, {
+                "description" : "103203",
+                "url" : "http://www.securityfocus.com/bid/103203"
+              }, {
+                "description" : "1040693",
+                "url" : "http://www.securitytracker.com/id/1040693"
+              }, {
+                "description" : "1041890",
+                "url" : "http://www.securitytracker.com/id/1041890"
+              }, {
+                "description" : "RHSA-2018:1447",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1447"
+              }, {
+                "description" : "RHSA-2018:1448",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1448"
+              }, {
+                "description" : "RHSA-2018:1449",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+              }, {
+                "description" : "RHSA-2018:1450",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+              }, {
+                "description" : "RHSA-2018:1451",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1451"
+              }, {
+                "description" : "RHSA-2018:1786",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1786"
+              }, {
+                "description" : "RHSA-2018:2088",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2088"
+              }, {
+                "description" : "RHSA-2018:2089",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2089"
+              }, {
+                "description" : "RHSA-2018:2090",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2090"
+              }, {
+                "description" : "RHSA-2018:2938",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2938"
+              }, {
+                "description" : "RHSA-2018:2939",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:2939"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1931",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1931"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20180328-0001/",
+                "url" : "https://security.netapp.com/advisory/ntap-20180328-0001/"
+              }, {
+                "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+              }, {
+                "description" : "DSA-4190",
+                "url" : "https://www.debian.org/security/2018/dsa-4190"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-5968",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 5.1
+              },
+              "references" : [ {
+                "description" : "RHSA-2018:0478",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0478"
+              }, {
+                "description" : "RHSA-2018:0479",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0479"
+              }, {
+                "description" : "RHSA-2018:0480",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0480"
+              }, {
+                "description" : "RHSA-2018:0481",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:0481"
+              }, {
+                "description" : "RHSA-2018:1525",
+                "url" : "https://access.redhat.com/errata/RHSA-2018:1525"
+              }, {
+                "description" : "RHSA-2019:2858",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+              }, {
+                "description" : "RHSA-2019:3149",
+                "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-databind/issues/1899",
+                "url" : "https://github.com/FasterXML/jackson-databind/issues/1899"
+              }, {
+                "description" : "https://security.netapp.com/advisory/ntap-20180423-0002/",
+                "url" : "https://security.netapp.com/advisory/ntap-20180423-0002/"
+              }, {
+                "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+              }, {
+                "description" : "DSA-4114",
+                "url" : "https://www.debian.org/security/2018/dsa-4114"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2018-1000873",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 4.3
+              },
+              "references" : [ {
+                "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1665601",
+                "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1665601"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-modules-java8/issues/90",
+                "url" : "https://github.com/FasterXML/jackson-modules-java8/issues/90"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-modules-java8/pull/87",
+                "url" : "https://github.com/FasterXML/jackson-modules-java8/pull/87"
+              }, {
+                "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+              }, {
+                "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+              }, {
+                "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+              }, {
+                "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+              } ],
+              "resolution" : "PATCHED"
+            } ]
+          },
+          "feature" : {
+            "type" : "VulnerabilitiesInProject",
+            "name" : "Info about vulnerabilities in open-source project"
+          }
+        }, {
+          "type" : "DateValue",
+          "feature" : {
+            "type" : "DateFeature",
+            "name" : "When a project started"
+          },
+          "date" : 1324624661000
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "ProjectPopularityScore",
+          "name" : "Open-source project popularity score"
+        },
+        "value" : 2.9410000000000003,
+        "weight" : 0.30515788031015273,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "IntegerValue",
+          "feature" : {
+            "type" : "PositiveIntegerFeature",
+            "name" : "Number of stars for a GitHub repository"
+          },
+          "number" : 2421
+        }, {
+          "type" : "IntegerValue",
+          "feature" : {
+            "type" : "PositiveIntegerFeature",
+            "name" : "Number of watchers for a GitHub repository"
+          },
+          "number" : 156
+        } ],
+        "explanation" : [ ]
+      } ],
+      "explanation" : [ ]
+    },
+    "label" : [ "OssSecurityRating$SecurityLabel", "MODERATE" ]
+  },
+  "ratingValueDate" : 1585322733962
+}, {
+  "organization" : {
+    "name" : "FasterXML"
+  },
+  "name" : "jackson-dataformat-xml",
+  "url" : "https://github.com/FasterXML/jackson-dataformat-xml",
+  "ratingValue" : {
+    "scoreValue" : {
+      "type" : "ScoreValue",
+      "score" : {
+        "type" : "OssSecurityScore",
+        "name" : "Security score for open-source projects",
+        "weightedScores" : [ {
+          "score" : {
+            "type" : "ProjectSecurityTestingScore",
+            "name" : "How well security testing is done for an open-source project",
+            "subScores" : [ {
+              "type" : "DependencyScanScore",
+              "name" : "How a project scans its dependencies for vulnerabilities"
+            }, {
+              "type" : "LgtmScore",
+              "name" : "How a project addresses issues reported by LGTM"
+            } ]
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.6283118906878548
+          }
+        }, {
+          "score" : {
+            "type" : "UnpatchedVulnerabilitiesScore",
+            "name" : "How well vulnerabilities are patched"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.8362090433439393
+          }
+        }, {
+          "score" : {
+            "type" : "ProjectActivityScore",
+            "name" : "Open-source project activity score"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.6300785405632551
+          }
+        }, {
+          "score" : {
+            "type" : "CommunityCommitmentScore",
+            "name" : "How well open-source community commits to support an open-source project"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.5529742430404292
+          }
+        }, {
+          "score" : {
+            "type" : "ProjectSecurityAwarenessScore",
+            "name" : "How well open-source community is aware about security"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.5383270608555468
+          }
+        }, {
+          "score" : {
+            "type" : "VulnerabilityLifetimeScore",
+            "name" : "How fast vulnerabilities are patched"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.22939855566110368
+          }
+        }, {
+          "score" : {
+            "type" : "ProjectPopularityScore",
+            "name" : "Open-source project popularity score"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.30515788031015273
+          }
+        } ]
+      },
+      "value" : 3.7048161557516126,
+      "weight" : 1.0,
+      "confidence" : 8.673285914850164,
+      "usedValues" : [ {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "ProjectSecurityTestingScore",
+          "name" : "How well security testing is done for an open-source project",
+          "subScores" : [ {
+            "type" : "DependencyScanScore",
+            "name" : "How a project scans its dependencies for vulnerabilities"
+          }, {
+            "type" : "LgtmScore",
+            "name" : "How a project addresses issues reported by LGTM"
+          } ]
+        },
+        "value" : 4.0,
+        "weight" : 0.6283118906878548,
+        "confidence" : 5.0,
+        "usedValues" : [ {
+          "type" : "ScoreValue",
+          "score" : {
+            "type" : "DependencyScanScore",
+            "name" : "How a project scans its dependencies for vulnerabilities"
+          },
+          "value" : 0.0,
+          "weight" : 1.0,
+          "confidence" : 0.0,
+          "usedValues" : [ {
+            "type" : "UnknownValue",
+            "feature" : {
+              "type" : "BooleanFeature",
+              "name" : "If an open-source project is regularly scanned for vulnerable dependencies"
+            }
+          } ],
+          "explanation" : [ ]
+        }, {
+          "type" : "ScoreValue",
+          "score" : {
+            "type" : "LgtmScore",
+            "name" : "How a project addresses issues reported by LGTM"
+          },
+          "value" : 8.0,
+          "weight" : 1.0,
+          "confidence" : 10.0,
+          "usedValues" : [ {
+            "type" : "BooleanValue",
+            "feature" : {
+              "type" : "BooleanFeature",
+              "name" : "If a project uses LGTM"
+            },
+            "flag" : true
+          }, {
+            "type" : "LgtmGradeValue",
+            "feature" : {
+              "type" : "LgtmGradeFeature",
+              "name" : "The worst LGTM grade of a project"
+            },
+            "value" : "B"
+          } ],
+          "explanation" : [ ]
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "UnpatchedVulnerabilitiesScore",
+          "name" : "How well vulnerabilities are patched"
+        },
+        "value" : 10.0,
+        "weight" : 0.8362090433439393,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "VulnerabilitiesValue",
+          "vulnerabilities" : {
+            "entries" : [ {
+              "id" : "CVE-2016-7051",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 5.0
+              },
+              "references" : [ {
+                "description" : "97688",
+                "url" : "http://www.securityfocus.com/bid/97688"
+              }, {
+                "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1378673",
+                "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1378673"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-dataformat-xml/issues/211",
+                "url" : "https://github.com/FasterXML/jackson-dataformat-xml/issues/211"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2016-3720",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "FEDORA-2016-13b4cae9df",
+                "url" : "http://lists.fedoraproject.org/pipermail/package-announce/2016-May/184561.html"
+              } ],
+              "resolution" : "PATCHED"
+            } ]
+          },
+          "feature" : {
+            "type" : "VulnerabilitiesInProject",
+            "name" : "Info about vulnerabilities in open-source project"
+          }
+        } ],
+        "explanation" : [ "No unpatched vulnerabilities found which is good" ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "ProjectActivityScore",
+          "name" : "Open-source project activity score"
+        },
+        "value" : 2.098720838336043,
+        "weight" : 0.6300785405632551,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "IntegerValue",
+          "feature" : {
+            "type" : "PositiveIntegerFeature",
+            "name" : "Number of commits in the last three months"
+          },
+          "number" : 42
+        }, {
+          "type" : "IntegerValue",
+          "feature" : {
+            "type" : "PositiveIntegerFeature",
+            "name" : "Number of contributors in the last three months"
+          },
+          "number" : 2
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "CommunityCommitmentScore",
+          "name" : "How well open-source community commits to support an open-source project"
+        },
+        "value" : 0.0,
+        "weight" : 0.5529742430404292,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project is supported by a company"
+          },
+          "flag" : false
+        }, {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project belongs to Apache Foundation"
+          },
+          "flag" : false
+        }, {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project belongs to Eclipse Foundation"
+          },
+          "flag" : false
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "ProjectSecurityAwarenessScore",
+          "name" : "How well open-source community is aware about security"
+        },
+        "value" : 0.0,
+        "weight" : 0.5383270608555468,
+        "confidence" : 6.666666666666667,
+        "usedValues" : [ {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project has a security policy"
+          },
+          "flag" : false
+        }, {
+          "type" : "UnknownValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project has a security team"
+          }
+        }, {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If a project uses verified signed commits"
+          },
+          "flag" : false
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "VulnerabilityLifetimeScore",
+          "name" : "How fast vulnerabilities are patched"
+        },
+        "value" : 6.25,
+        "weight" : 0.22939855566110368,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "VulnerabilitiesValue",
+          "vulnerabilities" : {
+            "entries" : [ {
+              "id" : "CVE-2016-7051",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 5.0
+              },
+              "references" : [ {
+                "description" : "97688",
+                "url" : "http://www.securityfocus.com/bid/97688"
+              }, {
+                "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1378673",
+                "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1378673"
+              }, {
+                "description" : "https://github.com/FasterXML/jackson-dataformat-xml/issues/211",
+                "url" : "https://github.com/FasterXML/jackson-dataformat-xml/issues/211"
+              } ],
+              "resolution" : "PATCHED"
+            }, {
+              "id" : "CVE-2016-3720",
+              "cvss" : {
+                "version" : "V2",
+                "value" : 7.5
+              },
+              "references" : [ {
+                "description" : "FEDORA-2016-13b4cae9df",
+                "url" : "http://lists.fedoraproject.org/pipermail/package-announce/2016-May/184561.html"
+              } ],
+              "resolution" : "PATCHED"
+            } ]
+          },
+          "feature" : {
+            "type" : "VulnerabilitiesInProject",
+            "name" : "Info about vulnerabilities in open-source project"
+          }
+        }, {
+          "type" : "DateValue",
+          "feature" : {
+            "type" : "DateFeature",
+            "name" : "When a project started"
+          },
+          "date" : 1293771650000
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "ProjectPopularityScore",
+          "name" : "Open-source project popularity score"
+        },
+        "value" : 0.4986666666666667,
+        "weight" : 0.30515788031015273,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "IntegerValue",
+          "feature" : {
+            "type" : "PositiveIntegerFeature",
+            "name" : "Number of stars for a GitHub repository"
+          },
+          "number" : 392
+        }, {
+          "type" : "IntegerValue",
+          "feature" : {
+            "type" : "PositiveIntegerFeature",
+            "name" : "Number of watchers for a GitHub repository"
+          },
+          "number" : 32
+        } ],
+        "explanation" : [ ]
+      } ],
+      "explanation" : [ ]
+    },
+    "label" : [ "OssSecurityRating$SecurityLabel", "BAD" ]
+  },
+  "ratingValueDate" : 1585322733962
+}, {
+  "organization" : {
+    "name" : "FasterXML"
+  },
+  "name" : "jackson-dataformats-text",
+  "url" : "https://github.com/FasterXML/jackson-dataformats-text",
+  "ratingValue" : {
+    "scoreValue" : {
+      "type" : "ScoreValue",
+      "score" : {
+        "type" : "OssSecurityScore",
+        "name" : "Security score for open-source projects",
+        "weightedScores" : [ {
+          "score" : {
+            "type" : "ProjectSecurityTestingScore",
+            "name" : "How well security testing is done for an open-source project",
+            "subScores" : [ {
+              "type" : "DependencyScanScore",
+              "name" : "How a project scans its dependencies for vulnerabilities"
+            }, {
+              "type" : "LgtmScore",
+              "name" : "How a project addresses issues reported by LGTM"
+            } ]
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.6283118906878548
+          }
+        }, {
+          "score" : {
+            "type" : "UnpatchedVulnerabilitiesScore",
+            "name" : "How well vulnerabilities are patched"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.8362090433439393
+          }
+        }, {
+          "score" : {
+            "type" : "ProjectActivityScore",
+            "name" : "Open-source project activity score"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.6300785405632551
+          }
+        }, {
+          "score" : {
+            "type" : "CommunityCommitmentScore",
+            "name" : "How well open-source community commits to support an open-source project"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.5529742430404292
+          }
+        }, {
+          "score" : {
+            "type" : "ProjectSecurityAwarenessScore",
+            "name" : "How well open-source community is aware about security"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.5383270608555468
+          }
+        }, {
+          "score" : {
+            "type" : "VulnerabilityLifetimeScore",
+            "name" : "How fast vulnerabilities are patched"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.22939855566110368
+          }
+        }, {
+          "score" : {
+            "type" : "ProjectPopularityScore",
+            "name" : "Open-source project popularity score"
+          },
+          "weight" : {
+            "type" : "ImmutableWeight",
+            "value" : 0.30515788031015273
+          }
+        } ]
+      },
+      "value" : 4.387928377759749,
+      "weight" : 1.0,
+      "confidence" : 8.673285914850164,
+      "usedValues" : [ {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "ProjectSecurityTestingScore",
+          "name" : "How well security testing is done for an open-source project",
+          "subScores" : [ {
+            "type" : "DependencyScanScore",
+            "name" : "How a project scans its dependencies for vulnerabilities"
+          }, {
+            "type" : "LgtmScore",
+            "name" : "How a project addresses issues reported by LGTM"
+          } ]
+        },
+        "value" : 5.0,
+        "weight" : 0.6283118906878548,
+        "confidence" : 5.0,
+        "usedValues" : [ {
+          "type" : "ScoreValue",
+          "score" : {
+            "type" : "DependencyScanScore",
+            "name" : "How a project scans its dependencies for vulnerabilities"
+          },
+          "value" : 0.0,
+          "weight" : 1.0,
+          "confidence" : 0.0,
+          "usedValues" : [ {
+            "type" : "UnknownValue",
+            "feature" : {
+              "type" : "BooleanFeature",
+              "name" : "If an open-source project is regularly scanned for vulnerable dependencies"
+            }
+          } ],
+          "explanation" : [ ]
+        }, {
+          "type" : "ScoreValue",
+          "score" : {
+            "type" : "LgtmScore",
+            "name" : "How a project addresses issues reported by LGTM"
+          },
+          "value" : 10.0,
+          "weight" : 1.0,
+          "confidence" : 10.0,
+          "usedValues" : [ {
+            "type" : "BooleanValue",
+            "feature" : {
+              "type" : "BooleanFeature",
+              "name" : "If a project uses LGTM"
+            },
+            "flag" : true
+          }, {
+            "type" : "LgtmGradeValue",
+            "feature" : {
+              "type" : "LgtmGradeFeature",
+              "name" : "The worst LGTM grade of a project"
+            },
+            "value" : "A"
+          } ],
+          "explanation" : [ ]
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "UnpatchedVulnerabilitiesScore",
+          "name" : "How well vulnerabilities are patched"
+        },
+        "value" : 10.0,
+        "weight" : 0.8362090433439393,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "VulnerabilitiesValue",
+          "vulnerabilities" : {
+            "entries" : [ ]
+          },
+          "feature" : {
+            "type" : "VulnerabilitiesInProject",
+            "name" : "Info about vulnerabilities in open-source project"
+          }
+        } ],
+        "explanation" : [ "No unpatched vulnerabilities found which is good" ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "ProjectActivityScore",
+          "name" : "Open-source project activity score"
+        },
+        "value" : 3.8893001467110873,
+        "weight" : 0.6300785405632551,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "IntegerValue",
+          "feature" : {
+            "type" : "PositiveIntegerFeature",
+            "name" : "Number of commits in the last three months"
+          },
+          "number" : 49
+        }, {
+          "type" : "IntegerValue",
+          "feature" : {
+            "type" : "PositiveIntegerFeature",
+            "name" : "Number of contributors in the last three months"
+          },
+          "number" : 5
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "CommunityCommitmentScore",
+          "name" : "How well open-source community commits to support an open-source project"
+        },
+        "value" : 0.0,
+        "weight" : 0.5529742430404292,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project is supported by a company"
+          },
+          "flag" : false
+        }, {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project belongs to Apache Foundation"
+          },
+          "flag" : false
+        }, {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project belongs to Eclipse Foundation"
+          },
+          "flag" : false
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "ProjectSecurityAwarenessScore",
+          "name" : "How well open-source community is aware about security"
+        },
+        "value" : 0.0,
+        "weight" : 0.5383270608555468,
+        "confidence" : 6.666666666666667,
+        "usedValues" : [ {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project has a security policy"
+          },
+          "flag" : false
+        }, {
+          "type" : "UnknownValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If an open-source project has a security team"
+          }
+        }, {
+          "type" : "BooleanValue",
+          "feature" : {
+            "type" : "BooleanFeature",
+            "name" : "If a project uses verified signed commits"
+          },
+          "flag" : false
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "VulnerabilityLifetimeScore",
+          "name" : "How fast vulnerabilities are patched"
+        },
+        "value" : 10.0,
+        "weight" : 0.22939855566110368,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "VulnerabilitiesValue",
+          "vulnerabilities" : {
+            "entries" : [ ]
+          },
+          "feature" : {
+            "type" : "VulnerabilitiesInProject",
+            "name" : "Info about vulnerabilities in open-source project"
+          }
+        }, {
+          "type" : "DateValue",
+          "feature" : {
+            "type" : "DateFeature",
+            "name" : "When a project started"
+          },
+          "date" : 1489953464000
+        } ],
+        "explanation" : [ ]
+      }, {
+        "type" : "ScoreValue",
+        "score" : {
+          "type" : "ProjectPopularityScore",
+          "name" : "Open-source project popularity score"
+        },
+        "value" : 0.252,
+        "weight" : 0.30515788031015273,
+        "confidence" : 10.0,
+        "usedValues" : [ {
+          "type" : "IntegerValue",
+          "feature" : {
+            "type" : "PositiveIntegerFeature",
+            "name" : "Number of stars for a GitHub repository"
+          },
+          "number" : 202
+        }, {
+          "type" : "IntegerValue",
+          "feature" : {
+            "type" : "PositiveIntegerFeature",
+            "name" : "Number of watchers for a GitHub repository"
+          },
+          "number" : 15
+        } ],
+        "explanation" : [ ]
+      } ],
+      "explanation" : [ ]
+    },
+    "label" : [ "OssSecurityRating$SecurityLabel", "BAD" ]
+  },
+  "ratingValueDate" : 1585322763788
+} ]

--- a/docs/oss/security/other.yml
+++ b/docs/oss/security/other.yml
@@ -1,0 +1,16 @@
+# this is a configuration for generating a report for other projects
+cache: .fosstars_model/project_rating_cache.json
+reports:
+  - type: markdown
+    where: docs/oss/security
+    source: docs/oss/security/github_projects.json
+  - type: json
+    where: docs/oss/security/github_projects.json
+finder:
+  repositories:
+    - organization: FasterXML
+      name: jackson-databind
+    - organization: FasterXML
+      name: jackson-dataformat-xml
+    - organization: FasterXML
+      name: jackson-dataformats-text

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
   <name>Fosstars Rating Core</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.jackson-databind>2.10.1</version.jackson-databind>
-    <version.jackson-dataformat-yaml>2.10.1</version.jackson-dataformat-yaml>
+    <version.jackson-databind>2.9.0</version.jackson-databind>
+    <version.jackson-dataformat-yaml>2.9.0</version.jackson-dataformat-yaml>
     <version.commons-math3>3.6.1</version.commons-math3>
     <version.commons-cli>1.4</version.commons-cli>
     <version.github-api>1.95</version.github-api>

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/Project.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/Project.java
@@ -1,5 +1,14 @@
 package com.sap.sgs.phosphor.fosstars.tool;
 
+import java.net.URL;
+
+/**
+ * An interface for an open-source project.
+ */
 public interface Project {
 
+  /**
+   * Returns a URL of the project's SCM.
+   */
+  URL url();
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/Reporter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/Reporter.java
@@ -1,5 +1,25 @@
 package com.sap.sgs.phosphor.fosstars.tool;
 
-public interface Reporter {
+import java.io.IOException;
+import java.util.List;
 
+/**
+ * A reporter create a report for a number of open-source projects.
+ *
+ * @param <T> A type of projects.
+ */
+public interface Reporter<T extends Project> {
+
+  /**
+   * Runs the reporter for a list of projects.
+   *
+   * @param projects The projects.
+   * @throws IOException If something went wrong.
+   */
+  void runFor(List<T> projects) throws IOException;
+
+  /**
+   * This is a reporter which does nothing.
+   */
+  Reporter DUMMY = projects -> {};
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/Formatter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/Formatter.java
@@ -1,5 +1,18 @@
 package com.sap.sgs.phosphor.fosstars.tool.format;
 
+import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
+
+/**
+ * The interface of a formatter which knows how to convert
+ * a rating value to a string.
+ */
 public interface Formatter {
 
+  /**
+   * Print out a formatted rating value.
+   *
+   * @param ratingValue The rating value to be printed.
+   * @return A formatted rating value.
+   */
+  String print(RatingValue ratingValue);
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/MarkdownFormatter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/MarkdownFormatter.java
@@ -1,5 +1,11 @@
 package com.sap.sgs.phosphor.fosstars.tool.format;
 
+import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
+
 public class MarkdownFormatter implements Formatter {
 
+  @Override
+  public String print(RatingValue ratingValue) {
+    throw new UnsupportedOperationException("No formatting for you!");
+  }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinter.java
@@ -30,6 +30,9 @@ import java.util.TreeMap;
  */
 public class PrettyPrinter implements Formatter {
 
+  /**
+   * An indent step.
+   */
   private static final String INDENT_STEP = "  ";
 
   /**
@@ -67,12 +70,7 @@ public class PrettyPrinter implements Formatter {
         OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES, "Does it scan for vulnerable dependencies?");
   }
 
-  /**
-   * Print out a formatted rating value.
-   *
-   * @param ratingValue The rating value to be printed.
-   * @return A string to be displayed.
-   */
+  @Override
   public String print(RatingValue ratingValue) {
     StringBuilder sb = new StringBuilder();
     sb.append(String.format("[+] Here is how the rating was calculated:%n"));
@@ -156,6 +154,7 @@ public class PrettyPrinter implements Formatter {
           maxLength = name.length();
         }
       }
+
       for (Map.Entry<String, Object> entry : nameToValue.entrySet()) {
         String name = entry.getKey();
         name += name.endsWith("?") ? "." : ":";

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/AbstractReporter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/AbstractReporter.java
@@ -1,7 +1,80 @@
 package com.sap.sgs.phosphor.fosstars.tool.github;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.sgs.phosphor.fosstars.tool.Project;
 import com.sap.sgs.phosphor.fosstars.tool.Reporter;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-abstract class AbstractReporter implements Reporter {
+abstract class AbstractReporter<T extends Project> implements Reporter<T> {
+
+  /**
+   * For serialization.
+   */
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /**
+   * A type reference of a list of {@link GitHubProject}s for deserialization.
+   */
+  private static final TypeReference<List<GitHubProject>> LIST_OF_GITHUB_PROJECTS_TYPE
+      = new TypeReference<List<GitHubProject>>() {};
+
+  /**
+   * Merges two lists of projects. The merge is based on URLs.
+   * If there are two projects with the same URLs,
+   * then the method uses the project from the first list.
+   *
+   * @param projects The first list of projects.
+   * @param extraProjects The second list of projects.
+   * @return A list of projects which contains all projects from the original lists.
+   */
+  static List<GitHubProject> merge(
+      List<GitHubProject> projects, List<GitHubProject> extraProjects) {
+
+    Map<URL, GitHubProject> map = new HashMap<>();
+    for (GitHubProject extraProject : extraProjects) {
+      map.put(extraProject.url(), extraProject);
+    }
+    for (GitHubProject project : projects) {
+      map.put(project.url(), project);
+    }
+
+    List<GitHubProject> allProjects = new ArrayList<>();
+    for (Map.Entry<URL, GitHubProject> entry : map.entrySet()) {
+      allProjects.add(entry.getValue());
+    }
+
+    return allProjects;
+  }
+
+  /**
+   * Loads projects from a JSON file.
+   * If the file doesn't exist, then the method returns an empty list.
+   *
+   * @param extraSourceFileName A path to the file.
+   * @return A list of loaded extra projects.
+   * @throws IOException If the projects couldn't be loaded.
+   */
+  static List<GitHubProject> loadProjects(String extraSourceFileName) throws IOException {
+    if (extraSourceFileName == null) {
+      return Collections.emptyList();
+    }
+    Path path = Paths.get(extraSourceFileName);
+    if (!Files.exists(path)) {
+      System.out.printf(
+          "[!] Oh no! I could not load extra projects from %s%n", extraSourceFileName);
+      return Collections.emptyList();
+    }
+    return MAPPER.readValue(Files.newInputStream(path), LIST_OF_GITHUB_PROJECTS_TYPE);
+  }
 
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubOrganization.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubOrganization.java
@@ -1,5 +1,8 @@
 package com.sap.sgs.phosphor.fosstars.tool.github;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
@@ -17,13 +20,15 @@ class GitHubOrganization {
    *
    * @param name A name of the organization.
    */
-  GitHubOrganization(String name) {
+  @JsonCreator
+  GitHubOrganization(@JsonProperty("name") String name) {
     this.name = Objects.requireNonNull(name, "Hey! Organization's name can't be null!");
   }
 
   /**
    * Returns organization's name.
    */
+  @JsonGetter("name")
   public String name() {
     return name;
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectCache.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectCache.java
@@ -1,0 +1,138 @@
+package com.sap.sgs.phosphor.fosstars.tool.github;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * This is a cache of {@link GitHubProject}s.
+ */
+class GitHubProjectCache {
+
+  /**
+   * The default lifetime of a cache entry in days.
+   */
+  private static final int DEFAULT_LIFETIME = 7;
+
+  /**
+   * Maps a URL of a project to a {@link GitHubProject}.
+   */
+  final Map<String, GitHubProject> cache;
+
+  /**
+   * A lifetime of a cache entry in days.
+   */
+  private long lifetime = DEFAULT_LIFETIME;
+
+  /**
+   * Creates an empty cache.
+   */
+  static GitHubProjectCache empty() {
+    return new GitHubProjectCache(new HashMap<>());
+  }
+
+  /**
+   * Initializes a new cache. The constructor is used for deserialization.
+   *
+   * @param cache A map with cache entries.
+   */
+  @JsonCreator
+  private GitHubProjectCache(@JsonProperty("cache") Map<String, GitHubProject> cache) {
+    this.cache = cache;
+  }
+
+  /**
+   * Returns a map with cache entries. The method is used for serialization.
+   */
+  @JsonGetter("cache")
+  private Map<String, GitHubProject> cache() {
+    return cache;
+  }
+
+  /**
+   * Set a lifetime for cache entries.
+   *
+   * @param days The lifetime in days.
+   * @return The same {@link GitHubProject}.
+   */
+  GitHubProjectCache lifetime(long days) {
+    if (days < 1) {
+      throw new IllegalArgumentException("Hey! You gave me a wrong life time for cache entries!");
+    }
+    lifetime = days;
+    return this;
+  }
+
+  /**
+   * Returns a size of the cache.
+   */
+  int size() {
+    return cache.size();
+  }
+
+  /**
+   * Add a new project to the cache.
+   *
+   * @param project The project.
+   * @return The same {@link GitHubProject}.
+   */
+  GitHubProjectCache add(GitHubProject project) {
+    cache.put(project.url().toString(), project);
+    return this;
+  }
+
+  /**
+   * Returns a rating value for a project if it's available in the cache.
+   *
+   * @param project The project.
+   * @return An {@link Optional} with a rating value for the project.
+   */
+  Optional<RatingValue> cachedRatingValueFor(GitHubProject project) {
+    GitHubProject cached = cache.get(project.url().toString());
+    if (cached == null) {
+      return Optional.empty();
+    }
+    if (!cached.ratingValue().isPresent()) {
+      return Optional.empty();
+    }
+    RatingValue ratingValue = cached.ratingValue().get();
+    long age = Duration.between(cached.ratingValueDate().toInstant(), Instant.now()).toDays();
+    if (age >= lifetime) {
+      return Optional.empty();
+    }
+    return Optional.of(ratingValue);
+  }
+
+  /**
+   * Load a cache from a file.
+   *
+   * @param filename A path to the file.
+   * @return A loaded cache.
+   * @throws IOException If something went wrong.
+   */
+  static GitHubProjectCache load(String filename) throws IOException {
+    return load(Files.newInputStream(Paths.get(filename)));
+  }
+
+  /**
+   * Load a chache from an input stream.
+   *
+   * @param is The input stream.
+   * @return A loaded cache.
+   * @throws IOException If something went wrong.
+   */
+  static GitHubProjectCache load(InputStream is) throws IOException {
+    return new ObjectMapper().readValue(is, GitHubProjectCache.class);
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectFinder.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectFinder.java
@@ -438,10 +438,10 @@ public class GitHubProjectFinder {
         @JsonProperty("organizations") List<OrganizationConfig> organizationConfigs,
         @JsonProperty("repositories") List<ProjectConfig> projectConfigs) {
 
-      this.organizationConfigs = Objects.requireNonNull(
-          organizationConfigs, "Hey configs for organizations can't be null!");
-      this.projectConfigs = Objects.requireNonNull(
-          projectConfigs, "Hey! Configs for projects can't be null!");
+      this.organizationConfigs
+          = organizationConfigs != null ? organizationConfigs : new ArrayList<>();
+      this.projectConfigs
+          = projectConfigs != null ? projectConfigs : new ArrayList<>();
     }
   }
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MarkdownReporter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MarkdownReporter.java
@@ -1,5 +1,191 @@
 package com.sap.sgs.phosphor.fosstars.tool.github;
 
-public class MarkdownReporter extends AbstractReporter {
+import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
+import com.sap.sgs.phosphor.fosstars.tool.format.PrettyPrinter;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.commons.io.IOUtils;
+
+/**
+ * This reporter takes a number of projects and generates a markdown report.
+ */
+public class MarkdownReporter extends AbstractReporter<GitHubProject> {
+
+  /**
+   * A formatter for rating values.
+   */
+  private static final  PrettyPrinter PRETTY_PRINTER = new PrettyPrinter();
+
+  /**
+   * A file where a report is going to be stored.
+   */
+  private static final String REPORT_FILENAME = "README.md";
+
+  /**
+   * A template for a table row in the report.
+   */
+  private static final String PROJECT_LINE_TEMPLATE
+      = "| %URL% | %SCORE% | %LABEL% | %CONFIDENCE% | %DATE% |";
+
+  /**
+   * A date formatter.
+   */
+  private static final SimpleDateFormat DATE_FORMAT
+      = new SimpleDateFormat("MMM d, YYYY", Locale.US);
+
+  /**
+   * This string is printed out if something is unknown.
+   */
+  private static final String UNKNOWN = "unknown";
+
+  /**
+   * An output directory.
+   */
+  private final String outputDirectory;
+
+  /**
+   * A list of extra projects which should be added to the report.
+   */
+  private final List<GitHubProject> extraProjects;
+
+  /**
+   * Initializes a new reporter.
+   *
+   * @param outputDirectory An output directory.
+   * @param extraSourceFileName A JSON file with serialized extra projects.
+   * @throws IOException If something went wrong
+   *                     (for example, the output directory doesn't exist,
+   *                     or the extra projects couldn't be loaded).
+   */
+  MarkdownReporter(String outputDirectory, String extraSourceFileName)
+      throws IOException {
+
+    Objects.requireNonNull(outputDirectory, "Oh no! Output directory is null!");
+    if (!Files.isDirectory(Paths.get(outputDirectory))) {
+      throw new FileNotFoundException(
+          String.format("Oh no! I could not find %s", outputDirectory));
+    }
+    this.outputDirectory = outputDirectory;
+    this.extraProjects = loadProjects(extraSourceFileName);
+  }
+
+  @Override
+  public void runFor(List<GitHubProject> projects) throws IOException {
+    List<GitHubProject> allProjects = merge(projects, extraProjects);
+    allProjects.sort(Comparator.comparing(project -> project.url().toString()));
+
+    String projectDetailsTemplate;
+    try (InputStream is = getClass().getResourceAsStream("MarkdownProjectDetailsTemplate.md")) {
+      projectDetailsTemplate = IOUtils.toString(is, "UTF-8");
+    }
+
+    StringBuilder sb = new StringBuilder();
+    for (GitHubProject project : allProjects) {
+      String projectPath = project.url().getPath().replaceFirst("/", "");
+
+      Path organizationDirectory = Paths.get(outputDirectory)
+          .resolve(project.organization().name());
+      if (!Files.isDirectory(organizationDirectory)) {
+        Files.createDirectories(organizationDirectory);
+      }
+
+      String details = projectDetailsTemplate
+          .replace("%PROJECT_NAME%", projectPath)
+          .replace("%DETAILS%", detailsOf(project));
+
+      String projectReportFilename = String.format("%s.md", project.name());
+      Files.write(
+          organizationDirectory.resolve(projectReportFilename),
+          details.getBytes());
+
+      String relativePathToDetails = String.format("%s/%s",
+          project.organization().name(), projectReportFilename);
+      String url = String.format("[%s](%s)", projectPath, project.url());
+      String label = String.format("[%s](%s)", labelOf(project), relativePathToDetails);
+      String line = PROJECT_LINE_TEMPLATE
+          .replace("%URL%", url)
+          .replace("%SCORE%", scoreOf(project))
+          .replace("%LABEL%", label)
+          .replace("%CONFIDENCE%", confidenceOf(project))
+          .replace("%DATE%", lastUpdateOf(project));
+      sb.append(line).append("\n");
+    }
+
+    try (InputStream is = getClass().getResourceAsStream("MarkdownReporterMainTemplate.md")) {
+      String template = IOUtils.toString(is, "UTF-8");
+      String content = template.replace("%PROJECT_TABLE%", sb.toString());
+
+      Path path = Paths.get(outputDirectory).resolve(REPORT_FILENAME);
+      System.out.printf("[+] Storing a report to %s%n", path);
+      Files.write(path, content.getBytes());
+    }
+  }
+
+  /**
+   * Prepares a description how a rating was calculated for a project.
+   *
+   * @param project The project.
+   * @return The details of the rating calculation.
+   */
+  private static String detailsOf(GitHubProject project) {
+    if (!project.ratingValue().isPresent()) {
+      return UNKNOWN;
+    }
+    return PRETTY_PRINTER.print(project.ratingValue().get());
+  }
+
+  /**
+   * Formats a date when a rating was calculated for a project.
+   */
+  private static String lastUpdateOf(GitHubProject project) {
+    if (project.ratingValueDate() == null) {
+      return UNKNOWN;
+    }
+    return DATE_FORMAT.format(project.ratingValueDate());
+  }
+
+  /**
+   * Formats a confidence of a rating of a project.
+   */
+  private static String confidenceOf(GitHubProject project) {
+    Optional<RatingValue> something = project.ratingValue();
+    if (!something.isPresent()) {
+      return UNKNOWN;
+    }
+    return String.format("%2.2f", something.get().confidence());
+  }
+
+  /**
+   * Formats a label of a rating of a project.
+   */
+  private static String labelOf(GitHubProject project) {
+    Optional<RatingValue> something = project.ratingValue();
+    if (!something.isPresent()) {
+      return UNKNOWN;
+    }
+    return something.get().label().name();
+  }
+
+  /**
+   * Formats a score of a project.
+   */
+  private static String scoreOf(GitHubProject project) {
+    Optional<RatingValue> something = project.ratingValue();
+    if (!something.isPresent()) {
+      return UNKNOWN;
+    }
+    return String.format("%2.2f", something.get().scoreValue().get());
+  }
+
 
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MergedJsonReporter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MergedJsonReporter.java
@@ -1,0 +1,50 @@
+package com.sap.sgs.phosphor.fosstars.tool.github;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * This reporter takes a number of projects and merge them in to a JSON file.
+ */
+public class MergedJsonReporter extends AbstractReporter<GitHubProject> {
+
+  /**
+   * Serializer and deserializer.
+   */
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /**
+   * A path to an output file.
+   */
+  private final String filename;
+
+  /**
+   * Initializes a new reporter.
+   *
+   * @param filename A path to an output file.
+   */
+  MergedJsonReporter(String filename) {
+    Objects.requireNonNull(filename, "Oh no! Output filename is null!");
+    if (filename.trim().isEmpty()) {
+      throw new IllegalArgumentException("Oh no! Output filename is empty!");
+    }
+    this.filename = filename;
+  }
+
+  @Override
+  public void runFor(List<GitHubProject> projects) throws IOException {
+    List<GitHubProject> existingProjects = loadProjects(filename);
+    List<GitHubProject> allProjects = merge(projects, existingProjects);
+
+    System.out.printf("[+] Storing info about projects to %s%n", filename);
+    allProjects.sort(Comparator.comparing(project -> project.url().toString()));
+    Files.write(
+        Paths.get(filename),
+        MAPPER.writerWithDefaultPrettyPrinter().writeValueAsBytes(allProjects));
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MultipleSecurityRatingsCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MultipleSecurityRatingsCalculator.java
@@ -1,13 +1,21 @@
 package com.sap.sgs.phosphor.fosstars.tool.github;
 
+import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import org.kohsuke.github.GitHub;
 
 /**
  * The class calculates security ratings for multiple open-source projects.
  */
 class MultipleSecurityRatingsCalculator extends AbstractRatingCalculator {
+
+  /**
+   * A cache of processed projects.
+   */
+  private GitHubProjectCache projectCache = GitHubProjectCache.empty();
 
   /**
    * Initializes a new calculator.
@@ -18,16 +26,43 @@ class MultipleSecurityRatingsCalculator extends AbstractRatingCalculator {
     super(github);
   }
 
+  /**
+   * Set a cache of processed projects.
+   *
+   * @param projectCache The cache.
+   * @return The same {@link MultipleSecurityRatingsCalculator}.
+   */
+  MultipleSecurityRatingsCalculator set(GitHubProjectCache projectCache) {
+    this.projectCache = Objects.requireNonNull(projectCache, "Oh no! Project cache can't be null!");
+    return this;
+  }
+
   @Override
   MultipleSecurityRatingsCalculator calculateFor(GitHubProject project) throws IOException {
     singleSecurityRatingCalculator().calculateFor(project);
     return this;
   }
 
+  /**
+   * Calculates ratings for multiple projects.
+   * First, the method checks if a rating value for a project is already available in cache.
+   *
+   * @param projects The projects.
+   * @return The same calculator.
+   * @throws IOException If something went wrong.
+   */
   @Override
   MultipleSecurityRatingsCalculator calculateFor(List<GitHubProject> projects) throws IOException {
     for (GitHubProject project : projects) {
+      Optional<RatingValue> cachedRatingValue = projectCache.cachedRatingValueFor(project);
+      if (cachedRatingValue.isPresent()) {
+        project.set(cachedRatingValue.get());
+        System.out.printf("Found a cached rating value!%n");
+        continue;
+      }
+
       calculateFor(project);
+      projectCache.add(project);
     }
     return this;
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MultipleSecurityRatingsCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MultipleSecurityRatingsCalculator.java
@@ -57,7 +57,7 @@ class MultipleSecurityRatingsCalculator extends AbstractRatingCalculator {
       Optional<RatingValue> cachedRatingValue = projectCache.cachedRatingValueFor(project);
       if (cachedRatingValue.isPresent()) {
         project.set(cachedRatingValue.get());
-        System.out.printf("Found a cached rating value!%n");
+        System.out.printf("[+] Found a cached rating value!%n");
         continue;
       }
 

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/tool/github/MarkdownProjectDetailsTemplate.md
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/tool/github/MarkdownProjectDetailsTemplate.md
@@ -1,0 +1,5 @@
+# %PROJECT_NAME%
+
+```
+%DETAILS%
+```

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/tool/github/MarkdownReporterMainTemplate.md
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/tool/github/MarkdownReporterMainTemplate.md
@@ -1,0 +1,5 @@
+# Projects
+
+| Project | Score | Rating | Confidence | Last updated |
+| ------- | ----- | ------ | ---------- | ------------ |
+%PROJECT_TABLE%

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectCacheTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectCacheTest.java
@@ -1,0 +1,66 @@
+package com.sap.sgs.phosphor.fosstars.tool.github;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.sgs.phosphor.fosstars.model.rating.example.SecurityRatingExample.SecurityLabelExample;
+import com.sap.sgs.phosphor.fosstars.model.score.example.ExampleScores;
+import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import org.junit.Test;
+
+public class GitHubProjectCacheTest {
+
+  @Test
+  public void load() throws IOException {
+    final String filename = "TestProjectRatingCache.json";
+    try (InputStream is = getClass().getResourceAsStream(filename)) {
+      GitHubProjectCache cache = GitHubProjectCache.load(is);
+      assertNotNull(cache);
+      assertEquals(3, cache.size());
+      cache.lifetime(100000);
+
+      GitHubProject project = new GitHubProject(new GitHubOrganization("netty"), "netty");
+      Optional<RatingValue> something = cache.cachedRatingValueFor(project);
+      assertTrue(something.isPresent());
+
+      project = new GitHubProject(new GitHubOrganization("netty"), "netty-tcnative");
+      something = cache.cachedRatingValueFor(project);
+      assertTrue(something.isPresent());
+
+      project = new GitHubProject(new GitHubOrganization("FasterXML"), "jackson-databind");
+      something = cache.cachedRatingValueFor(project);
+      assertTrue(something.isPresent());
+
+      project = new GitHubProject(new GitHubOrganization("not-existing"), "test");
+      something = cache.cachedRatingValueFor(project);
+      assertFalse(something.isPresent());
+    }
+  }
+
+  @Test
+  public void add() {
+    GitHubProjectCache cache = GitHubProjectCache.empty();
+    assertNotNull(cache);
+    assertEquals(0, cache.size());
+
+    GitHubProject project = new GitHubProject(new GitHubOrganization("netty"), "netty");
+    RatingValue ratingValue = new RatingValue(
+        new ScoreValue(ExampleScores.SECURITY_SCORE_EXAMPLE),
+        SecurityLabelExample.OKAY);
+    project.set(ratingValue);
+
+    Optional<RatingValue> something = cache.cachedRatingValueFor(project);
+    assertFalse(something.isPresent());
+
+    cache.add(project);
+
+    something = cache.cachedRatingValueFor(project);
+    assertTrue(something.isPresent());
+  }
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectFinderTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectFinderTest.java
@@ -98,6 +98,26 @@ public class GitHubProjectFinderTest {
         hasItem(new GitHubProject(new GitHubOrganization(eclipse), "extra")));
   }
 
+  @Test
+  public void noOrganizations() throws IOException {
+    ConfigParser parser = new ConfigParser();
+    final String resource = "NoOrganizationsProjectFinderConfig.yml";
+    try (InputStream is = getClass().getResourceAsStream(resource)) {
+      Config config = parser.parse(is);
+      assertNotNull(config);
+      assertNotNull(config.organizationConfigs);
+      assertEquals(0, config.organizationConfigs.size());
+      assertNotNull(config.projectConfigs);
+      assertEquals(2, config.projectConfigs.size());
+      assertThat(
+          config.projectConfigs,
+          hasItem(new ProjectConfig("FasterXML", "jackson-databind")));
+      assertThat(
+          config.projectConfigs,
+          hasItem(new ProjectConfig("FasterXML", "jackson-dataformat-xml")));
+    }
+  }
+
   private static GHRepository mockRepository(String name) {
     GHRepository repository = mock(GHRepository.class);
     when(repository.getName()).thenReturn(name);

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectTest.java
@@ -1,0 +1,34 @@
+package com.sap.sgs.phosphor.fosstars.tool.github;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.sgs.phosphor.fosstars.model.rating.example.SecurityRatingExample.SecurityLabelExample;
+import com.sap.sgs.phosphor.fosstars.model.score.example.ExampleScores;
+import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
+import java.io.IOException;
+import org.junit.Test;
+
+public class GitHubProjectTest {
+
+  @Test
+  public void serializeAndDeserialize() throws IOException {
+    GitHubOrganization apache = new GitHubOrganization("apache");
+    GitHubProject project = new GitHubProject(apache, "nifi");
+    project.set(
+        new RatingValue(
+            new ScoreValue(ExampleScores.SECURITY_SCORE_EXAMPLE),
+            SecurityLabelExample.OKAY));
+    ObjectMapper mapper = new ObjectMapper();
+    byte[] bytes = mapper.writeValueAsBytes(project);
+    assertNotNull(bytes);
+    assertTrue(bytes.length > 0);
+    GitHubProject clone = mapper.readValue(bytes, GitHubProject.class);
+    assertNotNull(clone);
+    assertEquals(project, clone);
+    assertEquals(project.hashCode(), clone.hashCode());
+  }
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculatorTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculatorTest.java
@@ -32,29 +32,38 @@ public class SecurityRatingCalculatorTest {
     final String filename = "ValidSecurityRatingCalculatorConfig.yml";
     try (InputStream is = getClass().getResourceAsStream(filename)) {
       SecurityRatingCalculator.Config mainConfig = SecurityRatingCalculator.config(is);
-      GitHubProjectFinder.Config finderConfig = mainConfig.finderConfig;
-      assertNotNull(finderConfig);
-      assertNotNull(finderConfig);
-      assertNotNull(finderConfig.organizationConfigs);
-      assertEquals(3, finderConfig.organizationConfigs.size());
+
+      assertEquals(".fosstars_model/project_rating_cache.json", mainConfig.cacheFilename);
+
+      assertNotNull(mainConfig.reportConfig);
+      assertEquals("markdown", mainConfig.reportConfig.type);
+      assertEquals(".fosstars_model/report", mainConfig.reportConfig.where);
+
+      assertNotNull(mainConfig.finderConfig);
+      assertNotNull(mainConfig.finderConfig.organizationConfigs);
+      assertEquals(3, mainConfig.finderConfig.organizationConfigs.size());
       assertThat(
-          finderConfig.organizationConfigs,
+          mainConfig.finderConfig.organizationConfigs,
           hasItem(
               new OrganizationConfig("apache", Arrays.asList("incubator", "incubating"))));
-      assertThat(finderConfig.organizationConfigs,
+      assertThat(
+          mainConfig.finderConfig.organizationConfigs,
           hasItem(
               new OrganizationConfig("eclipse", Collections.singletonList("incubator"))));
-      assertThat(finderConfig.organizationConfigs,
+      assertThat(
+          mainConfig.finderConfig.organizationConfigs,
           hasItem(
               new OrganizationConfig("spring-projects", EMPTY_EXCLUDE_LIST)));
-      assertNotNull(finderConfig.projectConfigs);
-      assertEquals(2, finderConfig.projectConfigs.size());
+      assertNotNull(mainConfig.finderConfig.projectConfigs);
+      assertEquals(2, mainConfig.finderConfig.projectConfigs.size());
       assertThat(
-          finderConfig.projectConfigs,
-          hasItem(new ProjectConfig("FasterXML", "jackson-databind")));
+          mainConfig.finderConfig.projectConfigs,
+          hasItem(
+              new ProjectConfig("FasterXML", "jackson-databind")));
       assertThat(
-          finderConfig.projectConfigs,
-          hasItem(new ProjectConfig("FasterXML", "jackson-dataformat-xml")));
+          mainConfig.finderConfig.projectConfigs,
+          hasItem(
+              new ProjectConfig("FasterXML", "jackson-dataformat-xml")));
     }
   }
 

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculatorTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculatorTest.java
@@ -5,9 +5,11 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProjectFinder.OrganizationConfig;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProjectFinder.ProjectConfig;
+import com.sap.sgs.phosphor.fosstars.tool.github.SecurityRatingCalculator.ReportConfig;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -35,9 +37,23 @@ public class SecurityRatingCalculatorTest {
 
       assertEquals(".fosstars_model/project_rating_cache.json", mainConfig.cacheFilename);
 
-      assertNotNull(mainConfig.reportConfig);
-      assertEquals("markdown", mainConfig.reportConfig.type);
-      assertEquals(".fosstars_model/report", mainConfig.reportConfig.where);
+      assertNotNull(mainConfig.reportConfigs);
+      assertEquals(2, mainConfig.reportConfigs.size());
+
+      for (ReportConfig reportConfig : mainConfig.reportConfigs) {
+        assertNotNull(reportConfig.type);
+        switch (reportConfig.type) {
+          case MARKDOWN:
+            assertEquals(".fosstars_model/report", reportConfig.where);
+            assertEquals(".fosstars_model/report/github_projects.json", reportConfig.source);
+            break;
+          case JSON:
+            assertEquals(".fosstars_model/report/github_projects.json", reportConfig.where);
+            break;
+          default:
+            fail("Unexpected report type: " + reportConfig.type);
+        }
+      }
 
       assertNotNull(mainConfig.finderConfig);
       assertNotNull(mainConfig.finderConfig.organizationConfigs);

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/tool/github/NoOrganizationsProjectFinderConfig.yml
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/tool/github/NoOrganizationsProjectFinderConfig.yml
@@ -1,0 +1,6 @@
+# this is a test configuration for the ConfigParser class
+repositories:
+  - organization: FasterXML
+    name: jackson-databind
+  - organization: FasterXML
+    name: jackson-dataformat-xml

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/tool/github/TestProjectRatingCache.json
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/tool/github/TestProjectRatingCache.json
@@ -1,0 +1,8248 @@
+{
+  "cache" : {
+    "https://github.com/netty/netty" : {
+      "organization" : {
+        "name" : "netty"
+      },
+      "name" : "netty",
+      "url" : "https://github.com/netty/netty",
+      "ratingValue" : {
+        "scoreValue" : {
+          "type" : "ScoreValue",
+          "score" : {
+            "type" : "OssSecurityScore",
+            "name" : "Security score for open-source projects",
+            "weightedScores" : [ {
+              "score" : {
+                "type" : "ProjectSecurityTestingScore",
+                "name" : "How well security testing is done for an open-source project",
+                "subScores" : [ {
+                  "type" : "DependencyScanScore",
+                  "name" : "How a project scans its dependencies for vulnerabilities"
+                }, {
+                  "type" : "LgtmScore",
+                  "name" : "How a project addresses issues reported by LGTM"
+                } ]
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.6283118906878548
+              }
+            }, {
+              "score" : {
+                "type" : "UnpatchedVulnerabilitiesScore",
+                "name" : "How well vulnerabilities are patched"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.8362090433439393
+              }
+            }, {
+              "score" : {
+                "type" : "ProjectActivityScore",
+                "name" : "Open-source project activity score"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.6300785405632551
+              }
+            }, {
+              "score" : {
+                "type" : "CommunityCommitmentScore",
+                "name" : "How well open-source community commits to support an open-source project"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.5529742430404292
+              }
+            }, {
+              "score" : {
+                "type" : "ProjectSecurityAwarenessScore",
+                "name" : "How well open-source community is aware about security"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.5383270608555468
+              }
+            }, {
+              "score" : {
+                "type" : "VulnerabilityLifetimeScore",
+                "name" : "How fast vulnerabilities are patched"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.22939855566110368
+              }
+            }, {
+              "score" : {
+                "type" : "ProjectPopularityScore",
+                "name" : "Open-source project popularity score"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.30515788031015273
+              }
+            } ]
+          },
+          "value" : 4.559066854685342,
+          "weight" : 1.0,
+          "confidence" : 8.673285914850164,
+          "usedValues" : [ {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "ProjectSecurityTestingScore",
+              "name" : "How well security testing is done for an open-source project",
+              "subScores" : [ {
+                "type" : "DependencyScanScore",
+                "name" : "How a project scans its dependencies for vulnerabilities"
+              }, {
+                "type" : "LgtmScore",
+                "name" : "How a project addresses issues reported by LGTM"
+              } ]
+            },
+            "value" : 2.0,
+            "weight" : 0.6283118906878548,
+            "confidence" : 5.0,
+            "usedValues" : [ {
+              "type" : "ScoreValue",
+              "score" : {
+                "type" : "DependencyScanScore",
+                "name" : "How a project scans its dependencies for vulnerabilities"
+              },
+              "value" : 0.0,
+              "weight" : 1.0,
+              "confidence" : 0.0,
+              "usedValues" : [ {
+                "type" : "UnknownValue",
+                "feature" : {
+                  "type" : "BooleanFeature",
+                  "name" : "If an open-source project is regularly scanned for vulnerable dependencies"
+                }
+              } ],
+              "explanation" : [ ]
+            }, {
+              "type" : "ScoreValue",
+              "score" : {
+                "type" : "LgtmScore",
+                "name" : "How a project addresses issues reported by LGTM"
+              },
+              "value" : 4.0,
+              "weight" : 1.0,
+              "confidence" : 10.0,
+              "usedValues" : [ {
+                "type" : "BooleanValue",
+                "feature" : {
+                  "type" : "BooleanFeature",
+                  "name" : "If a project uses LGTM"
+                },
+                "flag" : true
+              }, {
+                "type" : "LgtmGradeValue",
+                "feature" : {
+                  "type" : "LgtmGradeFeature",
+                  "name" : "The worst LGTM grade of a project"
+                },
+                "value" : "D"
+              } ],
+              "explanation" : [ ]
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "UnpatchedVulnerabilitiesScore",
+              "name" : "How well vulnerabilities are patched"
+            },
+            "value" : 10.0,
+            "weight" : 0.8362090433439393,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "VulnerabilitiesValue",
+              "vulnerabilities" : {
+                "entries" : [ {
+                  "id" : "CVE-2019-20445",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.4
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2020:0497",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0497"
+                  }, {
+                    "description" : "RHSA-2020:0567",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0567"
+                  }, {
+                    "description" : "RHSA-2020:0601",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0601"
+                  }, {
+                    "description" : "RHSA-2020:0605",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0605"
+                  }, {
+                    "description" : "RHSA-2020:0606",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0606"
+                  }, {
+                    "description" : "RHSA-2020:0804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0804"
+                  }, {
+                    "description" : "RHSA-2020:0805",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0805"
+                  }, {
+                    "description" : "RHSA-2020:0806",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0806"
+                  }, {
+                    "description" : "RHSA-2020:0811",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0811"
+                  }, {
+                    "description" : "https://github.com/netty/netty/compare/netty-4.1.43.Final...netty-4.1.44.Final",
+                    "url" : "https://github.com/netty/netty/compare/netty-4.1.43.Final...netty-4.1.44.Final"
+                  }, {
+                    "description" : "https://github.com/netty/netty/issues/9861",
+                    "url" : "https://github.com/netty/netty/issues/9861"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200209 [jira] [Updated] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r1fcccf8bdb3531c28bc9aa605a6a1bea7e68cef6fc12e01faafb2fb5@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r310d2ce22304d5298ff87f10134f918c87919b452734f9841d95682d@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r310d2ce22304d5298ff87f10134f918c87919b452734f9841d95682d@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Commented] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r36fcf538b28f2029e8b4f6b9a772f3b107913a78f09b095c5b153a62@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[spark-reviews] 20200310 [GitHub] [spark] dongjoon-hyun commented on issue #27870: [SPARK-31095][BUILD][2.4] Upgrade netty-all to 4.1.47.Final",
+                    "url" : "https://lists.apache.org/thread.html/r46f93de62b1e199f3f9babb18128681677c53493546f532ed88c359d@%3Creviews.spark.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200204 [jira] [Resolved] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r640eb9b3213058a963e18291f903fc1584e577f60035f941e32f760a@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200209 [jira] [Commented] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r6945f3c346b7af89bbd3526a7c9b705b1e3569070ebcd0964bcedd7d@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] zachjsh opened a new pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/r70b1ff22ee80e8101805b9a473116dd33265709007d2deb6f8c80bf2@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Assigned] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r804895eedd72c9ec67898286eb185e04df852b0dd5fe53cf5b6138f9@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200203 Re: [VOTE] Apache ZooKeeper release 3.6.0 candidate 1",
+                    "url" : "https://lists.apache.org/thread.html/r81700644754e66ffea465c869cb477de25f8041e21598e8818fc2c45@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r819aaeb9944bdcfca438dcc51f05650dc728daf64dfd7d774fc2499b@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r819aaeb9944bdcfca438dcc51f05650dc728daf64dfd7d774fc2499b@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20200218 [jira] [Created] (CASSANDRA-15590) Upgrade io.netty_netty-all dependency to fix security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/r959474dcf7f88565ed89f6252ca5a274419006cb71348f14764b183d@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200203 [jira] [Created] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r96e08f929234e8ba1ef4a93a0fd2870f535a1f9ab628fabc46115986@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r9b20cdac704cf9a583400350e2d5b576fa8417c18ddb961201676c60@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r9b20cdac704cf9a583400350e2d5b576fa8417c18ddb961201676c60@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Updated] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/ra2ace4bcb5cf487f72cbcbfa0f8cc08e755ec2b93d7e69f276148b08@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Created] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/ra9fbfe7d4830ae675bf34c7c0f8c22fc8a4099f65706c1bc4f54c593@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20200309 [jira] [Created] (SPARK-31095) Upgrade netty version to fix security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/rb5c065e7bd701b0744f9f28ad769943f91745102716c1eb516325f11@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rb84c57670ec48ef23f4d07973b7fa69f629b8e7fcfb48874362feb6f@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rb84c57670ec48ef23f4d07973b7fa69f629b8e7fcfb48874362feb6f@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rce71d33747010d32d31d90f5d737dae26291d96552f513a266c92fbb@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rce71d33747010d32d31d90f5d737dae26291d96552f513a266c92fbb@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] ccaominh commented on a change in pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/re45ee9256d3233c31d78e59ee59c7dc841c7fbd83d0769285b41e948@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rfb55f245b08d8a6ec0fb4dc159022227cd22de34c4419c2fbb18802b@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rfb55f245b08d8a6ec0fb4dc159022227cd22de34c4419c2fbb18802b@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] gianm merged pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/rff210a24f3a924829790e69eaefa84820902b7b31f17c3bf2def9114@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2109-1] netty security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00017.html"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2110-1] netty-3.9 security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-20444",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.4
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2020:0497",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0497"
+                  }, {
+                    "description" : "RHSA-2020:0567",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0567"
+                  }, {
+                    "description" : "RHSA-2020:0601",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0601"
+                  }, {
+                    "description" : "RHSA-2020:0605",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0605"
+                  }, {
+                    "description" : "RHSA-2020:0606",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0606"
+                  }, {
+                    "description" : "RHSA-2020:0804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0804"
+                  }, {
+                    "description" : "RHSA-2020:0805",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0805"
+                  }, {
+                    "description" : "RHSA-2020:0806",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0806"
+                  }, {
+                    "description" : "RHSA-2020:0811",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0811"
+                  }, {
+                    "description" : "https://github.com/netty/netty/compare/netty-4.1.43.Final...netty-4.1.44.Final",
+                    "url" : "https://github.com/netty/netty/compare/netty-4.1.43.Final...netty-4.1.44.Final"
+                  }, {
+                    "description" : "https://github.com/netty/netty/issues/9866",
+                    "url" : "https://github.com/netty/netty/issues/9866"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200204 Build failed in Jenkins: zookeeper-branch36-java8 #38",
+                    "url" : "https://lists.apache.org/thread.html/r059b042bca47be53ff8a51fd04d95eb01bb683f1afa209db136e8cb7@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200225 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r0c3d49bfdbc62fd3915676433cc5899c5506d06da1c552ef1b7923a5@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r0f5e72d5f69b4720dfe64fcbc2da9afae949ed1e9cbffa84bb7d92d7@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r0f5e72d5f69b4720dfe64fcbc2da9afae949ed1e9cbffa84bb7d92d7@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200209 [jira] [Updated] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r1fcccf8bdb3531c28bc9aa605a6a1bea7e68cef6fc12e01faafb2fb5@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r310d2ce22304d5298ff87f10134f918c87919b452734f9841d95682d@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r310d2ce22304d5298ff87f10134f918c87919b452734f9841d95682d@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200204 Build failed in Jenkins: zookeeper-master-maven-jdk11 #361",
+                    "url" : "https://lists.apache.org/thread.html/r34912a9b1a5c269a77b8be94ef6fb6d1e9b3c69129719dc00f01cf0b@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Commented] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r36fcf538b28f2029e8b4f6b9a772f3b107913a78f09b095c5b153a62@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200204 Build failed in Jenkins: zookeeper-branch36-java11 #39",
+                    "url" : "https://lists.apache.org/thread.html/r489886fe72a98768eed665474cba13bad8d6fe0654f24987706636c5@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r4c675b2d0cc2a5e506b11ee10d60a378859ee340aca052e4c7ef4749@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r4c675b2d0cc2a5e506b11ee10d60a378859ee340aca052e4c7ef4749@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200204 [jira] [Resolved] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r640eb9b3213058a963e18291f903fc1584e577f60035f941e32f760a@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200209 [jira] [Commented] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r6945f3c346b7af89bbd3526a7c9b705b1e3569070ebcd0964bcedd7d@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] zachjsh opened a new pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/r70b1ff22ee80e8101805b9a473116dd33265709007d2deb6f8c80bf2@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Assigned] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r804895eedd72c9ec67898286eb185e04df852b0dd5fe53cf5b6138f9@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r819aaeb9944bdcfca438dcc51f05650dc728daf64dfd7d774fc2499b@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r819aaeb9944bdcfca438dcc51f05650dc728daf64dfd7d774fc2499b@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200310 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r8402d67fdfe9cf169f859d52a7670b28a08eff31e54b522cc1432532@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-commits] 20200309 [hadoop] branch trunk updated: HADOOP-16871. Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444, CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r86befa74c5cd1482c711134104aec339bf7ae879f2c4437d7ec477d4@%3Ccommon-commits.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200219 [jira] [Updated] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r90030b0117490caed526e57271bf4d7f9b012091ac5083c895d16543@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r91e0fa345c86c128b75a4a791b4b503b53173ff4c13049ac7129d319@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r91e0fa345c86c128b75a4a791b4b503b53173ff4c13049ac7129d319@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20200218 [jira] [Created] (CASSANDRA-15590) Upgrade io.netty_netty-all dependency to fix security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/r959474dcf7f88565ed89f6252ca5a274419006cb71348f14764b183d@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200203 [jira] [Created] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r96e08f929234e8ba1ef4a93a0fd2870f535a1f9ab628fabc46115986@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r9b20cdac704cf9a583400350e2d5b576fa8417c18ddb961201676c60@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r9b20cdac704cf9a583400350e2d5b576fa8417c18ddb961201676c60@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Updated] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/ra2ace4bcb5cf487f72cbcbfa0f8cc08e755ec2b93d7e69f276148b08@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Created] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/ra9fbfe7d4830ae675bf34c7c0f8c22fc8a4099f65706c1bc4f54c593@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200309 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rb3361f6c6a5f834ad3db5e998c352760d393c0891b8d3bea90baa836@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rb84c57670ec48ef23f4d07973b7fa69f629b8e7fcfb48874362feb6f@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rb84c57670ec48ef23f4d07973b7fa69f629b8e7fcfb48874362feb6f@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200219 [jira] [Updated] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,",
+                    "url" : "https://lists.apache.org/thread.html/rc7eb5634b71d284483e58665b22bf274a69bd184d9bd7ede52015d91@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-commits] 20200309 [hadoop] branch branch-3.1 updated: HADOOP-16871. Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444, CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rcb2c59428f34d4757702f9ae739a8795bda7bea97b857e708a9c62c6@%3Ccommon-commits.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rce71d33747010d32d31d90f5d737dae26291d96552f513a266c92fbb@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rce71d33747010d32d31d90f5d737dae26291d96552f513a266c92fbb@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-commits] 20200309 [hadoop] branch branch-3.2 updated: HADOOP-16871. Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444, CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rdd5d243a5f8ed8b83c0104e321aa420e5e98792a95749e3c9a54c0b9@%3Ccommon-commits.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200219 [jira] [Assigned] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/re0b78a3d0a4ba2cf9f4e14e1d05040bde9051d5c78071177186336c9@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] ccaominh commented on a change in pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/re45ee9256d3233c31d78e59ee59c7dc841c7fbd83d0769285b41e948@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200224 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/re78eaef7d01ad65c370df30e45c686fffff00b37f7bfd78b26a08762@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200309 [jira] [Updated] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rf2bf8e2eb0a03227f5bc100b544113f8cafea01e887bb068e8d1fa41@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rfb55f245b08d8a6ec0fb4dc159022227cd22de34c4419c2fbb18802b@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rfb55f245b08d8a6ec0fb4dc159022227cd22de34c4419c2fbb18802b@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] gianm merged pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/rff210a24f3a924829790e69eaefa84820902b7b31f17c3bf2def9114@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2109-1] netty security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00017.html"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2110-1] netty-3.9 security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2014-0193",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.0
+                  },
+                  "references" : [ {
+                    "description" : "http://netty.io/news/2014/04/30/release-day.html",
+                    "url" : "http://netty.io/news/2014/04/30/release-day.html"
+                  }, {
+                    "description" : "RHSA-2014:1019",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2014-1019.html"
+                  }, {
+                    "description" : "RHSA-2014:1020",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2014-1020.html"
+                  }, {
+                    "description" : "RHSA-2014:1021",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2014-1021.html"
+                  }, {
+                    "description" : "RHSA-2014:1351",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2014-1351.html"
+                  }, {
+                    "description" : "RHSA-2015:0675",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2015-0675.html"
+                  }, {
+                    "description" : "RHSA-2015:0720",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2015-0720.html"
+                  }, {
+                    "description" : "RHSA-2015:0765",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2015-0765.html"
+                  }, {
+                    "description" : "58280",
+                    "url" : "http://secunia.com/advisories/58280"
+                  }, {
+                    "description" : "59290",
+                    "url" : "http://secunia.com/advisories/59290"
+                  }, {
+                    "description" : "67182",
+                    "url" : "http://www.securityfocus.com/bid/67182"
+                  }, {
+                    "description" : "https://github.com/netty/netty/issues/2441",
+                    "url" : "https://github.com/netty/netty/issues/2441"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2110-1] netty-3.9 security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2016-4970",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.8
+                  },
+                  "references" : [ {
+                    "description" : "http://netty.io/news/2016/06/07/4-0-37-Final.html",
+                    "url" : "http://netty.io/news/2016/06/07/4-0-37-Final.html"
+                  }, {
+                    "description" : "http://netty.io/news/2016/06/07/4-1-1-Final.html",
+                    "url" : "http://netty.io/news/2016/06/07/4-1-1-Final.html"
+                  }, {
+                    "description" : "RHSA-2017:0179",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2017-0179.html"
+                  }, {
+                    "description" : "RHSA-2017:1097",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2017-1097.html"
+                  }, {
+                    "description" : "96540",
+                    "url" : "http://www.securityfocus.com/bid/96540"
+                  }, {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1343616",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1343616"
+                  }, {
+                    "description" : "https://github.com/netty/netty/pull/5364",
+                    "url" : "https://github.com/netty/netty/pull/5364"
+                  }, {
+                    "description" : "[cassandra-commits] 20191112 [jira] [Created] (CASSANDRA-15412) Security vulnerability CVE-2016-4970 for Netty",
+                    "url" : "https://lists.apache.org/thread.html/afaa5860e3a6d327eb96c3d82cbd2f5996de815a16854ed1ad310144@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "https://wiki.opendaylight.org/view/Security_Advisories",
+                    "url" : "https://wiki.opendaylight.org/view/Security_Advisories"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2014-3488",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.0
+                  },
+                  "references" : [ {
+                    "description" : "http://netty.io/news/2014/06/11/3-9-2-Final.html",
+                    "url" : "http://netty.io/news/2014/06/11/3-9-2-Final.html"
+                  }, {
+                    "description" : "59196",
+                    "url" : "http://secunia.com/advisories/59196"
+                  }, {
+                    "description" : "https://github.com/netty/netty/commit/2fa9400a59d0563a66908aba55c41e7285a04994",
+                    "url" : "https://github.com/netty/netty/commit/2fa9400a59d0563a66908aba55c41e7285a04994"
+                  }, {
+                    "description" : "https://github.com/netty/netty/issues/2562",
+                    "url" : "https://github.com/netty/netty/issues/2562"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2110-1] netty-3.9 security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-7238",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.0
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2020:0497",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0497"
+                  }, {
+                    "description" : "RHSA-2020:0567",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0567"
+                  }, {
+                    "description" : "RHSA-2020:0601",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0601"
+                  }, {
+                    "description" : "RHSA-2020:0605",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0605"
+                  }, {
+                    "description" : "RHSA-2020:0606",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0606"
+                  }, {
+                    "description" : "RHSA-2020:0804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0804"
+                  }, {
+                    "description" : "RHSA-2020:0805",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0805"
+                  }, {
+                    "description" : "RHSA-2020:0806",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0806"
+                  }, {
+                    "description" : "RHSA-2020:0811",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0811"
+                  }, {
+                    "description" : "https://github.com/jdordonezn/CVE-2020-72381/issues/1",
+                    "url" : "https://github.com/jdordonezn/CVE-2020-72381/issues/1"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2109-1] netty security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00017.html"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2110-1] netty-3.9 security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html"
+                  }, {
+                    "description" : "https://netty.io/news/",
+                    "url" : "https://netty.io/news/"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-16869",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.0
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:3901",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+                  }, {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "https://github.com/netty/netty/compare/netty-4.1.41.Final...netty-4.1.42.Final",
+                    "url" : "https://github.com/netty/netty/compare/netty-4.1.41.Final...netty-4.1.42.Final"
+                  }, {
+                    "description" : "https://github.com/netty/netty/issues/9571",
+                    "url" : "https://github.com/netty/netty/issues/9571"
+                  }, {
+                    "description" : "[spark-issues] 20191219 [jira] [Commented] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/0acadfb96176768caac79b404110df62d14d30aa9d53b6dbdb1407ac@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191206 [jira] [Assigned] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/19fed892608db1efe5a5ce14372137669ff639df0205323959af7de3@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20190930 [jira] [Created] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - netty-3.10.6.Final.jar: CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/2494a2ac7f66af6e4646a4937b17972a4ec7cd3c7333c66ffd6c639d@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20191003 [jira] [Commented] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/2e1cf538b502713c2c42ffa46d81f4688edb5676eb55bd9fc4b4fed7@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191227 [jira] [Commented] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/35961d1ae00849974353a932b4fef12ebce074541552eceefa04f1fd@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20191001 [jira] [Commented] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/37ed432b8eb35d8bd757f53783ec3e334bd51f514534432bea7f1c3d@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20191003 [zookeeper] branch branch-3.5 updated: ZOOKEEPER-3563: Update Netty to fix CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/380f6d2730603a2cd6b0a8bea9bcb21a86c199147e77e448c5f7390b@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20191001 Re: [VOTE] Apache ZooKeeper release 3.5.6 candidate 2",
+                    "url" : "https://lists.apache.org/thread.html/3e6d7aae1cca10257e3caf2d69b22f74c875f12a1314155af422569d@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191220 [jira] [Resolved] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/51923a9ba513b2e816e02a9d1fd8aa6f12e3e4e99bbd9dc884bccbbe@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191206 [jira] [Updated] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/6063699b87b501ecca8dd3b0e82251bfc85f29363a9b46ac5ace80cf@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191220 [jira] [Commented] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/64b10f49c68333aaecf00348c5670fe182e49fd60d45c4a3ab241f8b@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191220 [jira] [Issue Comment Deleted] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/681493a2f9b63f5b468f741d88d1aa51b2cfcf7a1c5b74ea8c4343fb@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190930 [jira] [Updated] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - netty with CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/6e1e34c0d5635a987d595df9e532edac212307243bb1b49eead6d55b@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190930 [jira] [Updated] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/76540c8b0ed761bfa6c81fa28c13057f13a5448aed079d656f6a3c79@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191220 [jira] [Comment Edited] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/799eb85d67cbddc1851a3e63a07b55e95b2f44f1685225d38570ce89@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191219 [jira] [Created] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/860acce024d79837e963a51a42bab2cef8e8d017aad2b455ecd1dcf0@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190930 [jira] [Created] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - netty-3.10.6.Final.jar: CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/9128111213b7b734ffc85db08d8f789b00a85a7f241b708e55debbd0@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20191115 [GitHub] [incubator-druid] ccaominh opened a new pull request #8878: Address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/9317fd092b257a0815434b116a8af8daea6e920b6673f4fd5583d5fe@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20191008 [jira] [Resolved] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/a0f77c73af32cbe4ff0968bfcbbe80ae6361f3dccdd46f3177547266@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191206 [jira] [Commented] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/af6e9c2d716868606523857a4cd7a5ee506e6d1710f5fb0d567ec030@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191206 [jira] [Resolved] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/b264fa5801e87698e9f43f2b5585fbc5ebdc26c6f4aad861b258fb69@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20191008 [jira] [Commented] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/b2cd51795f938632c6f60a4c59d9e587fbacd7f7d0e0a3684850a30f@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191209 [jira] [Commented] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/b3dda6399a0ea2b647624b899fd330fca81834e41b13e3e11e1002d8@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191220 [jira] [Reopened] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/b3ddeebbfaf8a288d7de8ab2611cf2609ab76b9809f0633248546b7c@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20191002 Re: [VOTE] Apache ZooKeeper release 3.5.6 candidate 2",
+                    "url" : "https://lists.apache.org/thread.html/bdf7a5e597346a75d2d884ca48c767525e35137ad59d8f10b8fc943c@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20191003 [zookeeper] branch branch-3.5.6 updated: ZOOKEEPER-3563: Update Netty to fix CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/cbf6e6a04cb37e9320ad20e437df63beeab1755fc0761918ed5c5a6e@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20191003 [zookeeper] branch master updated: ZOOKEEPER-3563: Update Netty to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/cf5aa087632ead838f8ac3a42e9837684e7afe6e0fcb7704e0c73bc0@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20191113 [jira] [Created] (CASSANDRA-15417) CVE-2019-16869(Netty is vulnerable to HTTP Request Smuggling) of severity 7.5",
+                    "url" : "https://lists.apache.org/thread.html/d14f721e0099b914daebe29bca199fde85d8354253be9d6d3d46507a@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190930 [jira] [Commented] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/d3eb0dbea75ef5c400bd49dfa1901ad50be606cca3cb29e0d01b6a54@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191206 [jira] [Created] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/d7d530599dc7813056c712213e367b68cdf56fb5c9b73f864870bc4c@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[tinkerpop-commits] 20191022 [tinkerpop] branch tp34 updated: Bump to Netty 4.1.42 fixes CVE-2019-16869 - CTR",
+                    "url" : "https://lists.apache.org/thread.html/e192fe8797c192679759ffa6b15e4d0806546945a41d8ebfbc6ee3ac@%3Ccommits.tinkerpop.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20190930 Re: [VOTE] Apache ZooKeeper release 3.5.6 candidate 2",
+                    "url" : "https://lists.apache.org/thread.html/e39931d7cdd17241e69a0a09a89d99d7435bcc59afee8a9628d67769@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191219 [jira] [Updated] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/ee6faea9e542c0b90afd70297a9daa203e20d41aa2ac7fca6703662f@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20191113 [jira] [Created] (CASSANDRA-15418) CVE-2019-16869(Netty is vulnerable to HTTP Request Smuggling) of severity 7.5 for Cassendra 2.2.5",
+                    "url" : "https://lists.apache.org/thread.html/f6c5ebfb018787c764f000362d59e4b231c0a36b6253aa866de8c64e@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200225 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r0c3d49bfdbc62fd3915676433cc5899c5506d06da1c552ef1b7923a5@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200310 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r8402d67fdfe9cf169f859d52a7670b28a08eff31e54b522cc1432532@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-commits] 20200309 [hadoop] branch trunk updated: HADOOP-16871. Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444, CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r86befa74c5cd1482c711134104aec339bf7ae879f2c4437d7ec477d4@%3Ccommon-commits.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200219 [jira] [Updated] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r90030b0117490caed526e57271bf4d7f9b012091ac5083c895d16543@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20200218 [jira] [Created] (CASSANDRA-15590) Upgrade io.netty_netty-all dependency to fix security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/r959474dcf7f88565ed89f6252ca5a274419006cb71348f14764b183d@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200309 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rb3361f6c6a5f834ad3db5e998c352760d393c0891b8d3bea90baa836@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200219 [jira] [Updated] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,",
+                    "url" : "https://lists.apache.org/thread.html/rc7eb5634b71d284483e58665b22bf274a69bd184d9bd7ede52015d91@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-commits] 20200309 [hadoop] branch branch-3.1 updated: HADOOP-16871. Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444, CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rcb2c59428f34d4757702f9ae739a8795bda7bea97b857e708a9c62c6@%3Ccommon-commits.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-commits] 20200309 [hadoop] branch branch-3.2 updated: HADOOP-16871. Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444, CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rdd5d243a5f8ed8b83c0104e321aa420e5e98792a95749e3c9a54c0b9@%3Ccommon-commits.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200219 [jira] [Assigned] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/re0b78a3d0a4ba2cf9f4e14e1d05040bde9051d5c78071177186336c9@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] ccaominh commented on a change in pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/re45ee9256d3233c31d78e59ee59c7dc841c7fbd83d0769285b41e948@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200224 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/re78eaef7d01ad65c370df30e45c686fffff00b37f7bfd78b26a08762@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200309 [jira] [Updated] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rf2bf8e2eb0a03227f5bc100b544113f8cafea01e887bb068e8d1fa41@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190930 [SECURITY] [DLA 1941-1] netty security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/09/msg00035.html"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2110-1] netty-3.9 security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html"
+                  }, {
+                    "description" : "20200105 [SECURITY] [DSA 4597-1] netty security update",
+                    "url" : "https://seclists.org/bugtraq/2020/Jan/6"
+                  }, {
+                    "description" : "DSA-4597",
+                    "url" : "https://www.debian.org/security/2020/dsa-4597"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2015-2156",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 4.3
+                  },
+                  "references" : [ {
+                    "description" : "FEDORA-2015-8713",
+                    "url" : "http://lists.fedoraproject.org/pipermail/package-announce/2015-June/159379.html"
+                  }, {
+                    "description" : "FEDORA-2015-8684",
+                    "url" : "http://lists.fedoraproject.org/pipermail/package-announce/2015-May/159166.html"
+                  }, {
+                    "description" : "http://netty.io/news/2015/05/08/3-9-8-Final-and-3.html",
+                    "url" : "http://netty.io/news/2015/05/08/3-9-8-Final-and-3.html"
+                  }, {
+                    "description" : "[oss-security] 20150516 Netty/Play's Security Updates (CVE-2015-2156)",
+                    "url" : "http://www.openwall.com/lists/oss-security/2015/05/17/1"
+                  }, {
+                    "description" : "74704",
+                    "url" : "http://www.securityfocus.com/bid/74704"
+                  }, {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1222923",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1222923"
+                  }, {
+                    "description" : "https://github.com/netty/netty/pull/3754",
+                    "url" : "https://github.com/netty/netty/pull/3754"
+                  }, {
+                    "description" : "[druid-commits] 20191115 [GitHub] [incubator-druid] ccaominh opened a new pull request #8878: Address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/9317fd092b257a0815434b116a8af8daea6e920b6673f4fd5583d5fe@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20191113 [jira] [Created] (CASSANDRA-15423) CVE-2015-2156 (Netty is vulnerable to Information Disclosure)",
+                    "url" : "https://lists.apache.org/thread.html/a19bb1003b0d6cd22475ba83c019b4fc7facfef2a9e13f71132529d3@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20191114 [jira] [Commented] (CASSANDRA-15423) CVE-2015-2156 (Netty is vulnerable to Information Disclosure)",
+                    "url" : "https://lists.apache.org/thread.html/dc1275aef115bda172851a231c76c0932d973f9ffd8bc375c4aba769@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "https://www.playframework.com/security/vulnerability/CVE-2015-2156-HttpOnlyBypass",
+                    "url" : "https://www.playframework.com/security/vulnerability/CVE-2015-2156-HttpOnlyBypass"
+                  } ],
+                  "resolution" : "PATCHED"
+                } ]
+              },
+              "feature" : {
+                "type" : "VulnerabilitiesInProject",
+                "name" : "Info about vulnerabilities in open-source project"
+              }
+            } ],
+            "explanation" : [ "No unpatched vulnerabilities found which is good" ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "ProjectActivityScore",
+              "name" : "Open-source project activity score"
+            },
+            "value" : 6.811087628816771,
+            "weight" : 0.6300785405632551,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "ExpiringValue",
+              "value" : {
+                "type" : "IntegerValue",
+                "feature" : {
+                  "type" : "PositiveIntegerFeature",
+                  "name" : "Number of commits in the last three months"
+                },
+                "number" : 109
+              },
+              "expiration" : 1585306256265
+            }, {
+              "type" : "ExpiringValue",
+              "value" : {
+                "type" : "IntegerValue",
+                "feature" : {
+                  "type" : "PositiveIntegerFeature",
+                  "name" : "Number of contributors in the last three months"
+                },
+                "number" : 35
+              },
+              "expiration" : 1585306264817
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "CommunityCommitmentScore",
+              "name" : "How well open-source community commits to support an open-source project"
+            },
+            "value" : 0.0,
+            "weight" : 0.5529742430404292,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "BooleanValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project is supported by a company"
+              },
+              "flag" : false
+            }, {
+              "type" : "BooleanValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project belongs to Apache Foundation"
+              },
+              "flag" : false
+            }, {
+              "type" : "BooleanValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project belongs to Eclipse Foundation"
+              },
+              "flag" : false
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "ProjectSecurityAwarenessScore",
+              "name" : "How well open-source community is aware about security"
+            },
+            "value" : 0.0,
+            "weight" : 0.5383270608555468,
+            "confidence" : 6.666666666666667,
+            "usedValues" : [ {
+              "type" : "BooleanValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project has a security policy"
+              },
+              "flag" : false
+            }, {
+              "type" : "UnknownValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project has a security team"
+              }
+            }, {
+              "type" : "ExpiringValue",
+              "value" : {
+                "type" : "BooleanValue",
+                "feature" : {
+                  "type" : "BooleanFeature",
+                  "name" : "If a project uses verified signed commits"
+                },
+                "flag" : false
+              },
+              "expiration" : 1585306296141
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "VulnerabilityLifetimeScore",
+              "name" : "How fast vulnerabilities are patched"
+            },
+            "value" : 0.0,
+            "weight" : 0.22939855566110368,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "VulnerabilitiesValue",
+              "vulnerabilities" : {
+                "entries" : [ {
+                  "id" : "CVE-2019-20445",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.4
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2020:0497",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0497"
+                  }, {
+                    "description" : "RHSA-2020:0567",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0567"
+                  }, {
+                    "description" : "RHSA-2020:0601",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0601"
+                  }, {
+                    "description" : "RHSA-2020:0605",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0605"
+                  }, {
+                    "description" : "RHSA-2020:0606",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0606"
+                  }, {
+                    "description" : "RHSA-2020:0804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0804"
+                  }, {
+                    "description" : "RHSA-2020:0805",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0805"
+                  }, {
+                    "description" : "RHSA-2020:0806",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0806"
+                  }, {
+                    "description" : "RHSA-2020:0811",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0811"
+                  }, {
+                    "description" : "https://github.com/netty/netty/compare/netty-4.1.43.Final...netty-4.1.44.Final",
+                    "url" : "https://github.com/netty/netty/compare/netty-4.1.43.Final...netty-4.1.44.Final"
+                  }, {
+                    "description" : "https://github.com/netty/netty/issues/9861",
+                    "url" : "https://github.com/netty/netty/issues/9861"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200209 [jira] [Updated] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r1fcccf8bdb3531c28bc9aa605a6a1bea7e68cef6fc12e01faafb2fb5@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r310d2ce22304d5298ff87f10134f918c87919b452734f9841d95682d@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r310d2ce22304d5298ff87f10134f918c87919b452734f9841d95682d@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Commented] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r36fcf538b28f2029e8b4f6b9a772f3b107913a78f09b095c5b153a62@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[spark-reviews] 20200310 [GitHub] [spark] dongjoon-hyun commented on issue #27870: [SPARK-31095][BUILD][2.4] Upgrade netty-all to 4.1.47.Final",
+                    "url" : "https://lists.apache.org/thread.html/r46f93de62b1e199f3f9babb18128681677c53493546f532ed88c359d@%3Creviews.spark.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200204 [jira] [Resolved] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r640eb9b3213058a963e18291f903fc1584e577f60035f941e32f760a@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200209 [jira] [Commented] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r6945f3c346b7af89bbd3526a7c9b705b1e3569070ebcd0964bcedd7d@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] zachjsh opened a new pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/r70b1ff22ee80e8101805b9a473116dd33265709007d2deb6f8c80bf2@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Assigned] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r804895eedd72c9ec67898286eb185e04df852b0dd5fe53cf5b6138f9@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200203 Re: [VOTE] Apache ZooKeeper release 3.6.0 candidate 1",
+                    "url" : "https://lists.apache.org/thread.html/r81700644754e66ffea465c869cb477de25f8041e21598e8818fc2c45@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r819aaeb9944bdcfca438dcc51f05650dc728daf64dfd7d774fc2499b@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r819aaeb9944bdcfca438dcc51f05650dc728daf64dfd7d774fc2499b@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20200218 [jira] [Created] (CASSANDRA-15590) Upgrade io.netty_netty-all dependency to fix security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/r959474dcf7f88565ed89f6252ca5a274419006cb71348f14764b183d@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200203 [jira] [Created] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r96e08f929234e8ba1ef4a93a0fd2870f535a1f9ab628fabc46115986@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r9b20cdac704cf9a583400350e2d5b576fa8417c18ddb961201676c60@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r9b20cdac704cf9a583400350e2d5b576fa8417c18ddb961201676c60@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Updated] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/ra2ace4bcb5cf487f72cbcbfa0f8cc08e755ec2b93d7e69f276148b08@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Created] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/ra9fbfe7d4830ae675bf34c7c0f8c22fc8a4099f65706c1bc4f54c593@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20200309 [jira] [Created] (SPARK-31095) Upgrade netty version to fix security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/rb5c065e7bd701b0744f9f28ad769943f91745102716c1eb516325f11@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rb84c57670ec48ef23f4d07973b7fa69f629b8e7fcfb48874362feb6f@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rb84c57670ec48ef23f4d07973b7fa69f629b8e7fcfb48874362feb6f@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rce71d33747010d32d31d90f5d737dae26291d96552f513a266c92fbb@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rce71d33747010d32d31d90f5d737dae26291d96552f513a266c92fbb@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] ccaominh commented on a change in pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/re45ee9256d3233c31d78e59ee59c7dc841c7fbd83d0769285b41e948@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rfb55f245b08d8a6ec0fb4dc159022227cd22de34c4419c2fbb18802b@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rfb55f245b08d8a6ec0fb4dc159022227cd22de34c4419c2fbb18802b@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] gianm merged pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/rff210a24f3a924829790e69eaefa84820902b7b31f17c3bf2def9114@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2109-1] netty security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00017.html"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2110-1] netty-3.9 security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-20444",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.4
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2020:0497",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0497"
+                  }, {
+                    "description" : "RHSA-2020:0567",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0567"
+                  }, {
+                    "description" : "RHSA-2020:0601",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0601"
+                  }, {
+                    "description" : "RHSA-2020:0605",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0605"
+                  }, {
+                    "description" : "RHSA-2020:0606",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0606"
+                  }, {
+                    "description" : "RHSA-2020:0804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0804"
+                  }, {
+                    "description" : "RHSA-2020:0805",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0805"
+                  }, {
+                    "description" : "RHSA-2020:0806",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0806"
+                  }, {
+                    "description" : "RHSA-2020:0811",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0811"
+                  }, {
+                    "description" : "https://github.com/netty/netty/compare/netty-4.1.43.Final...netty-4.1.44.Final",
+                    "url" : "https://github.com/netty/netty/compare/netty-4.1.43.Final...netty-4.1.44.Final"
+                  }, {
+                    "description" : "https://github.com/netty/netty/issues/9866",
+                    "url" : "https://github.com/netty/netty/issues/9866"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200204 Build failed in Jenkins: zookeeper-branch36-java8 #38",
+                    "url" : "https://lists.apache.org/thread.html/r059b042bca47be53ff8a51fd04d95eb01bb683f1afa209db136e8cb7@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200225 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r0c3d49bfdbc62fd3915676433cc5899c5506d06da1c552ef1b7923a5@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r0f5e72d5f69b4720dfe64fcbc2da9afae949ed1e9cbffa84bb7d92d7@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r0f5e72d5f69b4720dfe64fcbc2da9afae949ed1e9cbffa84bb7d92d7@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200209 [jira] [Updated] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r1fcccf8bdb3531c28bc9aa605a6a1bea7e68cef6fc12e01faafb2fb5@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r310d2ce22304d5298ff87f10134f918c87919b452734f9841d95682d@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r310d2ce22304d5298ff87f10134f918c87919b452734f9841d95682d@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200204 Build failed in Jenkins: zookeeper-master-maven-jdk11 #361",
+                    "url" : "https://lists.apache.org/thread.html/r34912a9b1a5c269a77b8be94ef6fb6d1e9b3c69129719dc00f01cf0b@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Commented] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r36fcf538b28f2029e8b4f6b9a772f3b107913a78f09b095c5b153a62@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200204 Build failed in Jenkins: zookeeper-branch36-java11 #39",
+                    "url" : "https://lists.apache.org/thread.html/r489886fe72a98768eed665474cba13bad8d6fe0654f24987706636c5@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r4c675b2d0cc2a5e506b11ee10d60a378859ee340aca052e4c7ef4749@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r4c675b2d0cc2a5e506b11ee10d60a378859ee340aca052e4c7ef4749@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200204 [jira] [Resolved] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r640eb9b3213058a963e18291f903fc1584e577f60035f941e32f760a@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200209 [jira] [Commented] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r6945f3c346b7af89bbd3526a7c9b705b1e3569070ebcd0964bcedd7d@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] zachjsh opened a new pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/r70b1ff22ee80e8101805b9a473116dd33265709007d2deb6f8c80bf2@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Assigned] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r804895eedd72c9ec67898286eb185e04df852b0dd5fe53cf5b6138f9@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r819aaeb9944bdcfca438dcc51f05650dc728daf64dfd7d774fc2499b@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r819aaeb9944bdcfca438dcc51f05650dc728daf64dfd7d774fc2499b@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200310 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r8402d67fdfe9cf169f859d52a7670b28a08eff31e54b522cc1432532@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-commits] 20200309 [hadoop] branch trunk updated: HADOOP-16871. Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444, CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r86befa74c5cd1482c711134104aec339bf7ae879f2c4437d7ec477d4@%3Ccommon-commits.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200219 [jira] [Updated] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r90030b0117490caed526e57271bf4d7f9b012091ac5083c895d16543@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r91e0fa345c86c128b75a4a791b4b503b53173ff4c13049ac7129d319@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r91e0fa345c86c128b75a4a791b4b503b53173ff4c13049ac7129d319@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20200218 [jira] [Created] (CASSANDRA-15590) Upgrade io.netty_netty-all dependency to fix security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/r959474dcf7f88565ed89f6252ca5a274419006cb71348f14764b183d@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200203 [jira] [Created] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/r96e08f929234e8ba1ef4a93a0fd2870f535a1f9ab628fabc46115986@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r9b20cdac704cf9a583400350e2d5b576fa8417c18ddb961201676c60@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r9b20cdac704cf9a583400350e2d5b576fa8417c18ddb961201676c60@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Updated] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/ra2ace4bcb5cf487f72cbcbfa0f8cc08e755ec2b93d7e69f276148b08@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200203 [jira] [Created] (ZOOKEEPER-3716) upgrade netty 4.1.42 to address CVE-2019-20444 CVE-2019-20445",
+                    "url" : "https://lists.apache.org/thread.html/ra9fbfe7d4830ae675bf34c7c0f8c22fc8a4099f65706c1bc4f54c593@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200309 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rb3361f6c6a5f834ad3db5e998c352760d393c0891b8d3bea90baa836@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rb84c57670ec48ef23f4d07973b7fa69f629b8e7fcfb48874362feb6f@%3Ccommits.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rb84c57670ec48ef23f4d07973b7fa69f629b8e7fcfb48874362feb6f@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200219 [jira] [Updated] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,",
+                    "url" : "https://lists.apache.org/thread.html/rc7eb5634b71d284483e58665b22bf274a69bd184d9bd7ede52015d91@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-commits] 20200309 [hadoop] branch branch-3.1 updated: HADOOP-16871. Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444, CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rcb2c59428f34d4757702f9ae739a8795bda7bea97b857e708a9c62c6@%3Ccommon-commits.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rce71d33747010d32d31d90f5d737dae26291d96552f513a266c92fbb@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rce71d33747010d32d31d90f5d737dae26291d96552f513a266c92fbb@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-commits] 20200309 [hadoop] branch branch-3.2 updated: HADOOP-16871. Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444, CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rdd5d243a5f8ed8b83c0104e321aa420e5e98792a95749e3c9a54c0b9@%3Ccommon-commits.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200219 [jira] [Assigned] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/re0b78a3d0a4ba2cf9f4e14e1d05040bde9051d5c78071177186336c9@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] ccaominh commented on a change in pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/re45ee9256d3233c31d78e59ee59c7dc841c7fbd83d0769285b41e948@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200224 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/re78eaef7d01ad65c370df30e45c686fffff00b37f7bfd78b26a08762@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200309 [jira] [Updated] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rf2bf8e2eb0a03227f5bc100b544113f8cafea01e887bb068e8d1fa41@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rfb55f245b08d8a6ec0fb4dc159022227cd22de34c4419c2fbb18802b@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rfb55f245b08d8a6ec0fb4dc159022227cd22de34c4419c2fbb18802b@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] gianm merged pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/rff210a24f3a924829790e69eaefa84820902b7b31f17c3bf2def9114@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2109-1] netty security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00017.html"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2110-1] netty-3.9 security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2014-0193",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.0
+                  },
+                  "references" : [ {
+                    "description" : "http://netty.io/news/2014/04/30/release-day.html",
+                    "url" : "http://netty.io/news/2014/04/30/release-day.html"
+                  }, {
+                    "description" : "RHSA-2014:1019",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2014-1019.html"
+                  }, {
+                    "description" : "RHSA-2014:1020",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2014-1020.html"
+                  }, {
+                    "description" : "RHSA-2014:1021",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2014-1021.html"
+                  }, {
+                    "description" : "RHSA-2014:1351",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2014-1351.html"
+                  }, {
+                    "description" : "RHSA-2015:0675",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2015-0675.html"
+                  }, {
+                    "description" : "RHSA-2015:0720",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2015-0720.html"
+                  }, {
+                    "description" : "RHSA-2015:0765",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2015-0765.html"
+                  }, {
+                    "description" : "58280",
+                    "url" : "http://secunia.com/advisories/58280"
+                  }, {
+                    "description" : "59290",
+                    "url" : "http://secunia.com/advisories/59290"
+                  }, {
+                    "description" : "67182",
+                    "url" : "http://www.securityfocus.com/bid/67182"
+                  }, {
+                    "description" : "https://github.com/netty/netty/issues/2441",
+                    "url" : "https://github.com/netty/netty/issues/2441"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2110-1] netty-3.9 security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2016-4970",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.8
+                  },
+                  "references" : [ {
+                    "description" : "http://netty.io/news/2016/06/07/4-0-37-Final.html",
+                    "url" : "http://netty.io/news/2016/06/07/4-0-37-Final.html"
+                  }, {
+                    "description" : "http://netty.io/news/2016/06/07/4-1-1-Final.html",
+                    "url" : "http://netty.io/news/2016/06/07/4-1-1-Final.html"
+                  }, {
+                    "description" : "RHSA-2017:0179",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2017-0179.html"
+                  }, {
+                    "description" : "RHSA-2017:1097",
+                    "url" : "http://rhn.redhat.com/errata/RHSA-2017-1097.html"
+                  }, {
+                    "description" : "96540",
+                    "url" : "http://www.securityfocus.com/bid/96540"
+                  }, {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1343616",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1343616"
+                  }, {
+                    "description" : "https://github.com/netty/netty/pull/5364",
+                    "url" : "https://github.com/netty/netty/pull/5364"
+                  }, {
+                    "description" : "[cassandra-commits] 20191112 [jira] [Created] (CASSANDRA-15412) Security vulnerability CVE-2016-4970 for Netty",
+                    "url" : "https://lists.apache.org/thread.html/afaa5860e3a6d327eb96c3d82cbd2f5996de815a16854ed1ad310144@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "https://wiki.opendaylight.org/view/Security_Advisories",
+                    "url" : "https://wiki.opendaylight.org/view/Security_Advisories"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2014-3488",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.0
+                  },
+                  "references" : [ {
+                    "description" : "http://netty.io/news/2014/06/11/3-9-2-Final.html",
+                    "url" : "http://netty.io/news/2014/06/11/3-9-2-Final.html"
+                  }, {
+                    "description" : "59196",
+                    "url" : "http://secunia.com/advisories/59196"
+                  }, {
+                    "description" : "https://github.com/netty/netty/commit/2fa9400a59d0563a66908aba55c41e7285a04994",
+                    "url" : "https://github.com/netty/netty/commit/2fa9400a59d0563a66908aba55c41e7285a04994"
+                  }, {
+                    "description" : "https://github.com/netty/netty/issues/2562",
+                    "url" : "https://github.com/netty/netty/issues/2562"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2110-1] netty-3.9 security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-7238",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.0
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2020:0497",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0497"
+                  }, {
+                    "description" : "RHSA-2020:0567",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0567"
+                  }, {
+                    "description" : "RHSA-2020:0601",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0601"
+                  }, {
+                    "description" : "RHSA-2020:0605",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0605"
+                  }, {
+                    "description" : "RHSA-2020:0606",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0606"
+                  }, {
+                    "description" : "RHSA-2020:0804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0804"
+                  }, {
+                    "description" : "RHSA-2020:0805",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0805"
+                  }, {
+                    "description" : "RHSA-2020:0806",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0806"
+                  }, {
+                    "description" : "RHSA-2020:0811",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0811"
+                  }, {
+                    "description" : "https://github.com/jdordonezn/CVE-2020-72381/issues/1",
+                    "url" : "https://github.com/jdordonezn/CVE-2020-72381/issues/1"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2109-1] netty security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00017.html"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2110-1] netty-3.9 security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html"
+                  }, {
+                    "description" : "https://netty.io/news/",
+                    "url" : "https://netty.io/news/"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-16869",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.0
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:3901",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+                  }, {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "https://github.com/netty/netty/compare/netty-4.1.41.Final...netty-4.1.42.Final",
+                    "url" : "https://github.com/netty/netty/compare/netty-4.1.41.Final...netty-4.1.42.Final"
+                  }, {
+                    "description" : "https://github.com/netty/netty/issues/9571",
+                    "url" : "https://github.com/netty/netty/issues/9571"
+                  }, {
+                    "description" : "[spark-issues] 20191219 [jira] [Commented] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/0acadfb96176768caac79b404110df62d14d30aa9d53b6dbdb1407ac@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191206 [jira] [Assigned] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/19fed892608db1efe5a5ce14372137669ff639df0205323959af7de3@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20190930 [jira] [Created] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - netty-3.10.6.Final.jar: CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/2494a2ac7f66af6e4646a4937b17972a4ec7cd3c7333c66ffd6c639d@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20191003 [jira] [Commented] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/2e1cf538b502713c2c42ffa46d81f4688edb5676eb55bd9fc4b4fed7@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191227 [jira] [Commented] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/35961d1ae00849974353a932b4fef12ebce074541552eceefa04f1fd@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20191001 [jira] [Commented] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/37ed432b8eb35d8bd757f53783ec3e334bd51f514534432bea7f1c3d@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20191003 [zookeeper] branch branch-3.5 updated: ZOOKEEPER-3563: Update Netty to fix CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/380f6d2730603a2cd6b0a8bea9bcb21a86c199147e77e448c5f7390b@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20191001 Re: [VOTE] Apache ZooKeeper release 3.5.6 candidate 2",
+                    "url" : "https://lists.apache.org/thread.html/3e6d7aae1cca10257e3caf2d69b22f74c875f12a1314155af422569d@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191220 [jira] [Resolved] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/51923a9ba513b2e816e02a9d1fd8aa6f12e3e4e99bbd9dc884bccbbe@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191206 [jira] [Updated] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/6063699b87b501ecca8dd3b0e82251bfc85f29363a9b46ac5ace80cf@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191220 [jira] [Commented] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/64b10f49c68333aaecf00348c5670fe182e49fd60d45c4a3ab241f8b@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191220 [jira] [Issue Comment Deleted] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/681493a2f9b63f5b468f741d88d1aa51b2cfcf7a1c5b74ea8c4343fb@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190930 [jira] [Updated] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - netty with CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/6e1e34c0d5635a987d595df9e532edac212307243bb1b49eead6d55b@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190930 [jira] [Updated] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/76540c8b0ed761bfa6c81fa28c13057f13a5448aed079d656f6a3c79@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191220 [jira] [Comment Edited] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/799eb85d67cbddc1851a3e63a07b55e95b2f44f1685225d38570ce89@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191219 [jira] [Created] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/860acce024d79837e963a51a42bab2cef8e8d017aad2b455ecd1dcf0@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190930 [jira] [Created] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - netty-3.10.6.Final.jar: CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/9128111213b7b734ffc85db08d8f789b00a85a7f241b708e55debbd0@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20191115 [GitHub] [incubator-druid] ccaominh opened a new pull request #8878: Address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/9317fd092b257a0815434b116a8af8daea6e920b6673f4fd5583d5fe@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20191008 [jira] [Resolved] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/a0f77c73af32cbe4ff0968bfcbbe80ae6361f3dccdd46f3177547266@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191206 [jira] [Commented] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/af6e9c2d716868606523857a4cd7a5ee506e6d1710f5fb0d567ec030@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191206 [jira] [Resolved] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/b264fa5801e87698e9f43f2b5585fbc5ebdc26c6f4aad861b258fb69@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20191008 [jira] [Commented] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/b2cd51795f938632c6f60a4c59d9e587fbacd7f7d0e0a3684850a30f@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191209 [jira] [Commented] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/b3dda6399a0ea2b647624b899fd330fca81834e41b13e3e11e1002d8@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191220 [jira] [Reopened] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/b3ddeebbfaf8a288d7de8ab2611cf2609ab76b9809f0633248546b7c@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20191002 Re: [VOTE] Apache ZooKeeper release 3.5.6 candidate 2",
+                    "url" : "https://lists.apache.org/thread.html/bdf7a5e597346a75d2d884ca48c767525e35137ad59d8f10b8fc943c@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20191003 [zookeeper] branch branch-3.5.6 updated: ZOOKEEPER-3563: Update Netty to fix CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/cbf6e6a04cb37e9320ad20e437df63beeab1755fc0761918ed5c5a6e@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20191003 [zookeeper] branch master updated: ZOOKEEPER-3563: Update Netty to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/cf5aa087632ead838f8ac3a42e9837684e7afe6e0fcb7704e0c73bc0@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20191113 [jira] [Created] (CASSANDRA-15417) CVE-2019-16869(Netty is vulnerable to HTTP Request Smuggling) of severity 7.5",
+                    "url" : "https://lists.apache.org/thread.html/d14f721e0099b914daebe29bca199fde85d8354253be9d6d3d46507a@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190930 [jira] [Commented] (ZOOKEEPER-3563) dependency check failing on 3.4 and 3.5 branches - CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/d3eb0dbea75ef5c400bd49dfa1901ad50be606cca3cb29e0d01b6a54@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[olingo-dev] 20191206 [jira] [Created] (OLINGO-1414) Dependency check fails on 4.7.0 : CVE-2019-16869 on Netty",
+                    "url" : "https://lists.apache.org/thread.html/d7d530599dc7813056c712213e367b68cdf56fb5c9b73f864870bc4c@%3Cdev.olingo.apache.org%3E"
+                  }, {
+                    "description" : "[tinkerpop-commits] 20191022 [tinkerpop] branch tp34 updated: Bump to Netty 4.1.42 fixes CVE-2019-16869 - CTR",
+                    "url" : "https://lists.apache.org/thread.html/e192fe8797c192679759ffa6b15e4d0806546945a41d8ebfbc6ee3ac@%3Ccommits.tinkerpop.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20190930 Re: [VOTE] Apache ZooKeeper release 3.5.6 candidate 2",
+                    "url" : "https://lists.apache.org/thread.html/e39931d7cdd17241e69a0a09a89d99d7435bcc59afee8a9628d67769@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[spark-issues] 20191219 [jira] [Updated] (SPARK-30308) Update Netty and Netty-all to address CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/ee6faea9e542c0b90afd70297a9daa203e20d41aa2ac7fca6703662f@%3Cissues.spark.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20191113 [jira] [Created] (CASSANDRA-15418) CVE-2019-16869(Netty is vulnerable to HTTP Request Smuggling) of severity 7.5 for Cassendra 2.2.5",
+                    "url" : "https://lists.apache.org/thread.html/f6c5ebfb018787c764f000362d59e4b231c0a36b6253aa866de8c64e@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200225 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r0c3d49bfdbc62fd3915676433cc5899c5506d06da1c552ef1b7923a5@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200310 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r8402d67fdfe9cf169f859d52a7670b28a08eff31e54b522cc1432532@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-commits] 20200309 [hadoop] branch trunk updated: HADOOP-16871. Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444, CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r86befa74c5cd1482c711134104aec339bf7ae879f2c4437d7ec477d4@%3Ccommon-commits.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200219 [jira] [Updated] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/r90030b0117490caed526e57271bf4d7f9b012091ac5083c895d16543@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20200218 [jira] [Created] (CASSANDRA-15590) Upgrade io.netty_netty-all dependency to fix security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/r959474dcf7f88565ed89f6252ca5a274419006cb71348f14764b183d@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200309 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rb3361f6c6a5f834ad3db5e998c352760d393c0891b8d3bea90baa836@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200219 [jira] [Updated] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,",
+                    "url" : "https://lists.apache.org/thread.html/rc7eb5634b71d284483e58665b22bf274a69bd184d9bd7ede52015d91@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-commits] 20200309 [hadoop] branch branch-3.1 updated: HADOOP-16871. Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444, CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rcb2c59428f34d4757702f9ae739a8795bda7bea97b857e708a9c62c6@%3Ccommon-commits.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-commits] 20200309 [hadoop] branch branch-3.2 updated: HADOOP-16871. Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444, CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rdd5d243a5f8ed8b83c0104e321aa420e5e98792a95749e3c9a54c0b9@%3Ccommon-commits.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200219 [jira] [Assigned] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/re0b78a3d0a4ba2cf9f4e14e1d05040bde9051d5c78071177186336c9@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200131 [GitHub] [druid] ccaominh commented on a change in pull request #9300: Fix / suppress netty CVEs CVE-2019-20445 and CVE-2019-20444",
+                    "url" : "https://lists.apache.org/thread.html/re45ee9256d3233c31d78e59ee59c7dc841c7fbd83d0769285b41e948@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200224 [jira] [Commented] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/re78eaef7d01ad65c370df30e45c686fffff00b37f7bfd78b26a08762@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[hadoop-common-issues] 20200309 [jira] [Updated] (HADOOP-16871) Upgrade Netty version to 4.1.45.Final to handle CVE-2019-20444,CVE-2019-16869",
+                    "url" : "https://lists.apache.org/thread.html/rf2bf8e2eb0a03227f5bc100b544113f8cafea01e887bb068e8d1fa41@%3Ccommon-issues.hadoop.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190930 [SECURITY] [DLA 1941-1] netty security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/09/msg00035.html"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200219 [SECURITY] [DLA 2110-1] netty-3.9 security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html"
+                  }, {
+                    "description" : "20200105 [SECURITY] [DSA 4597-1] netty security update",
+                    "url" : "https://seclists.org/bugtraq/2020/Jan/6"
+                  }, {
+                    "description" : "DSA-4597",
+                    "url" : "https://www.debian.org/security/2020/dsa-4597"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2015-2156",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 4.3
+                  },
+                  "references" : [ {
+                    "description" : "FEDORA-2015-8713",
+                    "url" : "http://lists.fedoraproject.org/pipermail/package-announce/2015-June/159379.html"
+                  }, {
+                    "description" : "FEDORA-2015-8684",
+                    "url" : "http://lists.fedoraproject.org/pipermail/package-announce/2015-May/159166.html"
+                  }, {
+                    "description" : "http://netty.io/news/2015/05/08/3-9-8-Final-and-3.html",
+                    "url" : "http://netty.io/news/2015/05/08/3-9-8-Final-and-3.html"
+                  }, {
+                    "description" : "[oss-security] 20150516 Netty/Play's Security Updates (CVE-2015-2156)",
+                    "url" : "http://www.openwall.com/lists/oss-security/2015/05/17/1"
+                  }, {
+                    "description" : "74704",
+                    "url" : "http://www.securityfocus.com/bid/74704"
+                  }, {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1222923",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1222923"
+                  }, {
+                    "description" : "https://github.com/netty/netty/pull/3754",
+                    "url" : "https://github.com/netty/netty/pull/3754"
+                  }, {
+                    "description" : "[druid-commits] 20191115 [GitHub] [incubator-druid] ccaominh opened a new pull request #8878: Address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/9317fd092b257a0815434b116a8af8daea6e920b6673f4fd5583d5fe@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20191113 [jira] [Created] (CASSANDRA-15423) CVE-2015-2156 (Netty is vulnerable to Information Disclosure)",
+                    "url" : "https://lists.apache.org/thread.html/a19bb1003b0d6cd22475ba83c019b4fc7facfef2a9e13f71132529d3@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20191114 [jira] [Commented] (CASSANDRA-15423) CVE-2015-2156 (Netty is vulnerable to Information Disclosure)",
+                    "url" : "https://lists.apache.org/thread.html/dc1275aef115bda172851a231c76c0932d973f9ffd8bc375c4aba769@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "https://www.playframework.com/security/vulnerability/CVE-2015-2156-HttpOnlyBypass",
+                    "url" : "https://www.playframework.com/security/vulnerability/CVE-2015-2156-HttpOnlyBypass"
+                  } ],
+                  "resolution" : "PATCHED"
+                } ]
+              },
+              "feature" : {
+                "type" : "VulnerabilitiesInProject",
+                "name" : "Info about vulnerabilities in open-source project"
+              }
+            }, {
+              "type" : "DateValue",
+              "feature" : {
+                "type" : "DateFeature",
+                "name" : "When a project started"
+              },
+              "date" : 1218155838000
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "ProjectPopularityScore",
+              "name" : "Open-source project popularity score"
+            },
+            "value" : 10.0,
+            "weight" : 0.30515788031015273,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "IntegerValue",
+              "feature" : {
+                "type" : "PositiveIntegerFeature",
+                "name" : "Number of stars for a GitHub repository"
+              },
+              "number" : 22943
+            }, {
+              "type" : "IntegerValue",
+              "feature" : {
+                "type" : "PositiveIntegerFeature",
+                "name" : "Number of watchers for a GitHub repository"
+              },
+              "number" : 1792
+            } ],
+            "explanation" : [ ]
+          } ],
+          "explanation" : [ ]
+        },
+        "label" : [ "OssSecurityRating$SecurityLabel", "BAD" ]
+      },
+      "ratingValueDate" : 1585240261331
+    },
+    "https://github.com/netty/netty-tcnative" : {
+      "organization" : {
+        "name" : "netty"
+      },
+      "name" : "netty-tcnative",
+      "url" : "https://github.com/netty/netty-tcnative",
+      "ratingValue" : {
+        "scoreValue" : {
+          "type" : "ScoreValue",
+          "score" : {
+            "type" : "OssSecurityScore",
+            "name" : "Security score for open-source projects",
+            "weightedScores" : [ {
+              "score" : {
+                "type" : "ProjectSecurityTestingScore",
+                "name" : "How well security testing is done for an open-source project",
+                "subScores" : [ {
+                  "type" : "DependencyScanScore",
+                  "name" : "How a project scans its dependencies for vulnerabilities"
+                }, {
+                  "type" : "LgtmScore",
+                  "name" : "How a project addresses issues reported by LGTM"
+                } ]
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.6283118906878548
+              }
+            }, {
+              "score" : {
+                "type" : "UnpatchedVulnerabilitiesScore",
+                "name" : "How well vulnerabilities are patched"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.8362090433439393
+              }
+            }, {
+              "score" : {
+                "type" : "ProjectActivityScore",
+                "name" : "Open-source project activity score"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.6300785405632551
+              }
+            }, {
+              "score" : {
+                "type" : "CommunityCommitmentScore",
+                "name" : "How well open-source community commits to support an open-source project"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.5529742430404292
+              }
+            }, {
+              "score" : {
+                "type" : "ProjectSecurityAwarenessScore",
+                "name" : "How well open-source community is aware about security"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.5383270608555468
+              }
+            }, {
+              "score" : {
+                "type" : "VulnerabilityLifetimeScore",
+                "name" : "How fast vulnerabilities are patched"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.22939855566110368
+              }
+            }, {
+              "score" : {
+                "type" : "ProjectPopularityScore",
+                "name" : "Open-source project popularity score"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.30515788031015273
+              }
+            } ]
+          },
+          "value" : 3.426518889089499,
+          "weight" : 1.0,
+          "confidence" : 7.942791691059458,
+          "usedValues" : [ {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "ProjectSecurityTestingScore",
+              "name" : "How well security testing is done for an open-source project",
+              "subScores" : [ {
+                "type" : "DependencyScanScore",
+                "name" : "How a project scans its dependencies for vulnerabilities"
+              }, {
+                "type" : "LgtmScore",
+                "name" : "How a project addresses issues reported by LGTM"
+              } ]
+            },
+            "value" : 0.0,
+            "weight" : 0.6283118906878548,
+            "confidence" : 2.5,
+            "usedValues" : [ {
+              "type" : "ScoreValue",
+              "score" : {
+                "type" : "DependencyScanScore",
+                "name" : "How a project scans its dependencies for vulnerabilities"
+              },
+              "value" : 0.0,
+              "weight" : 1.0,
+              "confidence" : 0.0,
+              "usedValues" : [ {
+                "type" : "UnknownValue",
+                "feature" : {
+                  "type" : "BooleanFeature",
+                  "name" : "If an open-source project is regularly scanned for vulnerable dependencies"
+                }
+              } ],
+              "explanation" : [ ]
+            }, {
+              "type" : "ScoreValue",
+              "score" : {
+                "type" : "LgtmScore",
+                "name" : "How a project addresses issues reported by LGTM"
+              },
+              "value" : 0.0,
+              "weight" : 1.0,
+              "confidence" : 5.0,
+              "usedValues" : [ {
+                "type" : "BooleanValue",
+                "feature" : {
+                  "type" : "BooleanFeature",
+                  "name" : "If a project uses LGTM"
+                },
+                "flag" : false
+              }, {
+                "type" : "UnknownValue",
+                "feature" : {
+                  "type" : "LgtmGradeFeature",
+                  "name" : "The worst LGTM grade of a project"
+                }
+              } ],
+              "explanation" : [ ]
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "UnpatchedVulnerabilitiesScore",
+              "name" : "How well vulnerabilities are patched"
+            },
+            "value" : 10.0,
+            "weight" : 0.8362090433439393,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "VulnerabilitiesValue",
+              "vulnerabilities" : {
+                "entries" : [ ]
+              },
+              "feature" : {
+                "type" : "VulnerabilitiesInProject",
+                "name" : "Info about vulnerabilities in open-source project"
+              }
+            } ],
+            "explanation" : [ "No unpatched vulnerabilities found which is good" ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "ProjectActivityScore",
+              "name" : "Open-source project activity score"
+            },
+            "value" : 3.175472384853971,
+            "weight" : 0.6300785405632551,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "ExpiringValue",
+              "value" : {
+                "type" : "IntegerValue",
+                "feature" : {
+                  "type" : "PositiveIntegerFeature",
+                  "name" : "Number of commits in the last three months"
+                },
+                "number" : 16
+              },
+              "expiration" : 1585306297570
+            }, {
+              "type" : "ExpiringValue",
+              "value" : {
+                "type" : "IntegerValue",
+                "feature" : {
+                  "type" : "PositiveIntegerFeature",
+                  "name" : "Number of contributors in the last three months"
+                },
+                "number" : 4
+              },
+              "expiration" : 1585306298345
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "CommunityCommitmentScore",
+              "name" : "How well open-source community commits to support an open-source project"
+            },
+            "value" : 0.0,
+            "weight" : 0.5529742430404292,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "BooleanValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project is supported by a company"
+              },
+              "flag" : false
+            }, {
+              "type" : "BooleanValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project belongs to Apache Foundation"
+              },
+              "flag" : false
+            }, {
+              "type" : "BooleanValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project belongs to Eclipse Foundation"
+              },
+              "flag" : false
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "ProjectSecurityAwarenessScore",
+              "name" : "How well open-source community is aware about security"
+            },
+            "value" : 0.0,
+            "weight" : 0.5383270608555468,
+            "confidence" : 6.666666666666667,
+            "usedValues" : [ {
+              "type" : "BooleanValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project has a security policy"
+              },
+              "flag" : false
+            }, {
+              "type" : "UnknownValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project has a security team"
+              }
+            }, {
+              "type" : "ExpiringValue",
+              "value" : {
+                "type" : "BooleanValue",
+                "feature" : {
+                  "type" : "BooleanFeature",
+                  "name" : "If a project uses verified signed commits"
+                },
+                "flag" : false
+              },
+              "expiration" : 1585306310679
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "VulnerabilityLifetimeScore",
+              "name" : "How fast vulnerabilities are patched"
+            },
+            "value" : 10.0,
+            "weight" : 0.22939855566110368,
+            "confidence" : 5.0,
+            "usedValues" : [ {
+              "type" : "VulnerabilitiesValue",
+              "vulnerabilities" : {
+                "entries" : [ ]
+              },
+              "feature" : {
+                "type" : "VulnerabilitiesInProject",
+                "name" : "Info about vulnerabilities in open-source project"
+              }
+            }, {
+              "type" : "UnknownValue",
+              "feature" : {
+                "type" : "DateFeature",
+                "name" : "When a project started"
+              }
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "ProjectPopularityScore",
+              "name" : "Open-source project popularity score"
+            },
+            "value" : 0.29933333333333334,
+            "weight" : 0.30515788031015273,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "IntegerValue",
+              "feature" : {
+                "type" : "PositiveIntegerFeature",
+                "name" : "Number of stars for a GitHub repository"
+              },
+              "number" : 156
+            }, {
+              "type" : "IntegerValue",
+              "feature" : {
+                "type" : "PositiveIntegerFeature",
+                "name" : "Number of watchers for a GitHub repository"
+              },
+              "number" : 43
+            } ],
+            "explanation" : [ ]
+          } ],
+          "explanation" : [ ]
+        },
+        "label" : [ "OssSecurityRating$SecurityLabel", "BAD" ]
+      },
+      "ratingValueDate" : 1585240271894
+    },
+    "https://github.com/FasterXML/jackson-databind" : {
+      "organization" : {
+        "name" : "FasterXML"
+      },
+      "name" : "jackson-databind",
+      "url" : "https://github.com/FasterXML/jackson-databind",
+      "ratingValue" : {
+        "scoreValue" : {
+          "type" : "ScoreValue",
+          "score" : {
+            "type" : "OssSecurityScore",
+            "name" : "Security score for open-source projects",
+            "weightedScores" : [ {
+              "score" : {
+                "type" : "ProjectSecurityTestingScore",
+                "name" : "How well security testing is done for an open-source project",
+                "subScores" : [ {
+                  "type" : "DependencyScanScore",
+                  "name" : "How a project scans its dependencies for vulnerabilities"
+                }, {
+                  "type" : "LgtmScore",
+                  "name" : "How a project addresses issues reported by LGTM"
+                } ]
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.6283118906878548
+              }
+            }, {
+              "score" : {
+                "type" : "UnpatchedVulnerabilitiesScore",
+                "name" : "How well vulnerabilities are patched"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.8362090433439393
+              }
+            }, {
+              "score" : {
+                "type" : "ProjectActivityScore",
+                "name" : "Open-source project activity score"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.6300785405632551
+              }
+            }, {
+              "score" : {
+                "type" : "CommunityCommitmentScore",
+                "name" : "How well open-source community commits to support an open-source project"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.5529742430404292
+              }
+            }, {
+              "score" : {
+                "type" : "ProjectSecurityAwarenessScore",
+                "name" : "How well open-source community is aware about security"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.5383270608555468
+              }
+            }, {
+              "score" : {
+                "type" : "VulnerabilityLifetimeScore",
+                "name" : "How fast vulnerabilities are patched"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.22939855566110368
+              }
+            }, {
+              "score" : {
+                "type" : "ProjectPopularityScore",
+                "name" : "Open-source project popularity score"
+              },
+              "weight" : {
+                "type" : "ImmutableWeight",
+                "value" : 0.30515788031015273
+              }
+            } ]
+          },
+          "value" : 5.433734354938445,
+          "weight" : 1.0,
+          "confidence" : 8.673285914850164,
+          "usedValues" : [ {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "ProjectSecurityTestingScore",
+              "name" : "How well security testing is done for an open-source project",
+              "subScores" : [ {
+                "type" : "DependencyScanScore",
+                "name" : "How a project scans its dependencies for vulnerabilities"
+              }, {
+                "type" : "LgtmScore",
+                "name" : "How a project addresses issues reported by LGTM"
+              } ]
+            },
+            "value" : 5.0,
+            "weight" : 0.6283118906878548,
+            "confidence" : 5.0,
+            "usedValues" : [ {
+              "type" : "ScoreValue",
+              "score" : {
+                "type" : "DependencyScanScore",
+                "name" : "How a project scans its dependencies for vulnerabilities"
+              },
+              "value" : 0.0,
+              "weight" : 1.0,
+              "confidence" : 0.0,
+              "usedValues" : [ {
+                "type" : "UnknownValue",
+                "feature" : {
+                  "type" : "BooleanFeature",
+                  "name" : "If an open-source project is regularly scanned for vulnerable dependencies"
+                }
+              } ],
+              "explanation" : [ ]
+            }, {
+              "type" : "ScoreValue",
+              "score" : {
+                "type" : "LgtmScore",
+                "name" : "How a project addresses issues reported by LGTM"
+              },
+              "value" : 10.0,
+              "weight" : 1.0,
+              "confidence" : 10.0,
+              "usedValues" : [ {
+                "type" : "BooleanValue",
+                "feature" : {
+                  "type" : "BooleanFeature",
+                  "name" : "If a project uses LGTM"
+                },
+                "flag" : true
+              }, {
+                "type" : "LgtmGradeValue",
+                "feature" : {
+                  "type" : "LgtmGradeFeature",
+                  "name" : "The worst LGTM grade of a project"
+                },
+                "value" : "A"
+              } ],
+              "explanation" : [ ]
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "UnpatchedVulnerabilitiesScore",
+              "name" : "How well vulnerabilities are patched"
+            },
+            "value" : 10.0,
+            "weight" : 0.8362090433439393,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "VulnerabilitiesValue",
+              "vulnerabilities" : {
+                "entries" : [ {
+                  "id" : "CVE-2019-12384",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 4.3
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:1820",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1820"
+                  }, {
+                    "description" : "RHSA-2019:2720",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2720"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:2935",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+                  }, {
+                    "description" : "RHSA-2019:2936",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+                  }, {
+                    "description" : "RHSA-2019:2937",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+                  }, {
+                    "description" : "RHSA-2019:2938",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+                  }, {
+                    "description" : "RHSA-2019:2998",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2998"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "RHSA-2019:3292",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3292"
+                  }, {
+                    "description" : "RHSA-2019:3297",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3297"
+                  }, {
+                    "description" : "RHSA-2019:3901",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+                  }, {
+                    "description" : "RHSA-2019:4352",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4352"
+                  }, {
+                    "description" : "https://blog.doyensec.com/2019/07/22/jackson-gadgets.html",
+                    "url" : "https://blog.doyensec.com/2019/07/22/jackson-gadgets.html"
+                  }, {
+                    "description" : "https://doyensec.com/research.html",
+                    "url" : "https://doyensec.com/research.html"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/compare/74b90a4...a977aad",
+                    "url" : "https://github.com/FasterXML/jackson-databind/compare/74b90a4...a977aad"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                    "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[geode-notifications] 20191007 [GitHub] [geode] jmelchio commented on issue #4102: Fix for GEODE-7255: Pickup Jackson CVE fix",
+                    "url" : "https://lists.apache.org/thread.html/e0733058c0366b703e6757d8d2a7a04b943581f659e9c271f0841dfe@%3Cnotifications.geode.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.debian.org/debian-lts-announce/2019/06/msg00019.html",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/06/msg00019.html"
+                  }, {
+                    "description" : "FEDORA-2019-ae6a703b8f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+                  }, {
+                    "description" : "FEDORA-2019-fb23eccc03",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+                  }, {
+                    "description" : "FEDORA-2019-99ff6aa32c",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+                  }, {
+                    "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190703-0002/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190703-0002/"
+                  }, {
+                    "description" : "DSA-4542",
+                    "url" : "https://www.debian.org/security/2019/dsa-4542"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-14540",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/blob/master/release-notes/VERSION-2.x",
+                    "url" : "https://github.com/FasterXML/jackson-databind/blob/master/release-notes/VERSION-2.x"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2410",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2410"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2449",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2449"
+                  }, {
+                    "description" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch opened a new pull request #1200: Upgrade jackson due to CVE issues",
+                    "url" : "https://lists.apache.org/thread.html/0fcef7321095ce0bc597d468d150cff3d647f4cb3aef3bd4d20e1c69@%3Ccommits.tinkerpop.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190925 [GitHub] [hbase] SteNicholas opened a new pull request #660: HBASE-23075 Upgrade jackson version",
+                    "url" : "https://lists.apache.org/thread.html/40c00861b53bb611dee7d6f35f864aa7d1c1bd77df28db597cbf27e1@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190926 [GitHub] [hbase-connectors] SteNicholas opened a new pull request #45: HBASE-23075 Upgrade jackson version",
+                    "url" : "https://lists.apache.org/thread.html/a360b46061c91c5cad789b6c3190aef9b9f223a2b75c9c9f046fe016@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190925 [GitHub] [zookeeper] maoling commented on issue #1097: ZOOKEEPER-3559 - Update Jackson to 2.9.10",
+                    "url" : "https://lists.apache.org/thread.html/a4f2c9fb36642a48912cdec6836ec00e497427717c5d377f8d7ccce6@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190926 [jira] [Commented] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                    "url" : "https://lists.apache.org/thread.html/ad0d238e97a7da5eca47a014f0f7e81f440ed6bf74a93183825e18b9@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190926 [jira] [Updated] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                    "url" : "https://lists.apache.org/thread.html/dc6b5cad721a4f6b3b62ed1163894941140d9d5656140fb757505ca0@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-commits] 20190927 [hbase-connectors] 02/02: HBASE-23075 Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                    "url" : "https://lists.apache.org/thread.html/e90c3feb21702e68a8c08afce37045adb3870f2bf8223fa403fb93fb@%3Ccommits.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+                  }, {
+                    "description" : "FEDORA-2019-cf87377f5f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+                  }, {
+                    "description" : "FEDORA-2019-b171554877",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+                  }, {
+                    "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20191004-0002/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20191004-0002/"
+                  }, {
+                    "description" : "DSA-4542",
+                    "url" : "https://www.debian.org/security/2019/dsa-4542"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-16942",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:3901",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+                  }, {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2478",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2478"
+                  }, {
+                    "description" : "https://issues.apache.org/jira/browse/GEODE-7255",
+                    "url" : "https://issues.apache.org/jira/browse/GEODE-7255"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[geode-issues] 20191011 [jira] [Commented] (GEODE-7255) Need to pick up CVE-2019-16942",
+                    "url" : "https://lists.apache.org/thread.html/7782a937c9259a58337ee36b2961f00e2d744feafc13084e176d0df5@%3Cissues.geode.apache.org%3E"
+                  }, {
+                    "description" : "[geode-issues] 20191230 [jira] [Closed] (GEODE-7255) Need to pick up CVE-2019-16942",
+                    "url" : "https://lists.apache.org/thread.html/a430dbc9be874c41314cc69e697384567a9a24025e819d9485547954@%3Cissues.geode.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[geode-issues] 20191008 [jira] [Commented] (GEODE-7255) Need to pick up CVE-2019-16942",
+                    "url" : "https://lists.apache.org/thread.html/b2e23c94f9dfef53e04c492e5d02e5c75201734be7adc73a49ef2370@%3Cissues.geode.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+                  }, {
+                    "description" : "FEDORA-2019-cf87377f5f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+                  }, {
+                    "description" : "FEDORA-2019-b171554877",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  }, {
+                    "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20191017-0006/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20191017-0006/"
+                  }, {
+                    "description" : "DSA-4542",
+                    "url" : "https://www.debian.org/security/2019/dsa-4542"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-8840",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2620",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2620"
+                  }, {
+                    "description" : "[druid-commits] 20200219 [GitHub] [druid] ccaominh opened a new pull request #9379: Suppress CVE-2020-8840 for htrace-core-4.0.1",
+                    "url" : "https://lists.apache.org/thread.html/r078e68a926ea6be12e8404e47f45aabf04bb4668e8265c0de41db6db@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20200313 Re: CVE-2020-8840 on TomEE 8.0.1",
+                    "url" : "https://lists.apache.org/thread.html/r1c09b9551f6953dbeca190a4c4b78198cdbb9825fce36f96fe3d8218@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200219 [GitHub] [druid] suneet-s commented on issue #9379: Suppress CVE-2020-8840 for htrace-core-4.0.1",
+                    "url" : "https://lists.apache.org/thread.html/r319f19c74e06c201b9d4e8b282a4e4b2da6dcda022fb46f007dd00d3@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200223 [GitHub] [zookeeper] eolivelli opened a new pull request #1262: ZOOKEEPER-3734 upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r3539bd3a377991217d724879d239e16e86001c54160076408574e1da@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200221 [GitHub] [druid] ccaominh merged pull request #9379: Suppress CVE-2020-8840 for htrace-core-4.0.1",
+                    "url" : "https://lists.apache.org/thread.html/r3d20a2660b36551fd8257d479941782af4a7169582449fac1704bde2@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200223 [GitHub] [zookeeper] phunt commented on issue #1262: ZOOKEEPER-3734 upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r428d068b2a4923f1a5a4f5fc6381b95205cfe7620169d16db78e9c71@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200223 [zookeeper] branch master updated: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r46bebdeb59b8b7212d63a010ca445a9f5c4e9d64dcf693cab6f399d3@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200225 [jira] [Updated] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r65ee95fa09c831843bac81eaa582fdddc2b6119912a72d1c83a9b882@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200223 [jira] [Updated] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r6fdd4c61a09a0c89f581b4ddb3dc6f154ab0c705fcfd0a7358b2e4e5@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200223 [jira] [Resolved] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r8170007fd9b263d65b37d92a7b5d7bc357aedbb113a32838bc4a9485@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200222 [jira] [Created] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r9ecf211c22760b00967ebe158c6ed7dba9142078e2a630ab8904a5b7@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200223 [GitHub] [zookeeper] asfgit closed pull request #1262: ZOOKEEPER-3734 upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/rac5ee5d686818be7e7c430d35108ee01a88aae54f832d32f62431fd1@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200222 [jira] [Created] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/rb43f9a65150948a6bebd3cb77ee3e105d40db2820fd547528f4e7f89@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200224 [zookeeper] 01/02: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/rb5eedf90ba3633e171a2ffdfe484651c9490dc5df74c8a29244cbc0e@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20200311 CVE-2020-8840 on TomEE 8.0.1",
+                    "url" : "https://lists.apache.org/thread.html/rb99c7321eba5d4c907beec46675d52827528b738cfafd48eb4d862f1@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20200316 RE: CVE-2020-8840 on TomEE 8.0.1",
+                    "url" : "https://lists.apache.org/thread.html/rc068e824654c4b8bd4f2490bec869e29edbfcd5dfe02d47cbf7433b2@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20200311 Re: CVE-2020-8840 on TomEE 8.0.1",
+                    "url" : "https://lists.apache.org/thread.html/rdea588d4a0ebf9cb7ce8c3a8f18d0d306507c4f8ba178dd3d20207b8@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200223 [zookeeper] branch branch-3.6 updated: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/rdf8d389271a291dde3b2f99c36918d6cb1e796958af626cc140fee23@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200223 [jira] [Assigned] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/re7326b8655eab931f2a9ce074fd9a1a51b5db11456bee9b48e1e170c@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200223 [zookeeper] branch branch-3.5 updated: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/re8ae2670ec456ef1c5a2a661a2838ab2cd00e9efa1e88c069f546f21@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200220 [SECURITY] [DLA 2111-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00020.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-12086",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.0
+                  },
+                  "references" : [ {
+                    "description" : "http://russiansecurity.expert/2016/04/20/mysql-connect-file-read/",
+                    "url" : "http://russiansecurity.expert/2016/04/20/mysql-connect-file-read/"
+                  }, {
+                    "description" : "109227",
+                    "url" : "http://www.securityfocus.com/bid/109227"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:2935",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+                  }, {
+                    "description" : "RHSA-2019:2936",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+                  }, {
+                    "description" : "RHSA-2019:2937",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+                  }, {
+                    "description" : "RHSA-2019:2938",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+                  }, {
+                    "description" : "RHSA-2019:2998",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2998"
+                  }, {
+                    "description" : "RHSA-2019:3044",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3044"
+                  }, {
+                    "description" : "RHSA-2019:3045",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3045"
+                  }, {
+                    "description" : "RHSA-2019:3046",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3046"
+                  }, {
+                    "description" : "RHSA-2019:3050",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3050"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2326",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2326"
+                  }, {
+                    "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[spark-reviews] 20190520 [GitHub] [spark] Fokko opened a new pull request #24646: Spark 27757",
+                    "url" : "https://lists.apache.org/thread.html/88cd25375805950ae7337e669b0cb0eeda98b9604c1b8d806dccbad2@%3Creviews.spark.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-solr-user] 20200320 CVEs (vulnerabilities) that apply to Solr 8.4.1",
+                    "url" : "https://lists.apache.org/thread.html/r204ba2a9ea750f38d789d2bb429cc0925ad6133deea7cbc3001d96b5@%3Csolr-user.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190521 [SECURITY] [DLA 1798-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/05/msg00030.html"
+                  }, {
+                    "description" : "FEDORA-2019-ae6a703b8f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+                  }, {
+                    "description" : "FEDORA-2019-fb23eccc03",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+                  }, {
+                    "description" : "FEDORA-2019-99ff6aa32c",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-16943",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2478",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2478"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-commits] 20191028 [incubator-iceberg] branch master updated: Update Jackson to 2.10.0 for CVE-2019-16943 (#583)",
+                    "url" : "https://lists.apache.org/thread.html/5ec8d8d485c2c8ac55ea425f4cd96596ef37312532712639712ebcdd@%3Ccommits.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191027 [GitHub] [incubator-iceberg] rdsr commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/6788e4c991f75b89d290ad06b463fcd30bcae99fee610345a35b7bc6@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                    "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+                  }, {
+                    "description" : "FEDORA-2019-cf87377f5f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+                  }, {
+                    "description" : "FEDORA-2019-b171554877",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  }, {
+                    "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20191017-0006/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20191017-0006/"
+                  }, {
+                    "description" : "DSA-4542",
+                    "url" : "https://www.debian.org/security/2019/dsa-4542"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-17531",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:4192",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4192"
+                  }, {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2498",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2498"
+                  }, {
+                    "description" : "[pulsar-commits] 20191127 [GitHub] [pulsar] massakam opened a new pull request #5758: Bump jackson libraries to 2.10.1",
+                    "url" : "https://lists.apache.org/thread.html/b3c90d38f99db546de60fea65f99a924d540fae2285f014b79606ca5@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                    "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20191210 [SECURITY] [DLA 2030-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/12/msg00013.html"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20191024-0005/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20191024-0005/"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-19362",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "107985",
+                    "url" : "http://www.securityfocus.com/bid/107985"
+                  }, {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2186",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2186"
+                  }, {
+                    "description" : "https://issues.apache.org/jira/browse/TINKERPOP-2121",
+                    "url" : "https://issues.apache.org/jira/browse/TINKERPOP-2121"
+                  }, {
+                    "description" : "[infra-devnull] 20190329 [GitHub] [pulsar] massakam opened pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/37e1ed724a1b0e5d191d98c822c426670bdfde83804567131847d2a3@%3Cdevnull.infra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190329 [GitHub] [pulsar] massakam opened a new pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/c70da3cb6e3f03e0ad8013e38b6959419d866c4a7c80fdd34b73f25c@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-19361",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "107985",
+                    "url" : "http://www.securityfocus.com/bid/107985"
+                  }, {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2186",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2186"
+                  }, {
+                    "description" : "https://issues.apache.org/jira/browse/TINKERPOP-2121",
+                    "url" : "https://issues.apache.org/jira/browse/TINKERPOP-2121"
+                  }, {
+                    "description" : "[infra-devnull] 20190329 [GitHub] [pulsar] massakam opened pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/37e1ed724a1b0e5d191d98c822c426670bdfde83804567131847d2a3@%3Cdevnull.infra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190329 [GitHub] [pulsar] massakam opened a new pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/c70da3cb6e3f03e0ad8013e38b6959419d866c4a7c80fdd34b73f25c@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-19360",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "107985",
+                    "url" : "http://www.securityfocus.com/bid/107985"
+                  }, {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2186",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2186"
+                  }, {
+                    "description" : "https://issues.apache.org/jira/browse/TINKERPOP-2121",
+                    "url" : "https://issues.apache.org/jira/browse/TINKERPOP-2121"
+                  }, {
+                    "description" : "[infra-devnull] 20190329 [GitHub] [pulsar] massakam opened pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/37e1ed724a1b0e5d191d98c822c426670bdfde83804567131847d2a3@%3Cdevnull.infra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190329 [GitHub] [pulsar] massakam opened a new pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/c70da3cb6e3f03e0ad8013e38b6959419d866c4a7c80fdd34b73f25c@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2017-15095",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html"
+                  }, {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html"
+                  }, {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+                  }, {
+                    "description" : "103880",
+                    "url" : "http://www.securityfocus.com/bid/103880"
+                  }, {
+                    "description" : "1039769",
+                    "url" : "http://www.securitytracker.com/id/1039769"
+                  }, {
+                    "description" : "RHSA-2017:3189",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3189"
+                  }, {
+                    "description" : "RHSA-2017:3190",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3190"
+                  }, {
+                    "description" : "RHSA-2018:0342",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0342"
+                  }, {
+                    "description" : "RHSA-2018:0478",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0478"
+                  }, {
+                    "description" : "RHSA-2018:0479",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0479"
+                  }, {
+                    "description" : "RHSA-2018:0480",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0480"
+                  }, {
+                    "description" : "RHSA-2018:0481",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0481"
+                  }, {
+                    "description" : "RHSA-2018:0576",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0576"
+                  }, {
+                    "description" : "RHSA-2018:0577",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0577"
+                  }, {
+                    "description" : "RHSA-2018:1447",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1447"
+                  }, {
+                    "description" : "RHSA-2018:1448",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1448"
+                  }, {
+                    "description" : "RHSA-2018:1449",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+                  }, {
+                    "description" : "RHSA-2018:1450",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+                  }, {
+                    "description" : "RHSA-2018:1451",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1451"
+                  }, {
+                    "description" : "RHSA-2018:2927",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2927"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1680",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1680"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1737",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1737"
+                  }, {
+                    "description" : "[lucene-solr-user] 20191219 Re: CVE-2017-7525 fix for Solr 7.7.x",
+                    "url" : "https://lists.apache.org/thread.html/f095a791bda6c0595f691eddd0febb2d396987eec5cbd29120d8c629@%3Csolr-user.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200131 [SECURITY] [DLA 2091-1] libjackson-json-java security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/01/msg00037.html"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20171214-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20171214-0003/"
+                  }, {
+                    "description" : "DSA-4037",
+                    "url" : "https://www.debian.org/security/2017/dsa-4037"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2017-7525",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html"
+                  }, {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html"
+                  }, {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+                  }, {
+                    "description" : "99623",
+                    "url" : "http://www.securityfocus.com/bid/99623"
+                  }, {
+                    "description" : "1039744",
+                    "url" : "http://www.securitytracker.com/id/1039744"
+                  }, {
+                    "description" : "1039947",
+                    "url" : "http://www.securitytracker.com/id/1039947"
+                  }, {
+                    "description" : "1040360",
+                    "url" : "http://www.securitytracker.com/id/1040360"
+                  }, {
+                    "description" : "RHSA-2017:1834",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:1834"
+                  }, {
+                    "description" : "RHSA-2017:1835",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:1835"
+                  }, {
+                    "description" : "RHSA-2017:1836",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:1836"
+                  }, {
+                    "description" : "RHSA-2017:1837",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:1837"
+                  }, {
+                    "description" : "RHSA-2017:1839",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:1839"
+                  }, {
+                    "description" : "RHSA-2017:1840",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:1840"
+                  }, {
+                    "description" : "RHSA-2017:2477",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2477"
+                  }, {
+                    "description" : "RHSA-2017:2546",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2546"
+                  }, {
+                    "description" : "RHSA-2017:2547",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2547"
+                  }, {
+                    "description" : "RHSA-2017:2633",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2633"
+                  }, {
+                    "description" : "RHSA-2017:2635",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2635"
+                  }, {
+                    "description" : "RHSA-2017:2636",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2636"
+                  }, {
+                    "description" : "RHSA-2017:2637",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2637"
+                  }, {
+                    "description" : "RHSA-2017:2638",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2638"
+                  }, {
+                    "description" : "RHSA-2017:3141",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3141"
+                  }, {
+                    "description" : "RHSA-2017:3454",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3454"
+                  }, {
+                    "description" : "RHSA-2017:3455",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3455"
+                  }, {
+                    "description" : "RHSA-2017:3456",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3456"
+                  }, {
+                    "description" : "RHSA-2017:3458",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3458"
+                  }, {
+                    "description" : "RHSA-2018:0294",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0294"
+                  }, {
+                    "description" : "RHSA-2018:0342",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0342"
+                  }, {
+                    "description" : "RHSA-2018:1449",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+                  }, {
+                    "description" : "RHSA-2018:1450",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+                  }, {
+                    "description" : "RHSA-2019:0910",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0910"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1462702",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1462702"
+                  }, {
+                    "description" : "https://cwiki.apache.org/confluence/display/WW/S2-055",
+                    "url" : "https://cwiki.apache.org/confluence/display/WW/S2-055"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1599",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1599"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1723",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1723"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                    "url" : "https://lists.apache.org/thread.html/3c87dc8bca99a2b3b4743713b33d1de05b1d6b761fdf316224e9c81f@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20191113 [jira] [Created] (CASSANDRA-15416) CVE-2017-7525 ( jackson-databind is vulnerable to Remote Code Execution) on version 3.11.4",
+                    "url" : "https://lists.apache.org/thread.html/4641ed8616ccc2c1fbddac2c3dc9900c96387bc226eaf0232d61909b@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-solr-user] 20191218 CVE-2017-7525 fix for Solr 7.7.x",
+                    "url" : "https://lists.apache.org/thread.html/5008bcbd45ee65ce39e4220b6ac53d28a24d6bc67d5804e9773a7399@%3Csolr-user.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-solr-user] 20190104 Re: SOLR v7 Security Issues Caused Denial of Use - Sonatype Application Composition Report",
+                    "url" : "https://lists.apache.org/thread.html/708d94141126eac03011144a971a6411fcac16d9c248d1d535a39451@%3Csolr-user.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20191115 [GitHub] [incubator-druid] ccaominh opened a new pull request #8878: Address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/9317fd092b257a0815434b116a8af8daea6e920b6673f4fd5583d5fe@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                    "url" : "https://lists.apache.org/thread.html/b1f33fe5ade396bb903fdcabe9f243f7692c7dfce5418d3743c2d346@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Resolved] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                    "url" : "https://lists.apache.org/thread.html/c10a2bf0fdc3d25faf17bd191d6ec46b29a353fa9c97bebd7c4e5913@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Assigned] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                    "url" : "https://lists.apache.org/thread.html/c2ed4c0126b43e324cf740012a0edd371fd36096fd777be7bfe7a2a6@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-solr-user] 20191218 Re: CVE-2017-7525 fix for Solr 7.7.x",
+                    "url" : "https://lists.apache.org/thread.html/c9d5ff20929e8a3c8794facf4c4b326a9c10618812eec356caa20b87@%3Csolr-user.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-solr-user] 20191219 Re: CVE-2017-7525 fix for Solr 7.7.x",
+                    "url" : "https://lists.apache.org/thread.html/f095a791bda6c0595f691eddd0febb2d396987eec5cbd29120d8c629@%3Csolr-user.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Closed] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                    "url" : "https://lists.apache.org/thread.html/f60afd3c7e9ebaaf70fad4a4beb75cf8740ac959017a31e7006c7486@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200131 [SECURITY] [DLA 2091-1] libjackson-json-java security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/01/msg00037.html"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20171214-0002/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20171214-0002/"
+                  }, {
+                    "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                    "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+                  }, {
+                    "description" : "DSA-4004",
+                    "url" : "https://www.debian.org/security/2017/dsa-4004"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-14720",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:1106",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+                  }, {
+                    "description" : "RHSA-2019:1107",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+                  }, {
+                    "description" : "RHSA-2019:1108",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+                  }, {
+                    "description" : "RHSA-2019:1140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Assigned] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                    "url" : "https://lists.apache.org/thread.html/6a78f88716c3c57aa74ec05764a37ab3874769a347805903b393b286@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                    "url" : "https://lists.apache.org/thread.html/82b01bfb6787097427ce97cec6a7127e93718bc05d1efd5eaffc228f@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                    "url" : "https://lists.apache.org/thread.html/ba973114605d936be276ee6ce09dfbdbf78aa56f6cdc6e79bfa7b8df@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-14721",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:1106",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+                  }, {
+                    "description" : "RHSA-2019:1107",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+                  }, {
+                    "description" : "RHSA-2019:1108",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+                  }, {
+                    "description" : "RHSA-2019:1140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-12022",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.1
+                  },
+                  "references" : [ {
+                    "description" : "107585",
+                    "url" : "http://www.securityfocus.com/bid/107585"
+                  }, {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1106",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+                  }, {
+                    "description" : "RHSA-2019:1107",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+                  }, {
+                    "description" : "RHSA-2019:1108",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+                  }, {
+                    "description" : "RHSA-2019:1140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1671098",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1671098"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2052",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2052"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-issues] 20191004 [GitHub] [lucene-solr] marungo opened a new pull request #925: SOLR-13818: Upgrade jackson to 2.10.0",
+                    "url" : "https://lists.apache.org/thread.html/7fcf88aff0d1deaa5c3c7be8d58c05ad7ad5da94b59065d8e7c50c5d@%3Cissues.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf",
+                    "url" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-12023",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.1
+                  },
+                  "references" : [ {
+                    "description" : "http://www.securityfocus.com/bid/105659",
+                    "url" : "http://www.securityfocus.com/bid/105659"
+                  }, {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1106",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+                  }, {
+                    "description" : "RHSA-2019:1107",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+                  }, {
+                    "description" : "RHSA-2019:1108",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+                  }, {
+                    "description" : "RHSA-2019:1140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2058",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2058"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-issues] 20191004 [GitHub] [lucene-solr] marungo opened a new pull request #925: SOLR-13818: Upgrade jackson to 2.10.0",
+                    "url" : "https://lists.apache.org/thread.html/7fcf88aff0d1deaa5c3c7be8d58c05ad7ad5da94b59065d8e7c50c5d@%3Cissues.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf",
+                    "url" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-14893",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2020:0729",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0729"
+                  }, {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14893",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14893"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2469",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2469"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-16335",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "RHSA-2020:0729",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0729"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2449",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2449"
+                  }, {
+                    "description" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch opened a new pull request #1200: Upgrade jackson due to CVE issues",
+                    "url" : "https://lists.apache.org/thread.html/0fcef7321095ce0bc597d468d150cff3d647f4cb3aef3bd4d20e1c69@%3Ccommits.tinkerpop.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190925 [GitHub] [hbase] SteNicholas opened a new pull request #660: HBASE-23075 Upgrade jackson version",
+                    "url" : "https://lists.apache.org/thread.html/40c00861b53bb611dee7d6f35f864aa7d1c1bd77df28db597cbf27e1@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190926 [GitHub] [hbase-connectors] SteNicholas opened a new pull request #45: HBASE-23075 Upgrade jackson version",
+                    "url" : "https://lists.apache.org/thread.html/a360b46061c91c5cad789b6c3190aef9b9f223a2b75c9c9f046fe016@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190926 [jira] [Commented] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                    "url" : "https://lists.apache.org/thread.html/ad0d238e97a7da5eca47a014f0f7e81f440ed6bf74a93183825e18b9@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190926 [jira] [Updated] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                    "url" : "https://lists.apache.org/thread.html/dc6b5cad721a4f6b3b62ed1163894941140d9d5656140fb757505ca0@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-commits] 20190927 [hbase-connectors] 02/02: HBASE-23075 Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                    "url" : "https://lists.apache.org/thread.html/e90c3feb21702e68a8c08afce37045adb3870f2bf8223fa403fb93fb@%3Ccommits.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+                  }, {
+                    "description" : "FEDORA-2019-cf87377f5f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+                  }, {
+                    "description" : "FEDORA-2019-b171554877",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+                  }, {
+                    "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20191004-0002/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20191004-0002/"
+                  }, {
+                    "description" : "DSA-4542",
+                    "url" : "https://www.debian.org/security/2019/dsa-4542"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-14892",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2020:0729",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0729"
+                  }, {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14892",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14892"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2462",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2462"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-9546",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.8
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2631",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2631"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200308 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r35d30db00440ef63b791c4b7f7acb036e14d4a23afa2a249cb66c0fd@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r9464a40d25c3ba1a55622db72f113eb494a889656962d098c70c5bb1@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200319 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r98c9b6e4c9e17792e2cd1ec3e4aa20b61a791939046d3f10888176bb@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rb6fecb5e96a6d61e175ff49f33f2713798dd05cf03067c169d195596@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200319 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rd5a4457be4623038c3989294429bc063eec433a2e55995d81591e2ca@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200307 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rdd49ab9565bec436a896bc00c4b9fc9dce1598e106c318524fbdfec6@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200305 [SECURITY] [DLA 2135-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00008.html"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-14379",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHBA-2019:2824",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:2824"
+                  }, {
+                    "description" : "RHSA-2019:2743",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2743"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:2935",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+                  }, {
+                    "description" : "RHSA-2019:2936",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+                  }, {
+                    "description" : "RHSA-2019:2937",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+                  }, {
+                    "description" : "RHSA-2019:2938",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+                  }, {
+                    "description" : "RHSA-2019:2998",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2998"
+                  }, {
+                    "description" : "RHSA-2019:3044",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3044"
+                  }, {
+                    "description" : "RHSA-2019:3045",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3045"
+                  }, {
+                    "description" : "RHSA-2019:3046",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3046"
+                  }, {
+                    "description" : "RHSA-2019:3050",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3050"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "RHSA-2019:3292",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3292"
+                  }, {
+                    "description" : "RHSA-2019:3297",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3297"
+                  }, {
+                    "description" : "RHSA-2019:3901",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+                  }, {
+                    "description" : "RHSA-2020:0727",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0727"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2",
+                    "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2387",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2387"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch opened a new pull request #1200: Upgrade jackson due to CVE issues",
+                    "url" : "https://lists.apache.org/thread.html/0fcef7321095ce0bc597d468d150cff3d647f4cb3aef3bd4d20e1c69@%3Ccommits.tinkerpop.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/2766188be238a446a250ef76801037d452979152d85bce5e46805815@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190822 [GitHub] [pulsar] massakam opened a new pull request #5011: [security] Upgrade jackson-databind",
+                    "url" : "https://lists.apache.org/thread.html/525bcf949a4b0da87a375cbad2680b8beccde749522f24c49befe7fb@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191027 [GitHub] [incubator-iceberg] rdsr commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/6788e4c991f75b89d290ad06b463fcd30bcae99fee610345a35b7bc6@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] mccheah opened a new pull request #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/689c6bcc6c7612eee71e453a115a4c8581e7b718537025d4b265783d@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] mccheah commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/75f482fdc84abe6d0c8f438a76437c335a7bbeb5cddd4d70b4bc0cbf@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue opened a new pull request #533: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/859815b2e9f1575acbb2b260b73861c16ca49bca627fa0c46419051f@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue merged pull request #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/8723b52c2544e6cb804bc8a36622c584acd1bd6c53f2b6034c9fea54@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                    "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue closed pull request #533: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/99944f86abefde389da9b4040ea2327c6aa0b53a2ff9352bd4cfec17@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue commented on issue #533: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/d161ff3d59c5a8213400dd6afb1cce1fac4f687c32d1e0c0bfbfaa2d@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[ambari-commits] 20190813 [ambari] branch branch-2.7 updated: AMBARI-25352 : Upgrade fasterxml jackson dependency due to CVE-2019-14379 (#3066)",
+                    "url" : "https://lists.apache.org/thread.html/e25e734c315f70d8876a846926cfe3bfa1a4888044f146e844caf72f@%3Ccommits.ambari.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[ambari-commits] 20190813 [ambari] branch trunk updated: AMBARI-25352 : Upgrade fasterxml jackson dependency due to CVE-2019-14379(trunk) (#3067)",
+                    "url" : "https://lists.apache.org/thread.html/f17f63b0f8a57e4a5759e01d25cffc0548f0b61ff5c6bfd704ad2f2a@%3Ccommits.ambari.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190812 [SECURITY] [DLA 1879-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/08/msg00011.html"
+                  }, {
+                    "description" : "FEDORA-2019-ae6a703b8f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+                  }, {
+                    "description" : "FEDORA-2019-fb23eccc03",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+                  }, {
+                    "description" : "FEDORA-2019-99ff6aa32c",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190814-0001/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190814-0001/"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-17267",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.3...jackson-databind-2.9.10",
+                    "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.3...jackson-databind-2.9.10"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2460",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2460"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                    "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[skywalking-dev] 20200324 [CVE-2019-17267] Upgrade jackson-databind version to 2.9.10",
+                    "url" : "https://lists.apache.org/thread.html/r9d727fc681fb3828794acbefcaee31393742b4d73a29461ccd9597a8@%3Cdev.skywalking.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20191210 [SECURITY] [DLA 2030-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/12/msg00013.html"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20191017-0006/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20191017-0006/"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2017-17485",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "20180109 CVE-2017-17485: one more way of rce in jackson-databind when defaultTyping+objects are used",
+                    "url" : "http://www.securityfocus.com/archive/1/541652/100/0/threaded"
+                  }, {
+                    "description" : "RHSA-2018:0116",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0116"
+                  }, {
+                    "description" : "RHSA-2018:0342",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0342"
+                  }, {
+                    "description" : "RHSA-2018:0478",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0478"
+                  }, {
+                    "description" : "RHSA-2018:0479",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0479"
+                  }, {
+                    "description" : "RHSA-2018:0480",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0480"
+                  }, {
+                    "description" : "RHSA-2018:0481",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0481"
+                  }, {
+                    "description" : "RHSA-2018:1447",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1447"
+                  }, {
+                    "description" : "RHSA-2018:1448",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1448"
+                  }, {
+                    "description" : "RHSA-2018:1449",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+                  }, {
+                    "description" : "RHSA-2018:1450",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+                  }, {
+                    "description" : "RHSA-2018:1451",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1451"
+                  }, {
+                    "description" : "RHSA-2018:2930",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2930"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1855",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1855"
+                  }, {
+                    "description" : "https://github.com/irsl/jackson-rce-via-spel/",
+                    "url" : "https://github.com/irsl/jackson-rce-via-spel/"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20180201-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20180201-0003/"
+                  }, {
+                    "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                    "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+                  }, {
+                    "description" : "DSA-4114",
+                    "url" : "https://www.debian.org/security/2018/dsa-4114"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-9547",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.8
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2634",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2634"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200308 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r35d30db00440ef63b791c4b7f7acb036e14d4a23afa2a249cb66c0fd@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r4accb2e0de9679174efd3d113a059bab71ff3ec53e882790d21c1cc1@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r4accb2e0de9679174efd3d113a059bab71ff3ec53e882790d21c1cc1@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r742ef70d126548dcf7de5be5779355c9d76a9aec71d7a9ef02c6398a@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r742ef70d126548dcf7de5be5779355c9d76a9aec71d7a9ef02c6398a@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r9464a40d25c3ba1a55622db72f113eb494a889656962d098c70c5bb1@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200319 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r98c9b6e4c9e17792e2cd1ec3e4aa20b61a791939046d3f10888176bb@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/ra3e90712f2d59f8cef03fa796f5adf163d32b81fe7b95385f21790e6@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/ra3e90712f2d59f8cef03fa796f5adf163d32b81fe7b95385f21790e6@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rb6fecb5e96a6d61e175ff49f33f2713798dd05cf03067c169d195596@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rc0d5d0f72da1ed6fc5e438b1ddb3fa090c73006b55f873cf845375ab@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rc0d5d0f72da1ed6fc5e438b1ddb3fa090c73006b55f873cf845375ab@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200307 Build failed in Jenkins: PreCommit-ZOOKEEPER-github-pr-build-maven #1898",
+                    "url" : "https://lists.apache.org/thread.html/rd0e958d6d5c5ee16efed73314cd0e445c8dbb4bdcc80fc9d1d6c11fc@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200319 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rd5a4457be4623038c3989294429bc063eec433a2e55995d81591e2ca@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200307 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rdd49ab9565bec436a896bc00c4b9fc9dce1598e106c318524fbdfec6@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/redbe4f1e21bf080f637cf9fbec47729750a2f443a919765360337428@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/redbe4f1e21bf080f637cf9fbec47729750a2f443a919765360337428@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200305 [SECURITY] [DLA 2135-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00008.html"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-9548",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.8
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2634",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2634"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200308 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r35d30db00440ef63b791c4b7f7acb036e14d4a23afa2a249cb66c0fd@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r9464a40d25c3ba1a55622db72f113eb494a889656962d098c70c5bb1@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200319 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r98c9b6e4c9e17792e2cd1ec3e4aa20b61a791939046d3f10888176bb@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rb6fecb5e96a6d61e175ff49f33f2713798dd05cf03067c169d195596@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200319 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rd5a4457be4623038c3989294429bc063eec433a2e55995d81591e2ca@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200307 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rdd49ab9565bec436a896bc00c4b9fc9dce1598e106c318524fbdfec6@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200305 [SECURITY] [DLA 2135-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00008.html"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-14439",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.0
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/ad418eeb974e357f2797aef64aa0e3ffaaa6125b",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/ad418eeb974e357f2797aef64aa0e3ffaaa6125b"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2",
+                    "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2389",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2389"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                    "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190812 [SECURITY] [DLA 1879-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/08/msg00011.html"
+                  }, {
+                    "description" : "FEDORA-2019-ae6a703b8f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+                  }, {
+                    "description" : "FEDORA-2019-fb23eccc03",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+                  }, {
+                    "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190814-0001/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190814-0001/"
+                  }, {
+                    "description" : "DSA-4542",
+                    "url" : "https://www.debian.org/security/2019/dsa-4542"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-20330",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.10.1...jackson-databind-2.9.10.2",
+                    "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.10.1...jackson-databind-2.9.10.2"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2526",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2526"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200118 Build failed in Jenkins: zookeeper-master-maven-owasp #329",
+                    "url" : "https://lists.apache.org/thread.html/r107c8737db39ec9ec4f4e7147b249e29be79170b9ef4b80528105a2d@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200123 [GitHub] [zookeeper] nkalmar commented on issue #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r2c77dd6ab8344285bd8e481b57cf3029965a4b0036eefccef74cdd44@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                    "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200123 [jira] [Updated] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r3f8180d0d25a7c6473ebb9714b0c1d19a73f455ae70d0c5fefc17e6c@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200122 [jira] [Updated] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r428735963bee7cb99877b88d3228e28ec28af64646455c4f3e7a3c94@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200122 [jira] [Commented] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r50f513772f12e1babf65c7c2b9c16425bac2d945351879e2e267517f@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200118 [jira] [Created] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r5c14fdcabdeaba258857bcb67198652e4dce1d33ddc590cd81d82393@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [GitHub] [druid] ccaominh opened a new pull request #9191: [Backport] Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189)",
+                    "url" : "https://lists.apache.org/thread.html/r5c3644c97f0434d1ceb48ff48897a67bdbf3baf7efbe7d04625425b3@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200118 [jira] [Commented] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r5d3d10fdf28110da3f9ac1b7d08d7e252f98d7d37ce0a6bd139a2e4f@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200123 [zookeeper] branch branch-3.5 updated: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r67f4d4c48197454b83d62afbed8bebbda3764e6e3a6e26a848961764@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200123 [jira] [Resolved] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r707d23bb9ee245f50aa909add0da6e8d8f24719b1278ddd99d2428b2@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200123 [zookeeper] branch branch-3.6 updated: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r7a0821b44247a1e6c6fe5f2943b90ebc4f80a8d1fb0aa9a8b29a59a2@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [GitHub] [druid] clintropolis merged pull request #9191: [Backport] Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189)",
+                    "url" : "https://lists.apache.org/thread.html/r7fb123e7dad49af5886cfec7135c0fd5b74e4c67af029e1dc91ba744@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200123 [zookeeper] branch master updated: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r8831b7fa5ca87a1cf23ee08d6dedb7877a964c1d2bd869af24056a63@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200118 [jira] [Created] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r909c822409a276ba04dc2ae31179b16f6864ba02c4f9911bdffebf95@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200122 [GitHub] [zookeeper] phunt commented on issue #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/ra2e572f568de8df5ba151e6aebb225a0629faaf0476bf7c7ed877af8@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200122 [GitHub] [zookeeper] phunt opened a new pull request #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/ra5ce96faec37c26b0aa15b4b6a8b1cbb145a748653e56ae83e9685d0@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200122 Re: 3.5.7",
+                    "url" : "https://lists.apache.org/thread.html/ra8a80dbc7319916946397823aec0d893d24713cbf7b5aee0e957298c@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [GitHub] [druid] clintropolis merged pull request #9189: Suppress CVE-2019-20330 for htrace-core-4.0.1",
+                    "url" : "https://lists.apache.org/thread.html/rb532fed78d031fff477fd840b81946f6d1200f93a63698dae65aa528@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200123 [jira] [Commented] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/rd1f346227e11fc515914f3a7b20d81543e51e5822ba71baa0452634a@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200123 [GitHub] [zookeeper] asfgit closed pull request #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/rd49cfa41bbb71ef33b53736a6af2aa8ba88c2106e30f2a34902a87d2@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200114 [GitHub] [druid] ccaominh opened a new pull request #9189: Suppress CVE-2019-20330 for htrace-core-4.0.1",
+                    "url" : "https://lists.apache.org/thread.html/rd6c6fef14944f3dcfb58d35f9317eb1c32a700e86c1b5231e45d3d0b@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200122 [jira] [Assigned] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/rfa57d9c2a27d3af14c69607fb1a3da00e758b2092aa88eb6a51b6e99@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200220 [SECURITY] [DLA 2111-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00020.html"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20200127-0004/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20200127-0004/"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-12814",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 4.3
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:2935",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+                  }, {
+                    "description" : "RHSA-2019:2936",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+                  }, {
+                    "description" : "RHSA-2019:2937",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+                  }, {
+                    "description" : "RHSA-2019:2938",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+                  }, {
+                    "description" : "RHSA-2019:3044",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3044"
+                  }, {
+                    "description" : "RHSA-2019:3045",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3045"
+                  }, {
+                    "description" : "RHSA-2019:3046",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3046"
+                  }, {
+                    "description" : "RHSA-2019:3050",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3050"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "RHSA-2019:3292",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3292"
+                  }, {
+                    "description" : "RHSA-2019:3297",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3297"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2341",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2341"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20190623 [jira] [Created] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/129da0204c876f746636018751a086cc581e0e07bcdeb3ee22ff5731@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190623 [jira] [Created] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/15a55e1d837fa686db493137cc0330c7ee1089ed9a9eea7ae7151ef1@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190623 [GitHub] [zookeeper] eolivelli opened a new pull request #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/1e04d9381c801b31ab28dec813c31c304b2a596b2a3707fa5462c5c0@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190712 [jira] [Resolved] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/28be28ffd6471d230943a255c36fe196a54ef5afc494a4781d16e37c@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190712 [jira] [Commented] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/2ff264b6a94c5363a35c4c88fa93216f60ec54d1d973ed6b76a9f560@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190624 [GitHub] [zookeeper] eolivelli closed pull request #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/4b832d1327703d6b287a6d223307f8f884d798821209a10647e93324@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190712 [jira] [Assigned] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/71f9ffd92410a889e27b95a219eaa843fd820f8550898633d85d4ea3@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190624 [GitHub] [zookeeper] eolivelli commented on issue #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/8fe2983f6d9fee0aa737e4bd24483f8f5cf9b938b9adad0c4e79b2a4@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                    "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190708 [jira] [Commented] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/a3ae8a8c5e32c413cd27071d3a204166050bf79ce7f1299f6866338f@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190624 [GitHub] [zookeeper] phunt commented on a change in pull request #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/a62aa2706105d68f1c02023fe24aaa3c13b4d8a1826181fed07d9682@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190623 [jira] [Updated] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/a78239b1f11cddfa86e4edee19064c40b6272214630bfef070c37957@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190713 [jira] [Updated] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/b0a2b2cca072650dbd5882719976c3d353972c44f6736ddf0ba95209@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190710 [GitHub] [zookeeper] phunt closed pull request #1013: ZOOKEEPER-3441: OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/b148fa2e9ef468c4de00de255dd728b74e2a97d935f8ced31eb41ba2@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[accumulo-commits] 20190723 [accumulo] branch 2.0 updated: Fix CVE-2019-12814 Use jackson-databind 2.9.9.1",
+                    "url" : "https://lists.apache.org/thread.html/bf20574dbc2db255f1fd489942b5720f675e32a2c4f44eb6a36060cd@%3Ccommits.accumulo.apache.org%3E"
+                  }, {
+                    "description" : "[geode-notifications] 20191007 [GitHub] [geode] jmelchio commented on issue #4102: Fix for GEODE-7255: Pickup Jackson CVE fix",
+                    "url" : "https://lists.apache.org/thread.html/e0733058c0366b703e6757d8d2a7a04b943581f659e9c271f0841dfe@%3Cnotifications.geode.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190710 [GitHub] [zookeeper] phunt opened a new pull request #1013: ZOOKEEPER-3441: OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/eff7280055fc717ea8129cd28a9dd57b8446d00b36260c1caee10b87@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190621 [SECURITY] [DLA 1831-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/06/msg00019.html"
+                  }, {
+                    "description" : "FEDORA-2019-ae6a703b8f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+                  }, {
+                    "description" : "FEDORA-2019-fb23eccc03",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+                  }, {
+                    "description" : "FEDORA-2019-99ff6aa32c",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190625-0006/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190625-0006/"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-11307",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "https://access.redhat.com/errata/RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2032",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2032"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-issues] 20191004 [GitHub] [lucene-solr] marungo opened a new pull request #925: SOLR-13818: Upgrade jackson to 2.10.0",
+                    "url" : "https://lists.apache.org/thread.html/7fcf88aff0d1deaa5c3c7be8d58c05ad7ad5da94b59065d8e7c50c5d@%3Cissues.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  }, {
+                    "description" : "https://nvd.nist.gov/vuln/detail/CVE-2017-7525",
+                    "url" : "https://nvd.nist.gov/vuln/detail/CVE-2017-7525"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-14719",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-14718",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "106601",
+                    "url" : "http://www.securityfocus.com/bid/106601"
+                  }, {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Assigned] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                    "url" : "https://lists.apache.org/thread.html/6a78f88716c3c57aa74ec05764a37ab3874769a347805903b393b286@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                    "url" : "https://lists.apache.org/thread.html/82b01bfb6787097427ce97cec6a7127e93718bc05d1efd5eaffc228f@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                    "url" : "https://lists.apache.org/thread.html/ba973114605d936be276ee6ce09dfbdbf78aa56f6cdc6e79bfa7b8df@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-10672",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.8
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2659",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2659"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200322 [SECURITY] [DLA 2153-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00027.html"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-10673",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.8
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2660",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2660"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200322 [SECURITY] [DLA 2153-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00027.html"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-7489",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html"
+                  }, {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html"
+                  }, {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+                  }, {
+                    "description" : "103203",
+                    "url" : "http://www.securityfocus.com/bid/103203"
+                  }, {
+                    "description" : "1040693",
+                    "url" : "http://www.securitytracker.com/id/1040693"
+                  }, {
+                    "description" : "1041890",
+                    "url" : "http://www.securitytracker.com/id/1041890"
+                  }, {
+                    "description" : "RHSA-2018:1447",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1447"
+                  }, {
+                    "description" : "RHSA-2018:1448",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1448"
+                  }, {
+                    "description" : "RHSA-2018:1449",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+                  }, {
+                    "description" : "RHSA-2018:1450",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+                  }, {
+                    "description" : "RHSA-2018:1451",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1451"
+                  }, {
+                    "description" : "RHSA-2018:1786",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1786"
+                  }, {
+                    "description" : "RHSA-2018:2088",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2088"
+                  }, {
+                    "description" : "RHSA-2018:2089",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2089"
+                  }, {
+                    "description" : "RHSA-2018:2090",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2090"
+                  }, {
+                    "description" : "RHSA-2018:2938",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2938"
+                  }, {
+                    "description" : "RHSA-2018:2939",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2939"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1931",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1931"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20180328-0001/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20180328-0001/"
+                  }, {
+                    "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                    "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+                  }, {
+                    "description" : "DSA-4190",
+                    "url" : "https://www.debian.org/security/2018/dsa-4190"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-5968",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.1
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2018:0478",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0478"
+                  }, {
+                    "description" : "RHSA-2018:0479",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0479"
+                  }, {
+                    "description" : "RHSA-2018:0480",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0480"
+                  }, {
+                    "description" : "RHSA-2018:0481",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0481"
+                  }, {
+                    "description" : "RHSA-2018:1525",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1525"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1899",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1899"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20180423-0002/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20180423-0002/"
+                  }, {
+                    "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                    "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+                  }, {
+                    "description" : "DSA-4114",
+                    "url" : "https://www.debian.org/security/2018/dsa-4114"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-1000873",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 4.3
+                  },
+                  "references" : [ {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1665601",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1665601"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-modules-java8/issues/90",
+                    "url" : "https://github.com/FasterXML/jackson-modules-java8/issues/90"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-modules-java8/pull/87",
+                    "url" : "https://github.com/FasterXML/jackson-modules-java8/pull/87"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                } ]
+              },
+              "feature" : {
+                "type" : "VulnerabilitiesInProject",
+                "name" : "Info about vulnerabilities in open-source project"
+              }
+            } ],
+            "explanation" : [ "No unpatched vulnerabilities found which is good" ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "ProjectActivityScore",
+              "name" : "Open-source project activity score"
+            },
+            "value" : 9.841460358665667,
+            "weight" : 0.6300785405632551,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "ExpiringValue",
+              "value" : {
+                "type" : "IntegerValue",
+                "feature" : {
+                  "type" : "PositiveIntegerFeature",
+                  "name" : "Number of commits in the last three months"
+                },
+                "number" : 270
+              },
+              "expiration" : 1585306315391
+            }, {
+              "type" : "ExpiringValue",
+              "value" : {
+                "type" : "IntegerValue",
+                "feature" : {
+                  "type" : "PositiveIntegerFeature",
+                  "name" : "Number of contributors in the last three months"
+                },
+                "number" : 11
+              },
+              "expiration" : 1585306320816
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "CommunityCommitmentScore",
+              "name" : "How well open-source community commits to support an open-source project"
+            },
+            "value" : 0.0,
+            "weight" : 0.5529742430404292,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "BooleanValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project is supported by a company"
+              },
+              "flag" : false
+            }, {
+              "type" : "BooleanValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project belongs to Apache Foundation"
+              },
+              "flag" : false
+            }, {
+              "type" : "BooleanValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project belongs to Eclipse Foundation"
+              },
+              "flag" : false
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "ProjectSecurityAwarenessScore",
+              "name" : "How well open-source community is aware about security"
+            },
+            "value" : 3.0,
+            "weight" : 0.5383270608555468,
+            "confidence" : 6.666666666666667,
+            "usedValues" : [ {
+              "type" : "BooleanValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project has a security policy"
+              },
+              "flag" : true
+            }, {
+              "type" : "UnknownValue",
+              "feature" : {
+                "type" : "BooleanFeature",
+                "name" : "If an open-source project has a security team"
+              }
+            }, {
+              "type" : "ExpiringValue",
+              "value" : {
+                "type" : "BooleanValue",
+                "feature" : {
+                  "type" : "BooleanFeature",
+                  "name" : "If a project uses verified signed commits"
+                },
+                "flag" : false
+              },
+              "expiration" : 1585306340828
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "VulnerabilityLifetimeScore",
+              "name" : "How fast vulnerabilities are patched"
+            },
+            "value" : 0.0,
+            "weight" : 0.22939855566110368,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "VulnerabilitiesValue",
+              "vulnerabilities" : {
+                "entries" : [ {
+                  "id" : "CVE-2019-12384",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 4.3
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:1820",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1820"
+                  }, {
+                    "description" : "RHSA-2019:2720",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2720"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:2935",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+                  }, {
+                    "description" : "RHSA-2019:2936",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+                  }, {
+                    "description" : "RHSA-2019:2937",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+                  }, {
+                    "description" : "RHSA-2019:2938",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+                  }, {
+                    "description" : "RHSA-2019:2998",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2998"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "RHSA-2019:3292",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3292"
+                  }, {
+                    "description" : "RHSA-2019:3297",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3297"
+                  }, {
+                    "description" : "RHSA-2019:3901",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+                  }, {
+                    "description" : "RHSA-2019:4352",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4352"
+                  }, {
+                    "description" : "https://blog.doyensec.com/2019/07/22/jackson-gadgets.html",
+                    "url" : "https://blog.doyensec.com/2019/07/22/jackson-gadgets.html"
+                  }, {
+                    "description" : "https://doyensec.com/research.html",
+                    "url" : "https://doyensec.com/research.html"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/compare/74b90a4...a977aad",
+                    "url" : "https://github.com/FasterXML/jackson-databind/compare/74b90a4...a977aad"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                    "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[geode-notifications] 20191007 [GitHub] [geode] jmelchio commented on issue #4102: Fix for GEODE-7255: Pickup Jackson CVE fix",
+                    "url" : "https://lists.apache.org/thread.html/e0733058c0366b703e6757d8d2a7a04b943581f659e9c271f0841dfe@%3Cnotifications.geode.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.debian.org/debian-lts-announce/2019/06/msg00019.html",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/06/msg00019.html"
+                  }, {
+                    "description" : "FEDORA-2019-ae6a703b8f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+                  }, {
+                    "description" : "FEDORA-2019-fb23eccc03",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+                  }, {
+                    "description" : "FEDORA-2019-99ff6aa32c",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+                  }, {
+                    "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190703-0002/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190703-0002/"
+                  }, {
+                    "description" : "DSA-4542",
+                    "url" : "https://www.debian.org/security/2019/dsa-4542"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-14540",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/blob/master/release-notes/VERSION-2.x",
+                    "url" : "https://github.com/FasterXML/jackson-databind/blob/master/release-notes/VERSION-2.x"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2410",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2410"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2449",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2449"
+                  }, {
+                    "description" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch opened a new pull request #1200: Upgrade jackson due to CVE issues",
+                    "url" : "https://lists.apache.org/thread.html/0fcef7321095ce0bc597d468d150cff3d647f4cb3aef3bd4d20e1c69@%3Ccommits.tinkerpop.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190925 [GitHub] [hbase] SteNicholas opened a new pull request #660: HBASE-23075 Upgrade jackson version",
+                    "url" : "https://lists.apache.org/thread.html/40c00861b53bb611dee7d6f35f864aa7d1c1bd77df28db597cbf27e1@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190926 [GitHub] [hbase-connectors] SteNicholas opened a new pull request #45: HBASE-23075 Upgrade jackson version",
+                    "url" : "https://lists.apache.org/thread.html/a360b46061c91c5cad789b6c3190aef9b9f223a2b75c9c9f046fe016@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190925 [GitHub] [zookeeper] maoling commented on issue #1097: ZOOKEEPER-3559 - Update Jackson to 2.9.10",
+                    "url" : "https://lists.apache.org/thread.html/a4f2c9fb36642a48912cdec6836ec00e497427717c5d377f8d7ccce6@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190926 [jira] [Commented] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                    "url" : "https://lists.apache.org/thread.html/ad0d238e97a7da5eca47a014f0f7e81f440ed6bf74a93183825e18b9@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190926 [jira] [Updated] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                    "url" : "https://lists.apache.org/thread.html/dc6b5cad721a4f6b3b62ed1163894941140d9d5656140fb757505ca0@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-commits] 20190927 [hbase-connectors] 02/02: HBASE-23075 Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                    "url" : "https://lists.apache.org/thread.html/e90c3feb21702e68a8c08afce37045adb3870f2bf8223fa403fb93fb@%3Ccommits.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+                  }, {
+                    "description" : "FEDORA-2019-cf87377f5f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+                  }, {
+                    "description" : "FEDORA-2019-b171554877",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+                  }, {
+                    "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20191004-0002/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20191004-0002/"
+                  }, {
+                    "description" : "DSA-4542",
+                    "url" : "https://www.debian.org/security/2019/dsa-4542"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-16942",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:3901",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+                  }, {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2478",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2478"
+                  }, {
+                    "description" : "https://issues.apache.org/jira/browse/GEODE-7255",
+                    "url" : "https://issues.apache.org/jira/browse/GEODE-7255"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[geode-issues] 20191011 [jira] [Commented] (GEODE-7255) Need to pick up CVE-2019-16942",
+                    "url" : "https://lists.apache.org/thread.html/7782a937c9259a58337ee36b2961f00e2d744feafc13084e176d0df5@%3Cissues.geode.apache.org%3E"
+                  }, {
+                    "description" : "[geode-issues] 20191230 [jira] [Closed] (GEODE-7255) Need to pick up CVE-2019-16942",
+                    "url" : "https://lists.apache.org/thread.html/a430dbc9be874c41314cc69e697384567a9a24025e819d9485547954@%3Cissues.geode.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[geode-issues] 20191008 [jira] [Commented] (GEODE-7255) Need to pick up CVE-2019-16942",
+                    "url" : "https://lists.apache.org/thread.html/b2e23c94f9dfef53e04c492e5d02e5c75201734be7adc73a49ef2370@%3Cissues.geode.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+                  }, {
+                    "description" : "FEDORA-2019-cf87377f5f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+                  }, {
+                    "description" : "FEDORA-2019-b171554877",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  }, {
+                    "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20191017-0006/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20191017-0006/"
+                  }, {
+                    "description" : "DSA-4542",
+                    "url" : "https://www.debian.org/security/2019/dsa-4542"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-8840",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2620",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2620"
+                  }, {
+                    "description" : "[druid-commits] 20200219 [GitHub] [druid] ccaominh opened a new pull request #9379: Suppress CVE-2020-8840 for htrace-core-4.0.1",
+                    "url" : "https://lists.apache.org/thread.html/r078e68a926ea6be12e8404e47f45aabf04bb4668e8265c0de41db6db@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20200313 Re: CVE-2020-8840 on TomEE 8.0.1",
+                    "url" : "https://lists.apache.org/thread.html/r1c09b9551f6953dbeca190a4c4b78198cdbb9825fce36f96fe3d8218@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200219 [GitHub] [druid] suneet-s commented on issue #9379: Suppress CVE-2020-8840 for htrace-core-4.0.1",
+                    "url" : "https://lists.apache.org/thread.html/r319f19c74e06c201b9d4e8b282a4e4b2da6dcda022fb46f007dd00d3@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200223 [GitHub] [zookeeper] eolivelli opened a new pull request #1262: ZOOKEEPER-3734 upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r3539bd3a377991217d724879d239e16e86001c54160076408574e1da@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200221 [GitHub] [druid] ccaominh merged pull request #9379: Suppress CVE-2020-8840 for htrace-core-4.0.1",
+                    "url" : "https://lists.apache.org/thread.html/r3d20a2660b36551fd8257d479941782af4a7169582449fac1704bde2@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200223 [GitHub] [zookeeper] phunt commented on issue #1262: ZOOKEEPER-3734 upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r428d068b2a4923f1a5a4f5fc6381b95205cfe7620169d16db78e9c71@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200223 [zookeeper] branch master updated: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r46bebdeb59b8b7212d63a010ca445a9f5c4e9d64dcf693cab6f399d3@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200225 [jira] [Updated] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r65ee95fa09c831843bac81eaa582fdddc2b6119912a72d1c83a9b882@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200223 [jira] [Updated] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r6fdd4c61a09a0c89f581b4ddb3dc6f154ab0c705fcfd0a7358b2e4e5@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200223 [jira] [Resolved] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r8170007fd9b263d65b37d92a7b5d7bc357aedbb113a32838bc4a9485@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200222 [jira] [Created] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/r9ecf211c22760b00967ebe158c6ed7dba9142078e2a630ab8904a5b7@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200223 [GitHub] [zookeeper] asfgit closed pull request #1262: ZOOKEEPER-3734 upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/rac5ee5d686818be7e7c430d35108ee01a88aae54f832d32f62431fd1@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200222 [jira] [Created] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/rb43f9a65150948a6bebd3cb77ee3e105d40db2820fd547528f4e7f89@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200224 [zookeeper] 01/02: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/rb5eedf90ba3633e171a2ffdfe484651c9490dc5df74c8a29244cbc0e@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20200311 CVE-2020-8840 on TomEE 8.0.1",
+                    "url" : "https://lists.apache.org/thread.html/rb99c7321eba5d4c907beec46675d52827528b738cfafd48eb4d862f1@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20200316 RE: CVE-2020-8840 on TomEE 8.0.1",
+                    "url" : "https://lists.apache.org/thread.html/rc068e824654c4b8bd4f2490bec869e29edbfcd5dfe02d47cbf7433b2@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20200311 Re: CVE-2020-8840 on TomEE 8.0.1",
+                    "url" : "https://lists.apache.org/thread.html/rdea588d4a0ebf9cb7ce8c3a8f18d0d306507c4f8ba178dd3d20207b8@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200223 [zookeeper] branch branch-3.6 updated: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/rdf8d389271a291dde3b2f99c36918d6cb1e796958af626cc140fee23@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200223 [jira] [Assigned] (ZOOKEEPER-3734) upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/re7326b8655eab931f2a9ce074fd9a1a51b5db11456bee9b48e1e170c@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200223 [zookeeper] branch branch-3.5 updated: ZOOKEEPER-3734: upgrade jackson-databind to address CVE-2020-8840",
+                    "url" : "https://lists.apache.org/thread.html/re8ae2670ec456ef1c5a2a661a2838ab2cd00e9efa1e88c069f546f21@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200220 [SECURITY] [DLA 2111-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00020.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-12086",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.0
+                  },
+                  "references" : [ {
+                    "description" : "http://russiansecurity.expert/2016/04/20/mysql-connect-file-read/",
+                    "url" : "http://russiansecurity.expert/2016/04/20/mysql-connect-file-read/"
+                  }, {
+                    "description" : "109227",
+                    "url" : "http://www.securityfocus.com/bid/109227"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:2935",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+                  }, {
+                    "description" : "RHSA-2019:2936",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+                  }, {
+                    "description" : "RHSA-2019:2937",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+                  }, {
+                    "description" : "RHSA-2019:2938",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+                  }, {
+                    "description" : "RHSA-2019:2998",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2998"
+                  }, {
+                    "description" : "RHSA-2019:3044",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3044"
+                  }, {
+                    "description" : "RHSA-2019:3045",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3045"
+                  }, {
+                    "description" : "RHSA-2019:3046",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3046"
+                  }, {
+                    "description" : "RHSA-2019:3050",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3050"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2326",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2326"
+                  }, {
+                    "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[spark-reviews] 20190520 [GitHub] [spark] Fokko opened a new pull request #24646: Spark 27757",
+                    "url" : "https://lists.apache.org/thread.html/88cd25375805950ae7337e669b0cb0eeda98b9604c1b8d806dccbad2@%3Creviews.spark.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-solr-user] 20200320 CVEs (vulnerabilities) that apply to Solr 8.4.1",
+                    "url" : "https://lists.apache.org/thread.html/r204ba2a9ea750f38d789d2bb429cc0925ad6133deea7cbc3001d96b5@%3Csolr-user.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190521 [SECURITY] [DLA 1798-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/05/msg00030.html"
+                  }, {
+                    "description" : "FEDORA-2019-ae6a703b8f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+                  }, {
+                    "description" : "FEDORA-2019-fb23eccc03",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+                  }, {
+                    "description" : "FEDORA-2019-99ff6aa32c",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-16943",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2478",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2478"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-commits] 20191028 [incubator-iceberg] branch master updated: Update Jackson to 2.10.0 for CVE-2019-16943 (#583)",
+                    "url" : "https://lists.apache.org/thread.html/5ec8d8d485c2c8ac55ea425f4cd96596ef37312532712639712ebcdd@%3Ccommits.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191027 [GitHub] [incubator-iceberg] rdsr commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/6788e4c991f75b89d290ad06b463fcd30bcae99fee610345a35b7bc6@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                    "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+                  }, {
+                    "description" : "FEDORA-2019-cf87377f5f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+                  }, {
+                    "description" : "FEDORA-2019-b171554877",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  }, {
+                    "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20191017-0006/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20191017-0006/"
+                  }, {
+                    "description" : "DSA-4542",
+                    "url" : "https://www.debian.org/security/2019/dsa-4542"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-17531",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:4192",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4192"
+                  }, {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2498",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2498"
+                  }, {
+                    "description" : "[pulsar-commits] 20191127 [GitHub] [pulsar] massakam opened a new pull request #5758: Bump jackson libraries to 2.10.1",
+                    "url" : "https://lists.apache.org/thread.html/b3c90d38f99db546de60fea65f99a924d540fae2285f014b79606ca5@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                    "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20191210 [SECURITY] [DLA 2030-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/12/msg00013.html"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20191024-0005/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20191024-0005/"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-19362",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "107985",
+                    "url" : "http://www.securityfocus.com/bid/107985"
+                  }, {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2186",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2186"
+                  }, {
+                    "description" : "https://issues.apache.org/jira/browse/TINKERPOP-2121",
+                    "url" : "https://issues.apache.org/jira/browse/TINKERPOP-2121"
+                  }, {
+                    "description" : "[infra-devnull] 20190329 [GitHub] [pulsar] massakam opened pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/37e1ed724a1b0e5d191d98c822c426670bdfde83804567131847d2a3@%3Cdevnull.infra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190329 [GitHub] [pulsar] massakam opened a new pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/c70da3cb6e3f03e0ad8013e38b6959419d866c4a7c80fdd34b73f25c@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-19361",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "107985",
+                    "url" : "http://www.securityfocus.com/bid/107985"
+                  }, {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2186",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2186"
+                  }, {
+                    "description" : "https://issues.apache.org/jira/browse/TINKERPOP-2121",
+                    "url" : "https://issues.apache.org/jira/browse/TINKERPOP-2121"
+                  }, {
+                    "description" : "[infra-devnull] 20190329 [GitHub] [pulsar] massakam opened pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/37e1ed724a1b0e5d191d98c822c426670bdfde83804567131847d2a3@%3Cdevnull.infra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190329 [GitHub] [pulsar] massakam opened a new pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/c70da3cb6e3f03e0ad8013e38b6959419d866c4a7c80fdd34b73f25c@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-19360",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "107985",
+                    "url" : "http://www.securityfocus.com/bid/107985"
+                  }, {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/42912cac4753f3f718ece875e4d486f8264c2f2b"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2186",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2186"
+                  }, {
+                    "description" : "https://issues.apache.org/jira/browse/TINKERPOP-2121",
+                    "url" : "https://issues.apache.org/jira/browse/TINKERPOP-2121"
+                  }, {
+                    "description" : "[infra-devnull] 20190329 [GitHub] [pulsar] massakam opened pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/37e1ed724a1b0e5d191d98c822c426670bdfde83804567131847d2a3@%3Cdevnull.infra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190329 [GitHub] [pulsar] massakam opened a new pull request #3938: Upgrade third party libraries with security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/c70da3cb6e3f03e0ad8013e38b6959419d866c4a7c80fdd34b73f25c@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2017-15095",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html"
+                  }, {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html"
+                  }, {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+                  }, {
+                    "description" : "103880",
+                    "url" : "http://www.securityfocus.com/bid/103880"
+                  }, {
+                    "description" : "1039769",
+                    "url" : "http://www.securitytracker.com/id/1039769"
+                  }, {
+                    "description" : "RHSA-2017:3189",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3189"
+                  }, {
+                    "description" : "RHSA-2017:3190",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3190"
+                  }, {
+                    "description" : "RHSA-2018:0342",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0342"
+                  }, {
+                    "description" : "RHSA-2018:0478",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0478"
+                  }, {
+                    "description" : "RHSA-2018:0479",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0479"
+                  }, {
+                    "description" : "RHSA-2018:0480",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0480"
+                  }, {
+                    "description" : "RHSA-2018:0481",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0481"
+                  }, {
+                    "description" : "RHSA-2018:0576",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0576"
+                  }, {
+                    "description" : "RHSA-2018:0577",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0577"
+                  }, {
+                    "description" : "RHSA-2018:1447",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1447"
+                  }, {
+                    "description" : "RHSA-2018:1448",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1448"
+                  }, {
+                    "description" : "RHSA-2018:1449",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+                  }, {
+                    "description" : "RHSA-2018:1450",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+                  }, {
+                    "description" : "RHSA-2018:1451",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1451"
+                  }, {
+                    "description" : "RHSA-2018:2927",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2927"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1680",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1680"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1737",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1737"
+                  }, {
+                    "description" : "[lucene-solr-user] 20191219 Re: CVE-2017-7525 fix for Solr 7.7.x",
+                    "url" : "https://lists.apache.org/thread.html/f095a791bda6c0595f691eddd0febb2d396987eec5cbd29120d8c629@%3Csolr-user.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200131 [SECURITY] [DLA 2091-1] libjackson-json-java security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/01/msg00037.html"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20171214-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20171214-0003/"
+                  }, {
+                    "description" : "DSA-4037",
+                    "url" : "https://www.debian.org/security/2017/dsa-4037"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2017-7525",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html"
+                  }, {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html"
+                  }, {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+                  }, {
+                    "description" : "99623",
+                    "url" : "http://www.securityfocus.com/bid/99623"
+                  }, {
+                    "description" : "1039744",
+                    "url" : "http://www.securitytracker.com/id/1039744"
+                  }, {
+                    "description" : "1039947",
+                    "url" : "http://www.securitytracker.com/id/1039947"
+                  }, {
+                    "description" : "1040360",
+                    "url" : "http://www.securitytracker.com/id/1040360"
+                  }, {
+                    "description" : "RHSA-2017:1834",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:1834"
+                  }, {
+                    "description" : "RHSA-2017:1835",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:1835"
+                  }, {
+                    "description" : "RHSA-2017:1836",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:1836"
+                  }, {
+                    "description" : "RHSA-2017:1837",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:1837"
+                  }, {
+                    "description" : "RHSA-2017:1839",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:1839"
+                  }, {
+                    "description" : "RHSA-2017:1840",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:1840"
+                  }, {
+                    "description" : "RHSA-2017:2477",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2477"
+                  }, {
+                    "description" : "RHSA-2017:2546",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2546"
+                  }, {
+                    "description" : "RHSA-2017:2547",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2547"
+                  }, {
+                    "description" : "RHSA-2017:2633",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2633"
+                  }, {
+                    "description" : "RHSA-2017:2635",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2635"
+                  }, {
+                    "description" : "RHSA-2017:2636",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2636"
+                  }, {
+                    "description" : "RHSA-2017:2637",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2637"
+                  }, {
+                    "description" : "RHSA-2017:2638",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:2638"
+                  }, {
+                    "description" : "RHSA-2017:3141",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3141"
+                  }, {
+                    "description" : "RHSA-2017:3454",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3454"
+                  }, {
+                    "description" : "RHSA-2017:3455",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3455"
+                  }, {
+                    "description" : "RHSA-2017:3456",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3456"
+                  }, {
+                    "description" : "RHSA-2017:3458",
+                    "url" : "https://access.redhat.com/errata/RHSA-2017:3458"
+                  }, {
+                    "description" : "RHSA-2018:0294",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0294"
+                  }, {
+                    "description" : "RHSA-2018:0342",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0342"
+                  }, {
+                    "description" : "RHSA-2018:1449",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+                  }, {
+                    "description" : "RHSA-2018:1450",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+                  }, {
+                    "description" : "RHSA-2019:0910",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0910"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1462702",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1462702"
+                  }, {
+                    "description" : "https://cwiki.apache.org/confluence/display/WW/S2-055",
+                    "url" : "https://cwiki.apache.org/confluence/display/WW/S2-055"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1599",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1599"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1723",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1723"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                    "url" : "https://lists.apache.org/thread.html/3c87dc8bca99a2b3b4743713b33d1de05b1d6b761fdf316224e9c81f@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20191113 [jira] [Created] (CASSANDRA-15416) CVE-2017-7525 ( jackson-databind is vulnerable to Remote Code Execution) on version 3.11.4",
+                    "url" : "https://lists.apache.org/thread.html/4641ed8616ccc2c1fbddac2c3dc9900c96387bc226eaf0232d61909b@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-solr-user] 20191218 CVE-2017-7525 fix for Solr 7.7.x",
+                    "url" : "https://lists.apache.org/thread.html/5008bcbd45ee65ce39e4220b6ac53d28a24d6bc67d5804e9773a7399@%3Csolr-user.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-solr-user] 20190104 Re: SOLR v7 Security Issues Caused Denial of Use - Sonatype Application Composition Report",
+                    "url" : "https://lists.apache.org/thread.html/708d94141126eac03011144a971a6411fcac16d9c248d1d535a39451@%3Csolr-user.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20191115 [GitHub] [incubator-druid] ccaominh opened a new pull request #8878: Address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/9317fd092b257a0815434b116a8af8daea6e920b6673f4fd5583d5fe@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                    "url" : "https://lists.apache.org/thread.html/b1f33fe5ade396bb903fdcabe9f243f7692c7dfce5418d3743c2d346@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Resolved] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                    "url" : "https://lists.apache.org/thread.html/c10a2bf0fdc3d25faf17bd191d6ec46b29a353fa9c97bebd7c4e5913@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Assigned] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                    "url" : "https://lists.apache.org/thread.html/c2ed4c0126b43e324cf740012a0edd371fd36096fd777be7bfe7a2a6@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-solr-user] 20191218 Re: CVE-2017-7525 fix for Solr 7.7.x",
+                    "url" : "https://lists.apache.org/thread.html/c9d5ff20929e8a3c8794facf4c4b326a9c10618812eec356caa20b87@%3Csolr-user.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-solr-user] 20191219 Re: CVE-2017-7525 fix for Solr 7.7.x",
+                    "url" : "https://lists.apache.org/thread.html/f095a791bda6c0595f691eddd0febb2d396987eec5cbd29120d8c629@%3Csolr-user.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Closed] (SOLR-13110) CVE-2017-7525 Threat Level 9 Against Solr v7.6. org.codehaus.jackson : jackson-mapper-asl : 1.9.13. .A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, ...",
+                    "url" : "https://lists.apache.org/thread.html/f60afd3c7e9ebaaf70fad4a4beb75cf8740ac959017a31e7006c7486@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200131 [SECURITY] [DLA 2091-1] libjackson-json-java security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/01/msg00037.html"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20171214-0002/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20171214-0002/"
+                  }, {
+                    "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                    "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+                  }, {
+                    "description" : "DSA-4004",
+                    "url" : "https://www.debian.org/security/2017/dsa-4004"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-14720",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:1106",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+                  }, {
+                    "description" : "RHSA-2019:1107",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+                  }, {
+                    "description" : "RHSA-2019:1108",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+                  }, {
+                    "description" : "RHSA-2019:1140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Assigned] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                    "url" : "https://lists.apache.org/thread.html/6a78f88716c3c57aa74ec05764a37ab3874769a347805903b393b286@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                    "url" : "https://lists.apache.org/thread.html/82b01bfb6787097427ce97cec6a7127e93718bc05d1efd5eaffc228f@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                    "url" : "https://lists.apache.org/thread.html/ba973114605d936be276ee6ce09dfbdbf78aa56f6cdc6e79bfa7b8df@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-14721",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:1106",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+                  }, {
+                    "description" : "RHSA-2019:1107",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+                  }, {
+                    "description" : "RHSA-2019:1108",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+                  }, {
+                    "description" : "RHSA-2019:1140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-12022",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.1
+                  },
+                  "references" : [ {
+                    "description" : "107585",
+                    "url" : "http://www.securityfocus.com/bid/107585"
+                  }, {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1106",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+                  }, {
+                    "description" : "RHSA-2019:1107",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+                  }, {
+                    "description" : "RHSA-2019:1108",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+                  }, {
+                    "description" : "RHSA-2019:1140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1671098",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1671098"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2052",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2052"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-issues] 20191004 [GitHub] [lucene-solr] marungo opened a new pull request #925: SOLR-13818: Upgrade jackson to 2.10.0",
+                    "url" : "https://lists.apache.org/thread.html/7fcf88aff0d1deaa5c3c7be8d58c05ad7ad5da94b59065d8e7c50c5d@%3Cissues.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf",
+                    "url" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-12023",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.1
+                  },
+                  "references" : [ {
+                    "description" : "http://www.securityfocus.com/bid/105659",
+                    "url" : "http://www.securityfocus.com/bid/105659"
+                  }, {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1106",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1106"
+                  }, {
+                    "description" : "RHSA-2019:1107",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1107"
+                  }, {
+                    "description" : "RHSA-2019:1108",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1108"
+                  }, {
+                    "description" : "RHSA-2019:1140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1140"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/28badf7ef60ac3e7ef151cd8e8ec010b8479226a"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2058",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2058"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-issues] 20191004 [GitHub] [lucene-solr] marungo opened a new pull request #925: SOLR-13818: Upgrade jackson to 2.10.0",
+                    "url" : "https://lists.apache.org/thread.html/7fcf88aff0d1deaa5c3c7be8d58c05ad7ad5da94b59065d8e7c50c5d@%3Cissues.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZEDLDUYBSTDY4GWDBUXGJNS2RFYTFVRC/"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf",
+                    "url" : "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-14893",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2020:0729",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0729"
+                  }, {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14893",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14893"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2469",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2469"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-16335",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "RHSA-2020:0729",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0729"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2449",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2449"
+                  }, {
+                    "description" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch opened a new pull request #1200: Upgrade jackson due to CVE issues",
+                    "url" : "https://lists.apache.org/thread.html/0fcef7321095ce0bc597d468d150cff3d647f4cb3aef3bd4d20e1c69@%3Ccommits.tinkerpop.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190925 [GitHub] [hbase] SteNicholas opened a new pull request #660: HBASE-23075 Upgrade jackson version",
+                    "url" : "https://lists.apache.org/thread.html/40c00861b53bb611dee7d6f35f864aa7d1c1bd77df28db597cbf27e1@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190926 [GitHub] [hbase-connectors] SteNicholas opened a new pull request #45: HBASE-23075 Upgrade jackson version",
+                    "url" : "https://lists.apache.org/thread.html/a360b46061c91c5cad789b6c3190aef9b9f223a2b75c9c9f046fe016@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190926 [jira] [Commented] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                    "url" : "https://lists.apache.org/thread.html/ad0d238e97a7da5eca47a014f0f7e81f440ed6bf74a93183825e18b9@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-issues] 20190926 [jira] [Updated] (HBASE-23075) Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                    "url" : "https://lists.apache.org/thread.html/dc6b5cad721a4f6b3b62ed1163894941140d9d5656140fb757505ca0@%3Cissues.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[hbase-commits] 20190927 [hbase-connectors] 02/02: HBASE-23075 Upgrade jackson to version 2.9.10 due to CVE-2019-16335 and CVE-2019-14540",
+                    "url" : "https://lists.apache.org/thread.html/e90c3feb21702e68a8c08afce37045adb3870f2bf8223fa403fb93fb@%3Ccommits.hbase.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20191002 [SECURITY] [DLA 1943-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/10/msg00001.html"
+                  }, {
+                    "description" : "FEDORA-2019-cf87377f5f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Q7CANA7KV53JROZDX5Z5P26UG5VN2K43/"
+                  }, {
+                    "description" : "FEDORA-2019-b171554877",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TH5VFUN4P7CCIP7KSEXYA5MUTFCUDUJT/"
+                  }, {
+                    "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20191004-0002/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20191004-0002/"
+                  }, {
+                    "description" : "DSA-4542",
+                    "url" : "https://www.debian.org/security/2019/dsa-4542"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-14892",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2020:0729",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0729"
+                  }, {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14892",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-14892"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2462",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2462"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-9546",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.8
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2631",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2631"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200308 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r35d30db00440ef63b791c4b7f7acb036e14d4a23afa2a249cb66c0fd@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r9464a40d25c3ba1a55622db72f113eb494a889656962d098c70c5bb1@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200319 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r98c9b6e4c9e17792e2cd1ec3e4aa20b61a791939046d3f10888176bb@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rb6fecb5e96a6d61e175ff49f33f2713798dd05cf03067c169d195596@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200319 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rd5a4457be4623038c3989294429bc063eec433a2e55995d81591e2ca@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200307 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rdd49ab9565bec436a896bc00c4b9fc9dce1598e106c318524fbdfec6@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200305 [SECURITY] [DLA 2135-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00008.html"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-14379",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHBA-2019:2824",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:2824"
+                  }, {
+                    "description" : "RHSA-2019:2743",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2743"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:2935",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+                  }, {
+                    "description" : "RHSA-2019:2936",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+                  }, {
+                    "description" : "RHSA-2019:2937",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+                  }, {
+                    "description" : "RHSA-2019:2938",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+                  }, {
+                    "description" : "RHSA-2019:2998",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2998"
+                  }, {
+                    "description" : "RHSA-2019:3044",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3044"
+                  }, {
+                    "description" : "RHSA-2019:3045",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3045"
+                  }, {
+                    "description" : "RHSA-2019:3046",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3046"
+                  }, {
+                    "description" : "RHSA-2019:3050",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3050"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "RHSA-2019:3292",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3292"
+                  }, {
+                    "description" : "RHSA-2019:3297",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3297"
+                  }, {
+                    "description" : "RHSA-2019:3901",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3901"
+                  }, {
+                    "description" : "RHSA-2020:0727",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0727"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2",
+                    "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2387",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2387"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tinkerpop-commits] 20190924 [GitHub] [tinkerpop] justinchuch opened a new pull request #1200: Upgrade jackson due to CVE issues",
+                    "url" : "https://lists.apache.org/thread.html/0fcef7321095ce0bc597d468d150cff3d647f4cb3aef3bd4d20e1c69@%3Ccommits.tinkerpop.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/2766188be238a446a250ef76801037d452979152d85bce5e46805815@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190822 [GitHub] [pulsar] massakam opened a new pull request #5011: [security] Upgrade jackson-databind",
+                    "url" : "https://lists.apache.org/thread.html/525bcf949a4b0da87a375cbad2680b8beccde749522f24c49befe7fb@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191027 [GitHub] [incubator-iceberg] rdsr commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/6788e4c991f75b89d290ad06b463fcd30bcae99fee610345a35b7bc6@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] mccheah opened a new pull request #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/689c6bcc6c7612eee71e453a115a4c8581e7b718537025d4b265783d@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] mccheah commented on issue #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/75f482fdc84abe6d0c8f438a76437c335a7bbeb5cddd4d70b4bc0cbf@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue opened a new pull request #533: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/859815b2e9f1575acbb2b260b73861c16ca49bca627fa0c46419051f@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue merged pull request #535: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/8723b52c2544e6cb804bc8a36622c584acd1bd6c53f2b6034c9fea54@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                    "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue closed pull request #533: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/99944f86abefde389da9b4040ea2327c6aa0b53a2ff9352bd4cfec17@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[iceberg-issues] 20191010 [GitHub] [incubator-iceberg] rdblue commented on issue #533: Update Jackson to 2.9.10 for CVE-2019-14379",
+                    "url" : "https://lists.apache.org/thread.html/d161ff3d59c5a8213400dd6afb1cce1fac4f687c32d1e0c0bfbfaa2d@%3Cissues.iceberg.apache.org%3E"
+                  }, {
+                    "description" : "[ambari-commits] 20190813 [ambari] branch branch-2.7 updated: AMBARI-25352 : Upgrade fasterxml jackson dependency due to CVE-2019-14379 (#3066)",
+                    "url" : "https://lists.apache.org/thread.html/e25e734c315f70d8876a846926cfe3bfa1a4888044f146e844caf72f@%3Ccommits.ambari.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[ambari-commits] 20190813 [ambari] branch trunk updated: AMBARI-25352 : Upgrade fasterxml jackson dependency due to CVE-2019-14379(trunk) (#3067)",
+                    "url" : "https://lists.apache.org/thread.html/f17f63b0f8a57e4a5759e01d25cffc0548f0b61ff5c6bfd704ad2f2a@%3Ccommits.ambari.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190812 [SECURITY] [DLA 1879-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/08/msg00011.html"
+                  }, {
+                    "description" : "FEDORA-2019-ae6a703b8f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+                  }, {
+                    "description" : "FEDORA-2019-fb23eccc03",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+                  }, {
+                    "description" : "FEDORA-2019-99ff6aa32c",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190814-0001/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190814-0001/"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-17267",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "RHSA-2020:0159",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0159"
+                  }, {
+                    "description" : "RHSA-2020:0160",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0160"
+                  }, {
+                    "description" : "RHSA-2020:0161",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0161"
+                  }, {
+                    "description" : "RHSA-2020:0164",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0164"
+                  }, {
+                    "description" : "RHSA-2020:0445",
+                    "url" : "https://access.redhat.com/errata/RHSA-2020:0445"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.3...jackson-databind-2.9.10",
+                    "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.3...jackson-databind-2.9.10"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2460",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2460"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                    "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[skywalking-dev] 20200324 [CVE-2019-17267] Upgrade jackson-databind version to 2.9.10",
+                    "url" : "https://lists.apache.org/thread.html/r9d727fc681fb3828794acbefcaee31393742b4d73a29461ccd9597a8@%3Cdev.skywalking.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20191210 [SECURITY] [DLA 2030-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/12/msg00013.html"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20191017-0006/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20191017-0006/"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2017-17485",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "20180109 CVE-2017-17485: one more way of rce in jackson-databind when defaultTyping+objects are used",
+                    "url" : "http://www.securityfocus.com/archive/1/541652/100/0/threaded"
+                  }, {
+                    "description" : "RHSA-2018:0116",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0116"
+                  }, {
+                    "description" : "RHSA-2018:0342",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0342"
+                  }, {
+                    "description" : "RHSA-2018:0478",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0478"
+                  }, {
+                    "description" : "RHSA-2018:0479",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0479"
+                  }, {
+                    "description" : "RHSA-2018:0480",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0480"
+                  }, {
+                    "description" : "RHSA-2018:0481",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0481"
+                  }, {
+                    "description" : "RHSA-2018:1447",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1447"
+                  }, {
+                    "description" : "RHSA-2018:1448",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1448"
+                  }, {
+                    "description" : "RHSA-2018:1449",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+                  }, {
+                    "description" : "RHSA-2018:1450",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+                  }, {
+                    "description" : "RHSA-2018:1451",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1451"
+                  }, {
+                    "description" : "RHSA-2018:2930",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2930"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1855",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1855"
+                  }, {
+                    "description" : "https://github.com/irsl/jackson-rce-via-spel/",
+                    "url" : "https://github.com/irsl/jackson-rce-via-spel/"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20180201-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20180201-0003/"
+                  }, {
+                    "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                    "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+                  }, {
+                    "description" : "DSA-4114",
+                    "url" : "https://www.debian.org/security/2018/dsa-4114"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-9547",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.8
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2634",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2634"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200308 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r35d30db00440ef63b791c4b7f7acb036e14d4a23afa2a249cb66c0fd@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r4accb2e0de9679174efd3d113a059bab71ff3ec53e882790d21c1cc1@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r4accb2e0de9679174efd3d113a059bab71ff3ec53e882790d21c1cc1@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r742ef70d126548dcf7de5be5779355c9d76a9aec71d7a9ef02c6398a@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r742ef70d126548dcf7de5be5779355c9d76a9aec71d7a9ef02c6398a@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/r893a0104e50c1c2559eb9a5812add28ae8c3e5f43712947a9847ec18@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r9464a40d25c3ba1a55622db72f113eb494a889656962d098c70c5bb1@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200319 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r98c9b6e4c9e17792e2cd1ec3e4aa20b61a791939046d3f10888176bb@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/ra3e90712f2d59f8cef03fa796f5adf163d32b81fe7b95385f21790e6@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/ra3e90712f2d59f8cef03fa796f5adf163d32b81fe7b95385f21790e6@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rb6fecb5e96a6d61e175ff49f33f2713798dd05cf03067c169d195596@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/rc0d5d0f72da1ed6fc5e438b1ddb3fa090c73006b55f873cf845375ab@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/rc0d5d0f72da1ed6fc5e438b1ddb3fa090c73006b55f873cf845375ab@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200307 Build failed in Jenkins: PreCommit-ZOOKEEPER-github-pr-build-maven #1898",
+                    "url" : "https://lists.apache.org/thread.html/rd0e958d6d5c5ee16efed73314cd0e445c8dbb4bdcc80fc9d1d6c11fc@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200319 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rd5a4457be4623038c3989294429bc063eec433a2e55995d81591e2ca@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200307 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rdd49ab9565bec436a896bc00c4b9fc9dce1598e106c318524fbdfec6@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "https://lists.apache.org/thread.html/redbe4f1e21bf080f637cf9fbec47729750a2f443a919765360337428@%3Cnotifications.zookeeper.apache.org%3E",
+                    "url" : "https://lists.apache.org/thread.html/redbe4f1e21bf080f637cf9fbec47729750a2f443a919765360337428@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200305 [SECURITY] [DLA 2135-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00008.html"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-9548",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.8
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2634",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2634"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200308 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r35d30db00440ef63b791c4b7f7acb036e14d4a23afa2a249cb66c0fd@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r9464a40d25c3ba1a55622db72f113eb494a889656962d098c70c5bb1@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200319 [jira] [Commented] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/r98c9b6e4c9e17792e2cd1ec3e4aa20b61a791939046d3f10888176bb@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200307 [jira] [Created] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rb6fecb5e96a6d61e175ff49f33f2713798dd05cf03067c169d195596@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200319 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rd5a4457be4623038c3989294429bc063eec433a2e55995d81591e2ca@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200307 [jira] [Updated] (ZOOKEEPER-3750) update jackson-databind to address CVE-2020-9547, CVE-2020-9548, CVE-2020-9546",
+                    "url" : "https://lists.apache.org/thread.html/rdd49ab9565bec436a896bc00c4b9fc9dce1598e106c318524fbdfec6@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200305 [SECURITY] [DLA 2135-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00008.html"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-14439",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.0
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/ad418eeb974e357f2797aef64aa0e3ffaaa6125b",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/ad418eeb974e357f2797aef64aa0e3ffaaa6125b"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2",
+                    "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.9.1...jackson-databind-2.9.9.2"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2389",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2389"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                    "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190812 [SECURITY] [DLA 1879-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/08/msg00011.html"
+                  }, {
+                    "description" : "FEDORA-2019-ae6a703b8f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+                  }, {
+                    "description" : "FEDORA-2019-fb23eccc03",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+                  }, {
+                    "description" : "20191007 [SECURITY] [DSA 4542-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/Oct/6"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190814-0001/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190814-0001/"
+                  }, {
+                    "description" : "DSA-4542",
+                    "url" : "https://www.debian.org/security/2019/dsa-4542"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-20330",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.10.1...jackson-databind-2.9.10.2",
+                    "url" : "https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.9.10.1...jackson-databind-2.9.10.2"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2526",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2526"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200118 Build failed in Jenkins: zookeeper-master-maven-owasp #329",
+                    "url" : "https://lists.apache.org/thread.html/r107c8737db39ec9ec4f4e7147b249e29be79170b9ef4b80528105a2d@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200123 [GitHub] [zookeeper] nkalmar commented on issue #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r2c77dd6ab8344285bd8e481b57cf3029965a4b0036eefccef74cdd44@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [druid] branch 0.17.0 updated: Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189) (#9191)",
+                    "url" : "https://lists.apache.org/thread.html/r392099ed2757ff2e383b10440594e914d080511d7da1c8fed0612c1f@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200123 [jira] [Updated] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r3f8180d0d25a7c6473ebb9714b0c1d19a73f455ae70d0c5fefc17e6c@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200122 [jira] [Updated] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r428735963bee7cb99877b88d3228e28ec28af64646455c4f3e7a3c94@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200122 [jira] [Commented] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r50f513772f12e1babf65c7c2b9c16425bac2d945351879e2e267517f@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200118 [jira] [Created] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r5c14fdcabdeaba258857bcb67198652e4dce1d33ddc590cd81d82393@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [GitHub] [druid] ccaominh opened a new pull request #9191: [Backport] Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189)",
+                    "url" : "https://lists.apache.org/thread.html/r5c3644c97f0434d1ceb48ff48897a67bdbf3baf7efbe7d04625425b3@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200118 [jira] [Commented] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r5d3d10fdf28110da3f9ac1b7d08d7e252f98d7d37ce0a6bd139a2e4f@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200123 [zookeeper] branch branch-3.5 updated: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r67f4d4c48197454b83d62afbed8bebbda3764e6e3a6e26a848961764@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200123 [jira] [Resolved] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r707d23bb9ee245f50aa909add0da6e8d8f24719b1278ddd99d2428b2@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200123 [zookeeper] branch branch-3.6 updated: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r7a0821b44247a1e6c6fe5f2943b90ebc4f80a8d1fb0aa9a8b29a59a2@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [GitHub] [druid] clintropolis merged pull request #9191: [Backport] Suppress CVE-2019-20330 for htrace-core-4.0.1 (#9189)",
+                    "url" : "https://lists.apache.org/thread.html/r7fb123e7dad49af5886cfec7135c0fd5b74e4c67af029e1dc91ba744@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-commits] 20200123 [zookeeper] branch master updated: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r8831b7fa5ca87a1cf23ee08d6dedb7877a964c1d2bd869af24056a63@%3Ccommits.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200118 [jira] [Created] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/r909c822409a276ba04dc2ae31179b16f6864ba02c4f9911bdffebf95@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200122 [GitHub] [zookeeper] phunt commented on issue #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/ra2e572f568de8df5ba151e6aebb225a0629faaf0476bf7c7ed877af8@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200122 [GitHub] [zookeeper] phunt opened a new pull request #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/ra5ce96faec37c26b0aa15b4b6a8b1cbb145a748653e56ae83e9685d0@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20200122 Re: 3.5.7",
+                    "url" : "https://lists.apache.org/thread.html/ra8a80dbc7319916946397823aec0d893d24713cbf7b5aee0e957298c@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200115 [GitHub] [druid] clintropolis merged pull request #9189: Suppress CVE-2019-20330 for htrace-core-4.0.1",
+                    "url" : "https://lists.apache.org/thread.html/rb532fed78d031fff477fd840b81946f6d1200f93a63698dae65aa528@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200123 [jira] [Commented] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/rd1f346227e11fc515914f3a7b20d81543e51e5822ba71baa0452634a@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20200123 [GitHub] [zookeeper] asfgit closed pull request #1232: ZOOKEEPER-3699: upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/rd49cfa41bbb71ef33b53736a6af2aa8ba88c2106e30f2a34902a87d2@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[druid-commits] 20200114 [GitHub] [druid] ccaominh opened a new pull request #9189: Suppress CVE-2019-20330 for htrace-core-4.0.1",
+                    "url" : "https://lists.apache.org/thread.html/rd6c6fef14944f3dcfb58d35f9317eb1c32a700e86c1b5231e45d3d0b@%3Ccommits.druid.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20200122 [jira] [Assigned] (ZOOKEEPER-3699) upgrade jackson-databind to address CVE-2019-20330",
+                    "url" : "https://lists.apache.org/thread.html/rfa57d9c2a27d3af14c69607fb1a3da00e758b2092aa88eb6a51b6e99@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200220 [SECURITY] [DLA 2111-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/02/msg00020.html"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20200127-0004/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20200127-0004/"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2019-12814",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 4.3
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:2935",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2935"
+                  }, {
+                    "description" : "RHSA-2019:2936",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2936"
+                  }, {
+                    "description" : "RHSA-2019:2937",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2937"
+                  }, {
+                    "description" : "RHSA-2019:2938",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2938"
+                  }, {
+                    "description" : "RHSA-2019:3044",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3044"
+                  }, {
+                    "description" : "RHSA-2019:3045",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3045"
+                  }, {
+                    "description" : "RHSA-2019:3046",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3046"
+                  }, {
+                    "description" : "RHSA-2019:3050",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3050"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3200",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3200"
+                  }, {
+                    "description" : "RHSA-2019:3292",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3292"
+                  }, {
+                    "description" : "RHSA-2019:3297",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3297"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2341",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2341"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/0d4b630d9ee724aee50703397d9d1afa2b2befc9395ba7797d0ccea9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-dev] 20190623 [jira] [Created] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/129da0204c876f746636018751a086cc581e0e07bcdeb3ee22ff5731@%3Cdev.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190623 [jira] [Created] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/15a55e1d837fa686db493137cc0330c7ee1089ed9a9eea7ae7151ef1@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190623 [GitHub] [zookeeper] eolivelli opened a new pull request #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/1e04d9381c801b31ab28dec813c31c304b2a596b2a3707fa5462c5c0@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190712 [jira] [Resolved] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/28be28ffd6471d230943a255c36fe196a54ef5afc494a4781d16e37c@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/2d2a76440becb610b9a9cb49b15eac3934b02c2dbcaacde1000353e4@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190712 [jira] [Commented] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/2ff264b6a94c5363a35c4c88fa93216f60ec54d1d973ed6b76a9f560@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] rzo1 opened a new pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/34717424b4d08b74f65c09a083d6dd1cb0763f37a15d6de135998c1d@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[cassandra-commits] 20190919 [jira] [Created] (CASSANDRA-15328) Bump jackson version to >= 2.9.9.3 to address security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/3f99ae8dcdbd69438cb733d745ee3ad5e852068490719a66509b4592@%3Ccommits.cassandra.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190624 [GitHub] [zookeeper] eolivelli closed pull request #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/4b832d1327703d6b287a6d223307f8f884d798821209a10647e93324@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] asf-ci commented on issue #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/56c8042873595b8c863054c7bfccab4bf2c01c6f5abedae249d914b9@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190906 [GitHub] [tomee] rzo1 commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5ecc333113b139429f4f05000d4aa2886974d4df3269c1dd990bb319@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/5fc0e16b7af2590bf1e97c76c136291c4fdb244ee63c65c485c9a7a1@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190712 [jira] [Assigned] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/71f9ffd92410a889e27b95a219eaa843fd820f8550898633d85d4ea3@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190909 [GitHub] [tomee] jgallimore merged pull request #548: [TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/87e46591de8925f719664a845572d184027258c5a7af0a471b53c77b@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190624 [GitHub] [zookeeper] eolivelli commented on issue #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/8fe2983f6d9fee0aa737e4bd24483f8f5cf9b938b9adad0c4e79b2a4@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[struts-dev] 20190908 Build failed in Jenkins: Struts-master-JDK8-dependency-check #204",
+                    "url" : "https://lists.apache.org/thread.html/940b4c3fef002461b89a050935337056d4a036a65ef68e0bbd4621ef@%3Cdev.struts.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190708 [jira] [Commented] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/a3ae8a8c5e32c413cd27071d3a204166050bf79ce7f1299f6866338f@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190624 [GitHub] [zookeeper] phunt commented on a change in pull request #1001: ZOOKEEPER-3441 OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/a62aa2706105d68f1c02023fe24aaa3c13b4d8a1826181fed07d9682@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190623 [jira] [Updated] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/a78239b1f11cddfa86e4edee19064c40b6272214630bfef070c37957@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-issues] 20190713 [jira] [Updated] (ZOOKEEPER-3441) OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/b0a2b2cca072650dbd5882719976c3d353972c44f6736ddf0ba95209@%3Cissues.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190710 [GitHub] [zookeeper] phunt closed pull request #1013: ZOOKEEPER-3441: OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/b148fa2e9ef468c4de00de255dd728b74e2a97d935f8ced31eb41ba2@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[accumulo-commits] 20190723 [accumulo] branch 2.0 updated: Fix CVE-2019-12814 Use jackson-databind 2.9.9.1",
+                    "url" : "https://lists.apache.org/thread.html/bf20574dbc2db255f1fd489942b5720f675e32a2c4f44eb6a36060cd@%3Ccommits.accumulo.apache.org%3E"
+                  }, {
+                    "description" : "[geode-notifications] 20191007 [GitHub] [geode] jmelchio commented on issue #4102: Fix for GEODE-7255: Pickup Jackson CVE fix",
+                    "url" : "https://lists.apache.org/thread.html/e0733058c0366b703e6757d8d2a7a04b943581f659e9c271f0841dfe@%3Cnotifications.geode.apache.org%3E"
+                  }, {
+                    "description" : "[tomee-dev] 20190905 [GitHub] [tomee] robert-schaft-hon commented on issue #549: [TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439",
+                    "url" : "https://lists.apache.org/thread.html/ee0a051428d2c719acfa297d0854a189ea5e284ef3ed491fa672f4be@%3Cdev.tomee.apache.org%3E"
+                  }, {
+                    "description" : "[zookeeper-notifications] 20190710 [GitHub] [zookeeper] phunt opened a new pull request #1013: ZOOKEEPER-3441: OWASP is flagging jackson-databind-2.9.9.jar for CVE-2019-12814",
+                    "url" : "https://lists.apache.org/thread.html/eff7280055fc717ea8129cd28a9dd57b8446d00b36260c1caee10b87@%3Cnotifications.zookeeper.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190621 [SECURITY] [DLA 1831-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/06/msg00019.html"
+                  }, {
+                    "description" : "FEDORA-2019-ae6a703b8f",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/OVRZDN2T6AZ6DJCZJ3VSIQIVHBVMVWBL/"
+                  }, {
+                    "description" : "FEDORA-2019-fb23eccc03",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TXRVXNRFHJSQWFHPRJQRI5UPMZ63B544/"
+                  }, {
+                    "description" : "FEDORA-2019-99ff6aa32c",
+                    "url" : "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UKUALE2TUCKEKOHE2D342PQXN4MWCSLC/"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190625-0006/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190625-0006/"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-11307",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "https://access.redhat.com/errata/RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2032",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2032"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-issues] 20191004 [GitHub] [lucene-solr] marungo opened a new pull request #925: SOLR-13818: Upgrade jackson to 2.10.0",
+                    "url" : "https://lists.apache.org/thread.html/7fcf88aff0d1deaa5c3c7be8d58c05ad7ad5da94b59065d8e7c50c5d@%3Cissues.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  }, {
+                    "description" : "https://nvd.nist.gov/vuln/detail/CVE-2017-7525",
+                    "url" : "https://nvd.nist.gov/vuln/detail/CVE-2017-7525"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-14719",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-14718",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "106601",
+                    "url" : "http://www.securityfocus.com/bid/106601"
+                  }, {
+                    "description" : "RHBA-2019:0959",
+                    "url" : "https://access.redhat.com/errata/RHBA-2019:0959"
+                  }, {
+                    "description" : "RHSA-2019:0782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0782"
+                  }, {
+                    "description" : "RHSA-2019:0877",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:0877"
+                  }, {
+                    "description" : "RHSA-2019:1782",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1782"
+                  }, {
+                    "description" : "RHSA-2019:1797",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1797"
+                  }, {
+                    "description" : "RHSA-2019:1822",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1822"
+                  }, {
+                    "description" : "RHSA-2019:1823",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:1823"
+                  }, {
+                    "description" : "RHSA-2019:2804",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2804"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3002",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3002"
+                  }, {
+                    "description" : "RHSA-2019:3140",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3140"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "RHSA-2019:3892",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3892"
+                  }, {
+                    "description" : "RHSA-2019:4037",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:4037"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7",
+                    "url" : "https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44",
+                    "url" : "https://github.com/FasterXML/jackson-databind/commit/87d29af25e82a249ea15858e2d4ecbf64091db44"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2097",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2097"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Assigned] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                    "url" : "https://lists.apache.org/thread.html/6a78f88716c3c57aa74ec05764a37ab3874769a347805903b393b286@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                    "url" : "https://lists.apache.org/thread.html/82b01bfb6787097427ce97cec6a7127e93718bc05d1efd5eaffc228f@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[lucene-dev] 20190325 [jira] [Updated] (SOLR-13112) CVE-2018-14718(-14719),sonatype-2017-0312, CVE-2018-14720(-14721) Threat Level 8 Against Solr v7.6. com.fasterxml.jackson.core : jackson-databind : 2.9.6. FasterXML jackson-databind 2.x before 2.9.7 Remote Hackers...",
+                    "url" : "https://lists.apache.org/thread.html/ba973114605d936be276ee6ce09dfbdbf78aa56f6cdc6e79bfa7b8df@%3Cdev.lucene.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[debian-lts-announce] 20190304 [SECURITY] [DLA 1703-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2019/03/msg00005.html"
+                  }, {
+                    "description" : "20190527 [SECURITY] [DSA 4452-1] jackson-databind security update",
+                    "url" : "https://seclists.org/bugtraq/2019/May/68"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20190530-0003/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20190530-0003/"
+                  }, {
+                    "description" : "DSA-4452",
+                    "url" : "https://www.debian.org/security/2019/dsa-4452"
+                  }, {
+                    "description" : "https://www.oracle.com/security-alerts/cpujan2020.html",
+                    "url" : "https://www.oracle.com/security-alerts/cpujan2020.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-10672",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.8
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2659",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2659"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200322 [SECURITY] [DLA 2153-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00027.html"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2020-10673",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 6.8
+                  },
+                  "references" : [ {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/2660",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/2660"
+                  }, {
+                    "description" : "[debian-lts-announce] 20200322 [SECURITY] [DLA 2153-1] jackson-databind security update",
+                    "url" : "https://lists.debian.org/debian-lts-announce/2020/03/msg00027.html"
+                  }, {
+                    "description" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062",
+                    "url" : "https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-7489",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 7.5
+                  },
+                  "references" : [ {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpuapr2018-3678067.html"
+                  }, {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html"
+                  }, {
+                    "description" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html",
+                    "url" : "http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html"
+                  }, {
+                    "description" : "103203",
+                    "url" : "http://www.securityfocus.com/bid/103203"
+                  }, {
+                    "description" : "1040693",
+                    "url" : "http://www.securitytracker.com/id/1040693"
+                  }, {
+                    "description" : "1041890",
+                    "url" : "http://www.securitytracker.com/id/1041890"
+                  }, {
+                    "description" : "RHSA-2018:1447",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1447"
+                  }, {
+                    "description" : "RHSA-2018:1448",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1448"
+                  }, {
+                    "description" : "RHSA-2018:1449",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1449"
+                  }, {
+                    "description" : "RHSA-2018:1450",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1450"
+                  }, {
+                    "description" : "RHSA-2018:1451",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1451"
+                  }, {
+                    "description" : "RHSA-2018:1786",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1786"
+                  }, {
+                    "description" : "RHSA-2018:2088",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2088"
+                  }, {
+                    "description" : "RHSA-2018:2089",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2089"
+                  }, {
+                    "description" : "RHSA-2018:2090",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2090"
+                  }, {
+                    "description" : "RHSA-2018:2938",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2938"
+                  }, {
+                    "description" : "RHSA-2018:2939",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:2939"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1931",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1931"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20180328-0001/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20180328-0001/"
+                  }, {
+                    "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                    "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+                  }, {
+                    "description" : "DSA-4190",
+                    "url" : "https://www.debian.org/security/2018/dsa-4190"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-5968",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 5.1
+                  },
+                  "references" : [ {
+                    "description" : "RHSA-2018:0478",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0478"
+                  }, {
+                    "description" : "RHSA-2018:0479",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0479"
+                  }, {
+                    "description" : "RHSA-2018:0480",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0480"
+                  }, {
+                    "description" : "RHSA-2018:0481",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:0481"
+                  }, {
+                    "description" : "RHSA-2018:1525",
+                    "url" : "https://access.redhat.com/errata/RHSA-2018:1525"
+                  }, {
+                    "description" : "RHSA-2019:2858",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:2858"
+                  }, {
+                    "description" : "RHSA-2019:3149",
+                    "url" : "https://access.redhat.com/errata/RHSA-2019:3149"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-databind/issues/1899",
+                    "url" : "https://github.com/FasterXML/jackson-databind/issues/1899"
+                  }, {
+                    "description" : "https://security.netapp.com/advisory/ntap-20180423-0002/",
+                    "url" : "https://security.netapp.com/advisory/ntap-20180423-0002/"
+                  }, {
+                    "description" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us",
+                    "url" : "https://support.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03902en_us"
+                  }, {
+                    "description" : "DSA-4114",
+                    "url" : "https://www.debian.org/security/2018/dsa-4114"
+                  } ],
+                  "resolution" : "PATCHED"
+                }, {
+                  "id" : "CVE-2018-1000873",
+                  "cvss" : {
+                    "version" : "V2",
+                    "value" : 4.3
+                  },
+                  "references" : [ {
+                    "description" : "https://bugzilla.redhat.com/show_bug.cgi?id=1665601",
+                    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=1665601"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-modules-java8/issues/90",
+                    "url" : "https://github.com/FasterXML/jackson-modules-java8/issues/90"
+                  }, {
+                    "description" : "https://github.com/FasterXML/jackson-modules-java8/pull/87",
+                    "url" : "https://github.com/FasterXML/jackson-modules-java8/pull/87"
+                  }, {
+                    "description" : "[drill-dev] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[drill-dev] 20191017 Dependencies used by Drill contain known vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20191113 svn commit: r1869773 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "[drill-issues] 20191021 [jira] [Created] (DRILL-7416) Updates required to dependencies to resolve potential security vulnerabilities",
+                    "url" : "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+                  }, {
+                    "description" : "[pulsar-commits] 20190416 [GitHub] [pulsar] one70six opened a new issue #4057: Security Vulnerabilities - Black Duck Scan - Pulsar v.2.3.1",
+                    "url" : "https://lists.apache.org/thread.html/ff8dcfe29377088ab655fda9d585dccd5b1f07fabd94ae84fd60a7f8@%3Ccommits.pulsar.apache.org%3E"
+                  }, {
+                    "description" : "[nifi-commits] 20200123 svn commit: r1873083 - /nifi/site/trunk/security.html",
+                    "url" : "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+                  }, {
+                    "description" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html",
+                    "url" : "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+                  } ],
+                  "resolution" : "PATCHED"
+                } ]
+              },
+              "feature" : {
+                "type" : "VulnerabilitiesInProject",
+                "name" : "Info about vulnerabilities in open-source project"
+              }
+            }, {
+              "type" : "DateValue",
+              "feature" : {
+                "type" : "DateFeature",
+                "name" : "When a project started"
+              },
+              "date" : 1324624661000
+            } ],
+            "explanation" : [ ]
+          }, {
+            "type" : "ScoreValue",
+            "score" : {
+              "type" : "ProjectPopularityScore",
+              "name" : "Open-source project popularity score"
+            },
+            "value" : 2.937666666666667,
+            "weight" : 0.30515788031015273,
+            "confidence" : 10.0,
+            "usedValues" : [ {
+              "type" : "IntegerValue",
+              "feature" : {
+                "type" : "PositiveIntegerFeature",
+                "name" : "Number of stars for a GitHub repository"
+              },
+              "number" : 2421
+            }, {
+              "type" : "IntegerValue",
+              "feature" : {
+                "type" : "PositiveIntegerFeature",
+                "name" : "Number of watchers for a GitHub repository"
+              },
+              "number" : 155
+            } ],
+            "explanation" : [ ]
+          } ],
+          "explanation" : [ ]
+        },
+        "label" : [ "OssSecurityRating$SecurityLabel", "MODERATE" ]
+      },
+      "ratingValueDate" : 1585240281848
+    }
+  }
+}

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/tool/github/ValidSecurityRatingCalculatorConfig.yml
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/tool/github/ValidSecurityRatingCalculatorConfig.yml
@@ -1,4 +1,8 @@
 # this is a test configuration for the SecurityRatingCalculator class
+cache: .fosstars_model/project_rating_cache.json
+report:
+  type: markdown
+  where: .fosstars_model/report
 finder:
   organizations:
     - name: apache

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/tool/github/ValidSecurityRatingCalculatorConfig.yml
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/tool/github/ValidSecurityRatingCalculatorConfig.yml
@@ -1,8 +1,11 @@
 # this is a test configuration for the SecurityRatingCalculator class
 cache: .fosstars_model/project_rating_cache.json
-report:
-  type: markdown
-  where: .fosstars_model/report
+reports:
+  - type: markdown
+    where: .fosstars_model/report
+    source: .fosstars_model/report/github_projects.json
+  - type: json
+    where: .fosstars_model/report/github_projects.json
 finder:
   organizations:
     - name: apache


### PR DESCRIPTION
Here is a list of main updates:

- Implemented `MergedJsonReporter` which stores info about processed projects to a JSON file.
- Implemented `MarkdownReporter` which generates a markdown report for processed projects.
- Implemented a cache of processed projects.
- Updated the demo tool to generate a markdown report for multiple projects.
- Created a draft report in `docs/oss/security` directory. The report contains a few projects, it'll be extended later.
- Updated tests.

This is a part of #72