### PR TITLE
Separate interactive data providers

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/CompositeDataProvider.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/CompositeDataProvider.java
@@ -49,7 +49,7 @@ public class CompositeDataProvider<T> implements DataProvider<T> {
     if (providers.length == 0) {
       throw new IllegalArgumentException("No providers specified!");
     }
-    this.providers.addAll(Arrays.asList(providers));
+    add(providers);
   }
 
   /**
@@ -58,12 +58,17 @@ public class CompositeDataProvider<T> implements DataProvider<T> {
    * @param providers The data provider to be added.
    * @return This provider.
    */
-  public CompositeDataProvider<T> add(DataProvider<T>... providers) {
+  public final CompositeDataProvider<T> add(DataProvider<T>... providers) {
     Objects.requireNonNull(providers, "Providers can't be null!");
     if (providers.length == 0) {
       throw new IllegalArgumentException("No providers specified!");
     }
-    this.providers.addAll(Arrays.asList(providers));
+    for (DataProvider<T> provider : providers) {
+      if (provider.interactive()) {
+        throw new IllegalArgumentException("Unfortunately interactive providers are not supported");
+      }
+      this.providers.add(provider);
+    }
     return this;
   }
 
@@ -77,6 +82,11 @@ public class CompositeDataProvider<T> implements DataProvider<T> {
       provider.update(object, values);
     }
     return this;
+  }
+
+  @Override
+  public final boolean interactive() {
+    return false;
   }
 
   @Override

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/DataProvider.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/DataProvider.java
@@ -26,6 +26,11 @@ public interface DataProvider<T> {
   DataProvider<T> update(T object, ValueSet values) throws IOException;
 
   /**
+   * Returns true if a provider talks to a user via {@link UserCallback}, false otherwise.
+   */
+  boolean interactive();
+
+  /**
    * Returns a cache of values that is used by the data provider.
    */
   ValueCache<T> cache();

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/AbstractGitHubDataProvider.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/AbstractGitHubDataProvider.java
@@ -26,6 +26,11 @@ public abstract class AbstractGitHubDataProvider extends AbstractDataProvider<Gi
         github, "Oh no! You gave me a null instead of a GitHub instance!");
   }
 
+  @Override
+  public final boolean interactive() {
+    return false;
+  }
+
   /**
    * Returns a date for tomorrow.
    */

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/HasSecurityTeam.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/HasSecurityTeam.java
@@ -5,10 +5,6 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SE
 import com.sap.sgs.phosphor.fosstars.data.UserCallback;
 import com.sap.sgs.phosphor.fosstars.data.json.SecurityTeamStorage;
 import com.sap.sgs.phosphor.fosstars.model.ValueSet;
-import com.sap.sgs.phosphor.fosstars.model.value.BooleanValue;
-import com.sap.sgs.phosphor.fosstars.model.value.UnknownValue;
-import com.sap.sgs.phosphor.fosstars.tool.YesNoSkipQuestion;
-import com.sap.sgs.phosphor.fosstars.tool.YesNoSkipQuestion.Answer;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import org.kohsuke.github.GitHub;
@@ -17,9 +13,6 @@ import org.kohsuke.github.GitHub;
  * This data provider tries to figure out if a project has a security team. First, it checks if a
  * project belongs to an organization which provides a security team such as Apache Software
  * Foundation. Next, it tries to ask a user if {@link UserCallback} is available.
