### PR TITLE
Added three unpatched vulnerabilities for odata4j

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorage.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorage.java
@@ -1,7 +1,12 @@
 package com.sap.sgs.phosphor.fosstars.data.json;
 
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.UNKNOWN_FIXED_DATE;
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.UNKNOWN_INTRODUCED_DATE;
+
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sap.sgs.phosphor.fosstars.model.value.CVSS;
+import com.sap.sgs.phosphor.fosstars.model.value.Reference;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Resolution;
@@ -186,6 +191,51 @@ public class UnpatchedVulnerabilitiesStorage extends AbstractJsonStorage {
       }
     }
     return storage;
+  }
+
+  /**
+   * The main method is here for demo purposes.
+   * It can be also used to add unpatched vulnerabilities to the storage.
+   */
+  public static void main(String... args) throws IOException {
+    UnpatchedVulnerabilitiesStorage storage = UnpatchedVulnerabilitiesStorage.load();
+    storage.add(
+        "https://github.com/odata4j/odata4j",
+        new Vulnerability(
+            "https://nvd.nist.gov/vuln/detail/CVE-2014-0171",
+            "XML external entity (XXE) vulnerability",
+            CVSS.v2(5.0),
+            Collections.emptyList(),
+            Resolution.UNPATCHED,
+            UNKNOWN_INTRODUCED_DATE,
+            UNKNOWN_FIXED_DATE));
+    storage.add(
+        "https://github.com/odata4j/odata4j",
+        new Vulnerability(
+            "https://nvd.nist.gov/vuln/detail/CVE-2016-11023",
+            "SQL injection (ExecuteCountQueryCommand)",
+            CVSS.v3(9.8),
+            Collections.singletonList(
+                new Reference(
+                    "Public disclosure",
+                    new URL("https://groups.google.com/d/msg/odata4j-discuss/_lBwwXP30g0/Av6zkZMdBwAJ"))),
+            Resolution.UNPATCHED,
+            UNKNOWN_INTRODUCED_DATE,
+            UNKNOWN_FIXED_DATE));
+    storage.add(
+        "https://github.com/odata4j/odata4j",
+        new Vulnerability(
+            "https://nvd.nist.gov/vuln/detail/CVE-2016-11024",
+            "SQL injection (ExecuteJPQLQueryCommand)",
+            CVSS.v3(9.8),
+            Collections.singletonList(
+                new Reference(
+                    "Public disclosure",
+                    new URL("https://groups.google.com/d/msg/odata4j-discuss/_lBwwXP30g0/Av6zkZMdBwAJ"))),
+            Resolution.UNPATCHED,
+            UNKNOWN_INTRODUCED_DATE,
+            UNKNOWN_FIXED_DATE));
+    storage.store("src/main/resources/" + RESOURCE_PATH);
   }
 
 }

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/data/UnpatchedVulnerabilities.json
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/data/UnpatchedVulnerabilities.json
@@ -3,81 +3,116 @@
     "https://github.com/apache/httpcomponents-client" : {
       "entries" : [ {
         "id" : "https://issues.apache.org/jira/browse/HTTPCLIENT-1973",
-        "description" : null,
         "cvss" : {
           "version" : "UNKNOWN",
           "value" : null
         },
         "references" : [ ],
-        "resolution" : "UNPATCHED"
+        "resolution" : "UNPATCHED",
+        "introduced" : null,
+        "fixed" : null
       } ]
     },
     "https://github.com/apache/commons-fileupload" : {
-      "entries" : [
-        {
-          "id" : "https://issues.apache.org/jira/browse/FILEUPLOAD-297",
-          "description" : null,
-          "cvss" : {
-            "version" : "UNKNOWN",
-            "value" : null
-          },
-          "references" : [ ],
-          "resolution" : "UNPATCHED"
+      "entries" : [ {
+        "id" : "https://issues.apache.org/jira/browse/FILEUPLOAD-297",
+        "cvss" : {
+          "version" : "UNKNOWN",
+          "value" : null
         },
-        {
-          "id" : "https://nvd.nist.gov/vuln/detail/CVE-2013-0248",
-          "description" : null,
-          "cvss" : {
-            "version" : "UNKNOWN",
-            "value" : null
-          },
-          "references" : [
-            {
-              "url": "https://issues.apache.org/jira/browse/FILEUPLOAD-298",
-              "description": ""
-            }
-          ],
-          "resolution" : "UNPATCHED"
-        }
-      ]
+        "references" : [ ],
+        "resolution" : "UNPATCHED",
+        "introduced" : null,
+        "fixed" : null
+      }, {
+        "id" : "https://nvd.nist.gov/vuln/detail/CVE-2013-0248",
+        "cvss" : {
+          "version" : "UNKNOWN",
+          "value" : null
+        },
+        "references" : [ {
+          "description" : "",
+          "url" : "https://issues.apache.org/jira/browse/FILEUPLOAD-298"
+        } ],
+        "resolution" : "UNPATCHED",
+        "introduced" : null,
+        "fixed" : null
+      } ]
     },
     "https://github.com/spring-projects/spring-security-oauth" : {
-      "entries" : [
-        {
-          "id" : "https://github.com/spring-projects/spring-security-oauth/issues/1682",
-          "description" : null,
-          "cvss" : {
-            "version" : "UNKNOWN",
-            "value" : null
-          },
-          "references" : [ ],
-          "resolution" : "UNPATCHED"
+      "entries" : [ {
+        "id" : "https://github.com/spring-projects/spring-security-oauth/issues/1472",
+        "cvss" : {
+          "version" : "UNKNOWN",
+          "value" : null
         },
-        {
-          "id": "https://github.com/spring-projects/spring-security-oauth/issues/1472",
-          "description": null,
-          "cvss": {
-            "version": "UNKNOWN",
-            "value": null
-          },
-          "references": [ ],
-          "resolution" : "UNPATCHED"
-        }
-      ]
+        "references" : [ ],
+        "resolution" : "UNPATCHED",
+        "introduced" : null,
+        "fixed" : null
+      }, {
+        "id" : "https://github.com/spring-projects/spring-security-oauth/issues/1682",
+        "cvss" : {
+          "version" : "UNKNOWN",
+          "value" : null
+        },
+        "references" : [ ],
+        "resolution" : "UNPATCHED",
+        "introduced" : null,
+        "fixed" : null
+      } ]
     },
     "https://github.com/apache/batik" : {
-      "entries" : [
-        {
-          "id" : "https://issues.apache.org/jira/browse/BATIK-1189",
-          "description" : null,
-          "cvss" : {
-            "version" : "UNKNOWN",
-            "value" : null
-          },
-          "references" : [ ],
-          "resolution" : "UNPATCHED"
-        }
-      ]
+      "entries" : [ {
+        "id" : "https://issues.apache.org/jira/browse/BATIK-1189",
+        "cvss" : {
+          "version" : "UNKNOWN",
+          "value" : null
+        },
+        "references" : [ ],
+        "resolution" : "UNPATCHED",
+        "introduced" : null,
+        "fixed" : null
+      } ]
+    },
+    "https://github.com/odata4j/odata4j" : {
+      "entries" : [ {
+        "id" : "https://nvd.nist.gov/vuln/detail/CVE-2014-0171",
+        "cvss" : {
+          "version" : "V2",
+          "value" : 5.0
+        },
+        "references" : [ ],
+        "resolution" : "UNPATCHED",
+        "introduced" : null,
+        "fixed" : null
+      }, {
+        "id" : "https://nvd.nist.gov/vuln/detail/CVE-2016-11023",
+        "cvss" : {
+          "version" : "V3",
+          "value" : 9.8
+        },
+        "references" : [ {
+          "description" : "Public disclosure",
+          "url" : "https://groups.google.com/d/msg/odata4j-discuss/_lBwwXP30g0/Av6zkZMdBwAJ"
+        } ],
+        "resolution" : "UNPATCHED",
+        "introduced" : null,
+        "fixed" : null
+      }, {
+        "id" : "https://nvd.nist.gov/vuln/detail/CVE-2016-11024",
+        "cvss" : {
+          "version" : "V3",
+          "value" : 9.8
+        },
+        "references" : [ {
+          "description" : "Public disclosure",
+          "url" : "https://groups.google.com/d/msg/odata4j-discuss/_lBwwXP30g0/Av6zkZMdBwAJ"
+        } ],
+        "resolution" : "UNPATCHED",
+        "introduced" : null,
+        "fixed" : null
+      } ]
     }
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorageTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorageTest.java
@@ -64,4 +64,12 @@ public class UnpatchedVulnerabilitiesStorageTest {
     assertNotNull(vulnerabilities);
     assertEquals(1, vulnerabilities.entries().size());
   }
+
+  @Test
+  public void testOdata4j() throws IOException {
+    UnpatchedVulnerabilitiesStorage storage = UnpatchedVulnerabilitiesStorage.load();
+    Vulnerabilities vulnerabilities = storage.get("https://github.com/odata4j/odata4j");
+    assertNotNull(vulnerabilities);
+    assertEquals(3, vulnerabilities.entries().size());
+  }
 }


### PR DESCRIPTION
Here is a list of main updates:

- Added three entries to `UnpatchedVulnerabilities.json`.
- Added `UnpatchedVulnerabilitiesStorageTest.testOdata4j()` test case.
- Added `UnpatchedVulnerabilitiesStorageTest.main()` for demo purposes

This closes #106