- * TODO: This class doesn't talk to GitHub. Instead, it uses a local storage
- *       which contains info about known security teams.
- *       SecurityTeamStorage may be converted to a data provider.
  */
 public class HasSecurityTeam extends AbstractGitHubDataProvider {
 
@@ -42,28 +35,10 @@ public class HasSecurityTeam extends AbstractGitHubDataProvider {
   protected HasSecurityTeam doUpdate(GitHubProject project, ValueSet values) {
     logger.info("Figuring out if the project has a security team ...");
 
-    values.update(UnknownValue.of(HAS_SECURITY_TEAM));
-
     if (securityTeam.existsFor(project.url())) {
-      values.update(new BooleanValue(HAS_SECURITY_TEAM, true));
-    } else if (callback.canTalk()) {
-      String question = String.format(
-          "Does project %s have a security team? Say yes, no, or skip, please.", project.path());
-
-      Answer answer = new YesNoSkipQuestion(callback, question).ask();
-      switch (answer) {
-        case YES:
-          values.update(new BooleanValue(HAS_SECURITY_TEAM, true));
-          break;
-        case NO:
-          values.update(new BooleanValue(HAS_SECURITY_TEAM, false));
-          break;
-        default:
-          throw new IllegalArgumentException(
-              String.format("Hey! You gave me an unexpected answer: %s", answer));
-      }
-
-      // TODO: store the answer in the SecurityTeamStorage
+      values.update(HAS_SECURITY_TEAM.value(true));
+    } else {
+      values.update(HAS_SECURITY_TEAM.unknown());
     }
 
     return this;

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UnpatchedVulnerabilities.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UnpatchedVulnerabilities.java
@@ -1,22 +1,11 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
-import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.NO_DESCRIPTION;
-import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.NO_REFERENCES;
-import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.UNKNOWN_FIXED_DATE;
-import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.UNKNOWN_INTRODUCED_DATE;
-import static com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion.Answer.YES;
 
 import com.sap.sgs.phosphor.fosstars.data.json.UnpatchedVulnerabilitiesStorage;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.ValueSet;
-import com.sap.sgs.phosphor.fosstars.model.value.CVSS;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
-import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability;
-import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Resolution;
-import com.sap.sgs.phosphor.fosstars.tool.InputURL;
-import com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion;
-import com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion.Answer;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import org.kohsuke.github.GitHub;
@@ -24,15 +13,9 @@ import org.kohsuke.github.GitHub;
 /**
  * This data provider tries to figure out if an open-source project has any unpatched
  * vulnerabilities.
- * TODO: This class doesn't talk to GitHub. Instead, it uses a local storage
- *       which contains info about known security teams.
- *       UnpatchedVulnerabilities may be converted to a data provider.
  * TODO: The data provider should use the cache.
  */
 public class UnpatchedVulnerabilities extends AbstractGitHubDataProvider {
-
-  private static final String PATH =
-      "src/main/resources/com/sap/sgs/phosphor/fosstars/data/UnpatchedVulnerabilities.json";
 
   /**
    * A storage of unpatched vulnerabilities.
@@ -51,38 +34,10 @@ public class UnpatchedVulnerabilities extends AbstractGitHubDataProvider {
   }
 
   @Override
-  protected UnpatchedVulnerabilities doUpdate(GitHubProject project, ValueSet values)
-      throws IOException {
-
+  protected UnpatchedVulnerabilities doUpdate(GitHubProject project, ValueSet values) {
     logger.info("Figuring out if the project has any unpatched vulnerability ...");
 
     Vulnerabilities unpatchedVulnerabilities = storage.get(project.url());
-
-    if (callback.canTalk()) {
-      Answer answer = new YesNoQuestion(
-          callback, "Are you aware about any unpatched vulnerability in the project?").ask();
-
-      if (answer == YES) {
-        do {
-          callback.say("[+] This is awesome! Or, no?..");
-          callback.say("[?] Please give me a URL for the vulnerability");
-          String id = new InputURL(callback).get().toString();
-          Vulnerability vulnerability = new Vulnerability(
-              id, NO_DESCRIPTION, CVSS.UNKNOWN, NO_REFERENCES, Resolution.UNPATCHED,
-              UNKNOWN_INTRODUCED_DATE, UNKNOWN_FIXED_DATE);
-          unpatchedVulnerabilities.add(vulnerability);
-          storage.add(project.url().toString(), vulnerability);
-          answer = new YesNoQuestion(callback, "One more?").ask();
-        } while (answer == YES);
-
-        try {
-          storage.store(PATH);
-        } catch (IOException e) {
-          logger.warn("Could not store vulnerabilities to a file", e);
-        }
-      }
-    }
-
     Value<Vulnerabilities> vulnerabilities = knownVulnerabilities(values);
     vulnerabilities.get().add(unpatchedVulnerabilities);
     values.update(vulnerabilities);

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/interactive/AbstractInteractiveDataProvider.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/interactive/AbstractInteractiveDataProvider.java
@@ -1,0 +1,39 @@
+package com.sap.sgs.phosphor.fosstars.data.interactive;
+
+import com.sap.sgs.phosphor.fosstars.data.AbstractDataProvider;
+import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import java.io.IOException;
+
+/**
+ * This is a base class for data providers which talk to a user.
+ *
+ * @param <T> A type of objects for which a data provider gathers info.
+ */
+public abstract class AbstractInteractiveDataProvider<T> extends AbstractDataProvider<T> {
+
+  @Override
+  public final boolean interactive() {
+    return true;
+  }
+
+  @Override
+  protected final AbstractInteractiveDataProvider<T> doUpdate(T object, ValueSet values)
+      throws IOException {
+
+    if (!callback.canTalk()) {
+      throw new IOException("Oh no! Callback can't talk!");
+    }
+
+    return ask(object, values);
+  }
+
+  /**
+   * Asks a user a number of questions about an object and put corresponding feature values
+   * to a specified values set.
+   *
+   * @param object The object to ask about.
+   * @param values The value set to be updated.
+   * @return The same data provider.
+   */
+  protected abstract AbstractInteractiveDataProvider<T> ask(T object, ValueSet values);
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutSecurityTeam.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutSecurityTeam.java
@@ -1,0 +1,39 @@
+package com.sap.sgs.phosphor.fosstars.data.interactive;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_TEAM;
+
+import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.value.BooleanValue;
+import com.sap.sgs.phosphor.fosstars.tool.YesNoSkipQuestion;
+import com.sap.sgs.phosphor.fosstars.tool.YesNoSkipQuestion.Answer;
+
+/**
+ * This data provider asks a user about security teams.
+ */
+public class AskAboutSecurityTeam<T> extends AbstractInteractiveDataProvider<T> {
+
+  @Override
+  protected AskAboutSecurityTeam<T> ask(T object, ValueSet values) {
+    String question = String.format(
+        "Does project '%s' have a security team? Say yes, no, or skip, please.", object);
+
+    Answer answer = new YesNoSkipQuestion(callback, question).ask();
+    switch (answer) {
+      case YES:
+        values.update(new BooleanValue(HAS_SECURITY_TEAM, true));
+        break;
+      case NO:
+        values.update(new BooleanValue(HAS_SECURITY_TEAM, false));
+        break;
+      case SKIP:
+        break;
+      default:
+        throw new IllegalArgumentException(
+            String.format("Hey! You gave me an unexpected answer: %s", answer));
+    }
+
+    // TODO: store the answer in the SecurityTeamStorage
+
+    return this;
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutUnpatchedVulnerabilities.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutUnpatchedVulnerabilities.java
@@ -1,0 +1,65 @@
+package com.sap.sgs.phosphor.fosstars.data.interactive;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.NO_DESCRIPTION;
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.NO_REFERENCES;
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.UNKNOWN_FIXED_DATE;
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.UNKNOWN_INTRODUCED_DATE;
+import static com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion.Answer.YES;
+
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.value.CVSS;
+import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
+import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability;
+import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Resolution;
+import com.sap.sgs.phosphor.fosstars.tool.InputURL;
+import com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion;
+import com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion.Answer;
+
+/**
+ * This data provider asks a user about unpatched vulnerabilities.
+ */
+public class AskAboutUnpatchedVulnerabilities<T> extends AbstractInteractiveDataProvider<T> {
+
+  @Override
+  protected AskAboutUnpatchedVulnerabilities<T> ask(T object, ValueSet values) {
+    Vulnerabilities unpatchedVulnerabilities = new Vulnerabilities();
+
+    Answer answer = new YesNoQuestion(
+        callback, "Are you aware about any unpatched vulnerability in the project?").ask();
+
+    if (answer == YES) {
+      do {
+        callback.say("[+] This is awesome! Or, no?..");
+        callback.say("[?] Please give me a URL for the vulnerability");
+        String id = new InputURL(callback).get().toString();
+        Vulnerability vulnerability = new Vulnerability(
+            id, NO_DESCRIPTION, CVSS.UNKNOWN, NO_REFERENCES, Resolution.UNPATCHED,
+            UNKNOWN_INTRODUCED_DATE, UNKNOWN_FIXED_DATE);
+        unpatchedVulnerabilities.add(vulnerability);
+        answer = new YesNoQuestion(callback, "One more?").ask();
+      } while (answer == YES);
+    }
+
+    Value<Vulnerabilities> vulnerabilities = knownVulnerabilities(values);
+    vulnerabilities.get().add(unpatchedVulnerabilities);
+    values.update(vulnerabilities);
+
+    // TODO: store the entered vulnerabilities somewhere
+
+    return this;
+  }
+
+  /**
+   * Searches for
+   * {@link com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#VULNERABILITIES}
+   * feature a set of values.
+   *
+   * @param values The set of value.
+   * @return An existing value for the feature, or an empty value otherwise.
+   */
+  private static Value<Vulnerabilities> knownVulnerabilities(ValueSet values) {
+    return values.of(VULNERABILITIES).orElseGet(() -> VULNERABILITIES.value(new Vulnerabilities()));
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/AbstractRatingCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/AbstractRatingCalculator.java
@@ -4,8 +4,6 @@ import com.sap.sgs.phosphor.fosstars.data.NoCache;
 import com.sap.sgs.phosphor.fosstars.data.NoUserCallback;
 import com.sap.sgs.phosphor.fosstars.data.UserCallback;
 import com.sap.sgs.phosphor.fosstars.data.ValueCache;
-import java.io.IOException;
-import java.util.List;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -14,7 +12,7 @@ import org.kohsuke.github.GitHub;
 /**
  * A base class for rating calculators.
  */
-abstract class AbstractRatingCalculator {
+abstract class AbstractRatingCalculator implements RatingCalculator {
 
   /**
    * A logger.
@@ -56,7 +54,8 @@ abstract class AbstractRatingCalculator {
    * @param token The token.
    * @return The same calculator.
    */
-  AbstractRatingCalculator token(String token) {
+  @Override
+  public RatingCalculator token(String token) {
     this.token = token;
     return this;
   }
@@ -67,7 +66,8 @@ abstract class AbstractRatingCalculator {
    * @param callback The interface for interacting with a user.
    * @return The same calculator.
    */
-  AbstractRatingCalculator set(UserCallback callback) {
+  @Override
+  public RatingCalculator set(UserCallback callback) {
     this.callback = callback;
     return this;
   }
@@ -78,25 +78,10 @@ abstract class AbstractRatingCalculator {
    * @param cache The cache.
    * @return The same calculator.
    */
-  AbstractRatingCalculator set(ValueCache<GitHubProject> cache) {
+  @Override
+  public RatingCalculator set(ValueCache<GitHubProject> cache) {
     this.cache = Objects.requireNonNull(cache, "Oh no! Cache can't be null!");
     return this;
   }
 
-  /**
-   * Calculates a rating for a single project.
-   *
-   * @param project The project.
-   * @return The same calculator.
-   * @throws IOException If something went wrong.
-   */
-  abstract AbstractRatingCalculator calculateFor(GitHubProject project) throws IOException;
-
-  /**
-   * Calculates ratings for multiple projects.
-   *
-   * @param projects The projects.
-   * @throws IOException If something went wrong.
-   */
-  abstract AbstractRatingCalculator calculateFor(List<GitHubProject> projects) throws IOException;
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProject.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProject.java
@@ -175,6 +175,11 @@ public class GitHubProject implements Project {
     return Objects.hash(organization, name);
   }
 
+  @Override
+  public String toString() {
+    return url.toString();
+  }
+
   /**
    * Makes a project from its URL.
    *

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/RatingCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/RatingCalculator.java
@@ -1,0 +1,53 @@
+package com.sap.sgs.phosphor.fosstars.tool.github;
+
+import com.sap.sgs.phosphor.fosstars.data.UserCallback;
+import com.sap.sgs.phosphor.fosstars.data.ValueCache;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * An interface of a rating calculator for projects on GitHub.
+ */
+public interface RatingCalculator {
+
+  /**
+   * Set a token for accessing the GitHub APIs.
+   *
+   * @param token The token.
+   * @return The same calculator.
+   */
+  RatingCalculator token(String token);
+
+  /**
+   * Sets a {@link UserCallback} to talk to a user.
+   *
+   * @param callback The callback.
+   * @return The same calculator.
+   */
+  RatingCalculator set(UserCallback callback);
+
+  /**
+   * Sets a cache for feature values.
+   *
+   * @param cache The cache.
+   * @return The same calculator.
+   */
+  RatingCalculator set(ValueCache<GitHubProject> cache);
+
+  /**
+   * Calculates a rating for a single project.
+   *
+   * @param project The project.
+   * @return The same calculator.
+   * @throws IOException If something went wrong.
+   */
+  RatingCalculator calculateFor(GitHubProject project) throws IOException;
+
+  /**
+   * Calculates ratings for multiple projects.
+   *
+   * @param projects The projects.
+   * @throws IOException If something went wrong.
+   */
+  RatingCalculator calculateFor(List<GitHubProject> projects) throws IOException;
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculator.java
@@ -135,12 +135,12 @@ public class SecurityRatingCalculator {
           "You have to give me either --url or --config option but not both!");
     }
 
-    boolean mayTalk = !commandLine.hasOption("no-questions");
-    UserCallback callback = mayTalk ? new Terminal() : NoUserCallback.INSTANCE;
-
-    GitHub github = connectToGithub(commandLine.getOptionValue("token"), callback);
+    UserCallback callback = commandLine.hasOption("no-questions")
+        ? NoUserCallback.INSTANCE : new Terminal();
 
     String token = commandLine.getOptionValue("token");
+
+    GitHub github = connectToGithub(token, callback);
 
     try {
       if (commandLine.hasOption("url")) {

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/CompositeDataProviderTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/CompositeDataProviderTest.java
@@ -33,6 +33,11 @@ public class CompositeDataProviderTest {
     }
 
     @Override
+    public boolean interactive() {
+      return false;
+    }
+
+    @Override
     public ValueCache cache() {
       return null;
     }
@@ -81,6 +86,38 @@ public class CompositeDataProviderTest {
       assertTrue(booleanValue.feature().name().startsWith("feature "));
       assertTrue(booleanValue.get());
     }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void noInteractiveProviders() {
+    new CompositeDataProvider(
+        new DataProvider() {
+          @Override
+          public DataProvider update(Object object, ValueSet values) {
+            throw new UnsupportedOperationException("This should not be called!");
+          }
+
+          @Override
+          public boolean interactive() {
+            return true;
+          }
+
+          @Override
+          public ValueCache cache() {
+            throw new UnsupportedOperationException("This should not be called!");
+          }
+
+          @Override
+          public DataProvider set(UserCallback callback) {
+            throw new UnsupportedOperationException("This should not be called!");
+          }
+
+          @Override
+          public DataProvider set(ValueCache cache) {
+            throw new UnsupportedOperationException("This should not be called!");
+          }
+        }
+    );
   }
 
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutSecurityTeamTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutSecurityTeamTest.java
@@ -1,0 +1,41 @@
+package com.sap.sgs.phosphor.fosstars.data.interactive;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_TEAM;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.sgs.phosphor.fosstars.data.StandardValueCache;
+import com.sap.sgs.phosphor.fosstars.data.UserCallback;
+import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
+import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
+import java.io.IOException;
+import org.junit.Test;
+
+public class AskAboutSecurityTeamTest {
+
+  @Test
+  public void answerYes() throws IOException {
+    testProvider(true, new AskAboutSecurityTeam(), new TestUserCallback("yes"));
+  }
+
+  @Test
+  public void answerNo() throws IOException {
+    testProvider(false, new AskAboutSecurityTeam(), new TestUserCallback("no"));
+  }
+
+  private static void testProvider(
+      boolean expected, AskAboutSecurityTeam provider, UserCallback callback) throws IOException {
+
+    ValueSet values = new ValueHashSet();
+    provider.set(new StandardValueCache());
+    provider.set(callback);
+    GitHubProject project = new GitHubProject("org", "test");
+    provider.update(project, values);
+    assertEquals(1, values.size());
+    assertTrue(values.has(HAS_SECURITY_TEAM));
+    assertTrue(values.of(HAS_SECURITY_TEAM).isPresent());
+    assertEquals(expected, values.of(HAS_SECURITY_TEAM).get().get());
+  }
+
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutUnpatchedVulnerabilitiesTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutUnpatchedVulnerabilitiesTest.java
@@ -1,0 +1,54 @@
+package com.sap.sgs.phosphor.fosstars.data.interactive;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.sgs.phosphor.fosstars.data.StandardValueCache;
+import com.sap.sgs.phosphor.fosstars.data.UserCallback;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
+import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
+import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability;
+import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
+import org.junit.Test;
+
+public class AskAboutUnpatchedVulnerabilitiesTest {
+
+  @Test
+  public void twoVulnerabilities() {
+    final String firstIssueId = "https://github.com/org/test/issues/1";
+    final String secondIssueId = "https://github.com/org/test/issues/2";
+
+    testProvider(
+        new Vulnerabilities(
+            new Vulnerability(firstIssueId),
+            new Vulnerability(secondIssueId)),
+        new AskAboutUnpatchedVulnerabilities(),
+        new TestUserCallback("yes", firstIssueId, "yes", secondIssueId, "no"));
+  }
+
+  @Test
+  public void noVulnerabilities() {
+    testProvider(
+        new Vulnerabilities(),
+        new AskAboutUnpatchedVulnerabilities(),
+        new TestUserCallback("no"));
+  }
+
+  private static void testProvider(Vulnerabilities expectedVulnerabilities,
+      AskAboutUnpatchedVulnerabilities provider, UserCallback callback) {
+
+    ValueSet values = new ValueHashSet();
+    provider.set(new StandardValueCache());
+    provider.set(callback);
+    GitHubProject project = new GitHubProject("org", "test");
+    provider.ask(project, values);
+    assertEquals(1, values.size());
+    assertTrue(values.has(VULNERABILITIES));
+    assertTrue(values.of(VULNERABILITIES).isPresent());
+    Value<Vulnerabilities> value = values.of(VULNERABILITIES).get();
+    assertEquals(expectedVulnerabilities, value.get());
+  }
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/interactive/TestUserCallback.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/interactive/TestUserCallback.java
@@ -1,0 +1,55 @@
+package com.sap.sgs.phosphor.fosstars.data.interactive;
+
+import com.sap.sgs.phosphor.fosstars.data.UserCallback;
+import java.util.Arrays;
+import java.util.Iterator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * This is a callback for testing purposes.
+ * It can answer a number of questions with pre-defined answers.
+ */
+public class TestUserCallback implements UserCallback {
+
+  private static final Logger LOGGER = LogManager.getLogger(TestUserCallback.class);
+
+  /**
+   * An iterator over pre-defined answers.
+   */
+  private Iterator<String> iterator;
+
+  /**
+   * Initialize a callback with a number of answers.
+   * @param answers The answers.
+   */
+  TestUserCallback(String... answers) {
+    iterator = Arrays.asList(answers).iterator();
+  }
+
+  @Override
+  public boolean canTalk() {
+    return true;
+  }
+
+  @Override
+  public String ask() {
+    if (!iterator.hasNext()) {
+      throw new IllegalStateException("I don't know the answer any more!");
+    }
+    String answer = iterator.next();
+    LOGGER.info("answer: {}", answer);
+    return answer;
+  }
+
+  @Override
+  public String ask(String question) {
+    LOGGER.info("question: {}", question);
+    return ask();
+  }
+
+  @Override
+  public void say(String phrase) {
+    LOGGER.info("message: {}", phrase);
+  }
+}


### PR DESCRIPTION
Here is a list of main updates:

- Added a new `DataProvider.interactive()` method.
- Extracted interactive part of the existing data providers to new `AskAboutUnpatchedVulnerabilities` and `AskAboutSecurityTeam` data providers.
- Added tests.
- Updated the demo tool.

This closes #108