### PR TITLE
Introduced not-applicable values

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/Label.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/Label.java
@@ -2,6 +2,7 @@ package com.sap.sgs.phosphor.fosstars.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.sap.sgs.phosphor.fosstars.model.rating.NotApplicableLabel;
 import com.sap.sgs.phosphor.fosstars.model.rating.example.SecurityRatingExample;
 import com.sap.sgs.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 
@@ -11,7 +12,8 @@ import com.sap.sgs.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(value = OssSecurityRating.SecurityLabel.class),
-    @JsonSubTypes.Type(value = SecurityRatingExample.SecurityLabelExample.class)
+    @JsonSubTypes.Type(value = SecurityRatingExample.SecurityLabelExample.class),
+    @JsonSubTypes.Type(value = NotApplicableLabel.class),
 })
 public interface Label {
 
@@ -19,4 +21,16 @@ public interface Label {
    * Return the label's name.
    */
   String name();
+
+  /**
+   * Returns true if the value is not applicable in the current context, false otherwise.
+   */
+  default boolean isNotApplicable() {
+    return false;
+  }
+
+  /**
+   * This is a label for a score value that is marked as not-applicable.
+   */
+  Label NOT_APPLICABLE = new NotApplicableLabel();
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/Value.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/Value.java
@@ -10,6 +10,7 @@ import com.sap.sgs.phosphor.fosstars.model.value.ExpiringValue;
 import com.sap.sgs.phosphor.fosstars.model.value.IntegerValue;
 import com.sap.sgs.phosphor.fosstars.model.value.LanguagesValue;
 import com.sap.sgs.phosphor.fosstars.model.value.LgtmGradeValue;
+import com.sap.sgs.phosphor.fosstars.model.value.NotApplicableValue;
 import com.sap.sgs.phosphor.fosstars.model.value.PackageManagersValue;
 import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import com.sap.sgs.phosphor.fosstars.model.value.SecurityReviewsDoneValue;
@@ -31,6 +32,7 @@ import com.sap.sgs.phosphor.fosstars.model.value.VulnerabilitiesValue;
     @JsonSubTypes.Type(value = ExpiringValue.class),
     @JsonSubTypes.Type(value = VulnerabilitiesValue.class),
     @JsonSubTypes.Type(value = UnknownValue.class),
+    @JsonSubTypes.Type(value = NotApplicableValue.class),
     @JsonSubTypes.Type(value = SecurityReviewsDoneValue.class),
     @JsonSubTypes.Type(value = EnumValue.class),
     @JsonSubTypes.Type(value = LgtmGradeValue.class),
@@ -48,6 +50,11 @@ public interface Value<T> {
    * Returns true if the value is unknown, false otherwise.
    */
   boolean isUnknown();
+
+  /**
+   * Returns true if the value is not applicable in the current context, false otherwise.
+   */
+  boolean isNotApplicable();
 
   /**
    * Returns the value.

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreVerifier.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreVerifier.java
@@ -1,7 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.model.qa;
 
 import com.sap.sgs.phosphor.fosstars.model.Score;
-import com.sap.sgs.phosphor.fosstars.model.qa.TestVectorResult.Status;
 import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,16 +35,7 @@ public class ScoreVerifier extends AbstractVerifier {
     int index = 0;
     for (TestVector vector : vectors) {
       ScoreValue scoreValue = score.calculate(vector.values());
-      double actualScore = scoreValue.get();
-
-      if (vector.expectedScore().contains(actualScore)) {
-        results.add(new TestVectorResult(vector, index++, actualScore, Status.PASSED, "Ok"));
-      } else {
-        String message = String.format(
-            "Expected a score in the interval %s but %s returned",
-            vector.expectedScore(), actualScore);
-        results.add(new TestVectorResult(vector, index++, actualScore, Status.FAILED, message));
-      }
+      results.add(testResultFor(vector, scoreValue, index++));
     }
 
     return results;

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorBuilder.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorBuilder.java
@@ -16,10 +16,30 @@ import java.util.Set;
  */
 public class TestVectorBuilder {
 
+  /**
+   * A set of feature values.
+   */
   private final Set<Value> values = new HashSet<>();
+
+  /**
+   * An interval for an expected score.
+   */
   private Interval expectedScore;
-  private Label expectedLabel;
-  private String description = "unknown";
+
+  /**
+   * If it's set to true, then a not-applicable score value is expected.
+   */
+  private boolean expectNotApplicableScore = false;
+
+  /**
+   * An expected label.
+   */
+  private Label expectedLabel = TestVector.NO_LABEL;
+
+  /**
+   * An alias.
+   */
+  private String alias;
 
   /**
    * Creates a new test vector.
@@ -42,8 +62,17 @@ public class TestVectorBuilder {
    * @return This instance of TestVectorBuilder.
    */
   public TestVectorBuilder expectedScore(Interval interval) {
-    Objects.requireNonNull(interval, "Hey! You have to give me an internal but not null!");
     expectedScore = interval;
+    return this;
+  }
+
+  /**
+   * Makes a test vector to expect a not-applicable score value.
+   *
+   * @return This instance of TestVectorBuilder.
+   */
+  public TestVectorBuilder expectNotApplicableScore() {
+    expectNotApplicableScore = true;
     return this;
   }
 
@@ -54,7 +83,6 @@ public class TestVectorBuilder {
    * @return This instance of TestVectorBuilder.
    */
   public TestVectorBuilder expectedLabel(Label label) {
-    Objects.requireNonNull(label, "Hey! You have to give me a label but not null!");
     expectedLabel = label;
     return this;
   }
@@ -104,14 +132,14 @@ public class TestVectorBuilder {
   }
 
   /**
-   * Set a description.
+   * Set an alias.
    *
-   * @param text The description.
+   * @param alias The alias.
    * @return This instance of TestVectorBuilder.
    */
-  public TestVectorBuilder description(String text) {
-    Objects.requireNonNull(text, "Hey! You have to give me a description but not null!");
-    description = text;
+  public TestVectorBuilder alias(String alias) {
+    Objects.requireNonNull(alias, "Hey! You have to give me an alias but not null!");
+    this.alias = alias;
     return this;
   }
 
@@ -121,14 +149,18 @@ public class TestVectorBuilder {
    * @return An instance of TestVector.
    */
   public TestVector make() {
-    Objects.requireNonNull(expectedScore,
-        "Oh no! Looks like you forgot to tell me about an expected score!");
+    if (expectedScore == null && !expectNotApplicableScore) {
+      throw new IllegalArgumentException(
+          "Hey! Expected score can't be null unless a not-applicable value is expected!");
+    }
+
     if (values.isEmpty()) {
       throw new IllegalArgumentException(
           "Oh no! Looks like you forgot to give me features values!");
     }
-    return new TestVector(
-        Collections.unmodifiableSet(values), expectedScore, expectedLabel, description);
+
+    return new TestVector(Collections.unmodifiableSet(values), expectedScore, expectedLabel,
+        alias, expectNotApplicableScore);
   }
 
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorResult.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorResult.java
@@ -1,6 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.model.qa;
 
-import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import java.util.Objects;
 
 /**
@@ -25,7 +25,7 @@ public class TestVectorResult {
   /**
    * A calculated score value.
    */
-  public final double scoreValue;
+  public final ScoreValue scoreValue;
 
   /**
    * Passed or failed.
@@ -46,7 +46,9 @@ public class TestVectorResult {
    * @param status Passed or failed.
    * @param message A message which provides more details about the result.
    */
-  TestVectorResult(TestVector vector, int index, double scoreValue, Status status, String message) {
+  TestVectorResult(
+      TestVector vector, int index, ScoreValue scoreValue, Status status, String message) {
+
     if (index < 0) {
       throw new IllegalArgumentException("Hey! Index can't be negative!");
     }
@@ -56,7 +58,7 @@ public class TestVectorResult {
     this.vector = Objects.requireNonNull(vector, "Hey! Vector can't be null!");
     this.status = Objects.requireNonNull(status, "Hey! Status can't be null!");
     this.message = Objects.requireNonNull(message, "Hey! Reason can't be null!");
-    this.scoreValue = Score.check(scoreValue);
+    this.scoreValue = Objects.requireNonNull(scoreValue, "Hey! Score value can't be null!");
     this.index = index;
   }
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/rating/AbstractRating.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/rating/AbstractRating.java
@@ -66,6 +66,9 @@ public abstract class AbstractRating implements Rating {
   }
 
   private RatingValue calculate(ScoreValue scoreValue) {
+    if (scoreValue.isNotApplicable()) {
+      return new RatingValue(scoreValue, Label.NOT_APPLICABLE);
+    }
     return new RatingValue(scoreValue, label(scoreValue.get()));
   }
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/rating/NotApplicableLabel.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/rating/NotApplicableLabel.java
@@ -1,0 +1,38 @@
+package com.sap.sgs.phosphor.fosstars.model.rating;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.sap.sgs.phosphor.fosstars.model.Label;
+
+/**
+ * This is a label for a score value that is marked as not-applicable.
+ */
+public class NotApplicableLabel implements Label {
+
+  @Override
+  @JsonIgnore
+  public final String name() {
+    return "N/A";
+  }
+
+  @Override
+  @JsonIgnore
+  public final boolean isNotApplicable() {
+    return true;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) {
+      return false;
+    }
+    if (obj == this) {
+      return true;
+    }
+    return obj instanceof NotApplicableLabel;
+  }
+
+  @Override
+  public int hashCode() {
+    return 42;
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AverageCompositeScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AverageCompositeScore.java
@@ -84,15 +84,24 @@ public class AverageCompositeScore extends AbstractScore {
 
     double subScoreSum = 0.0;
     double confidenceSum = 0.0;
+    int numberOfSubScores = 0;
     for (Score subScore : subScores) {
       ScoreValue subScoreValue = calculateIfNecessary(subScore, valueSet);
+      if (subScoreValue.isNotApplicable()) {
+        continue;
+      }
+      numberOfSubScores++;
       scoreValue.usedValues(subScoreValue);
       subScoreSum += subScoreValue.get();
       confidenceSum += subScoreValue.confidence();
     }
 
-    scoreValue.set(subScoreSum / subScores.size());
-    scoreValue.confidence(confidenceSum / subScores.size());
+    if (numberOfSubScores == 0) {
+      return scoreValue.makeNotApplicable();
+    }
+
+    scoreValue.set(subScoreSum / numberOfSubScores);
+    scoreValue.confidence(confidenceSum / numberOfSubScores);
 
     return scoreValue;
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/WeightedCompositeScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/WeightedCompositeScore.java
@@ -27,6 +27,9 @@ import java.util.Set;
  */
 public class WeightedCompositeScore extends AbstractScore implements Tunable {
 
+  /**
+   * The default weight for sub-scores.
+   */
   private static final double DEFAULT_WEIGHT = 1.0;
 
   /**
@@ -119,14 +122,23 @@ public class WeightedCompositeScore extends AbstractScore implements Tunable {
     double scoreSum = 0.0;
     double confidenceSum = 0.0;
     ScoreValue scoreValue = new ScoreValue(this);
+    boolean allNotApplicable = true;
     for (WeightedScore weightedScore : weightedScores) {
       double weight = weightedScore.weight.value();
       ScoreValue subScoreValue = calculateIfNecessary(weightedScore.score, valueSet);
+      if (subScoreValue.isNotApplicable()) {
+        continue;
+      }
+      allNotApplicable = false;
       subScoreValue.weight(weightedScore.weight.value());
       scoreValue.usedValues(subScoreValue);
       scoreSum += weight * subScoreValue.get();
       confidenceSum += weight * subScoreValue.confidence();
       weightSum += weight;
+    }
+
+    if (allNotApplicable) {
+      return scoreValue.makeNotApplicable();
     }
 
     if (weightSum == 0) {

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/tuning/TuningWithCMAES.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/tuning/TuningWithCMAES.java
@@ -261,8 +261,8 @@ public class TuningWithCMAES extends AbstractTuning {
       for (TestVectorResult result : results) {
         if (result.failed()) {
           value += PENALTY;
-        } else {
-          value += Math.abs(result.vector.expectedScore().mean() - result.scoreValue);
+        } else if (!result.scoreValue.isNotApplicable()) {
+          value += Math.abs(result.vector.expectedScore().mean() - result.scoreValue.get());
         }
       }
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/AbstractValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/AbstractValue.java
@@ -40,6 +40,12 @@ public abstract class AbstractValue<T> implements Value<T> {
   }
 
   @Override
+  @JsonIgnore
+  public boolean isNotApplicable() {
+    return false;
+  }
+
+  @Override
   public Value<T> processIfKnown(Processor<T> processor) {
     Objects.requireNonNull(processor, "Processor can't be null!");
     if (!isUnknown()) {

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ExpiringValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ExpiringValue.java
@@ -56,6 +56,12 @@ public class ExpiringValue<T> implements Value<T> {
   }
 
   @Override
+  @JsonIgnore
+  public boolean isNotApplicable() {
+    return value.isNotApplicable();
+  }
+
+  @Override
   public T get() {
     return value.get();
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/NotApplicableValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/NotApplicableValue.java
@@ -1,0 +1,62 @@
+package com.sap.sgs.phosphor.fosstars.model.value;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+
+/**
+ * A not-applicable value of a feature.
+ */
+public final class NotApplicableValue<T> extends AbstractValue<T> {
+
+  /**
+   * This factory method returns a not-applicable value of a specified feature.
+   *
+   * @param feature The feature.
+   */
+  public static <T> NotApplicableValue<T> of(Feature<T> feature) {
+    return new NotApplicableValue<>(feature);
+  }
+
+  /**
+   * Initializes a not-applicable value for a feature.
+   *
+   * @param feature The feature.
+   */
+  public NotApplicableValue(@JsonProperty("feature") Feature feature) {
+    super(feature);
+  }
+
+  @Override
+  @JsonIgnore
+  public final boolean isUnknown() {
+    return true;
+  }
+
+  @Override
+  @JsonIgnore
+  public final boolean isNotApplicable() {
+    return true;
+  }
+
+  @Override
+  public final T get() {
+    throw new UnsupportedOperationException(
+        "It's a not-applicable value, get() method is not supposed to be called!");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "N/A";
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValue.java
@@ -121,6 +121,12 @@ public class ScoreValue implements Value<Double>, Confidence {
   }
 
   @Override
+  @JsonIgnore
+  public boolean isNotApplicable() {
+    return false;
+  }
+
+  @Override
   @JsonGetter("value")
   public Double get() {
     return value;

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/UnknownValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/UnknownValue.java
@@ -20,7 +20,7 @@ public final class UnknownValue<T> implements Value<T> {
   /**
    * This factory method returns an unknown values of the specified feature.
    */
-  public static <T> Value<T> of(Feature<T> feature) {
+  public static <T> UnknownValue<T> of(Feature<T> feature) {
     return new UnknownValue<>(feature);
   }
 
@@ -30,6 +30,7 @@ public final class UnknownValue<T> implements Value<T> {
    * @param feature The feature.
    */
   public UnknownValue(@JsonProperty("feature") Feature feature) {
+    Objects.requireNonNull(feature, "Feature can't be null!");
     this.feature = feature;
   }
 
@@ -43,6 +44,12 @@ public final class UnknownValue<T> implements Value<T> {
   @JsonIgnore
   public final boolean isUnknown() {
     return true;
+  }
+
+  @Override
+  @JsonIgnore
+  public boolean isNotApplicable() {
+    return false;
   }
 
   @Override

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinter.java
@@ -115,7 +115,7 @@ public class PrettyPrinter implements Formatter {
 
     sb.append(String.format("%sValue:........%s out of %2.2f%n",
         indent,
-        append(String.format("%.2f", scoreValue.get()), ' ', 4),
+        append(String.format("%s", tellMeActualValueOf(scoreValue)), ' ', 4),
         Score.MAX));
     sb.append(String.format("%sConfidence:...%s out of %2.2f%n",
         indent,
@@ -176,6 +176,23 @@ public class PrettyPrinter implements Formatter {
     }
 
     return sb.toString();
+  }
+
+  /**
+   * Prints an actual value of a score value. The method takes care about
+   * unknown and not-applicable score values.
+   *
+   * @param scoreValue The score value.
+   * @return A string that represents the score value.
+   */
+  public static String tellMeActualValueOf(ScoreValue scoreValue) {
+    if (scoreValue.isNotApplicable()) {
+      return "N/A";
+    }
+    if (scoreValue.isUnknown()) {
+      return "unknown";
+    }
+    return String.format("%2.2f", scoreValue.get());
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MarkdownReporter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/MarkdownReporter.java
@@ -205,7 +205,8 @@ public class MarkdownReporter extends AbstractReporter<GitHubProject> {
     if (!something.isPresent()) {
       return UNKNOWN;
     }
-    return String.format("%2.2f", something.get().scoreValue().get());
+    ScoreValue scoreValue = something.get().scoreValue();
+    return PrettyPrinter.tellMeActualValueOf(scoreValue);
   }
 
   /**

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreVerifierTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreVerifierTest.java
@@ -5,8 +5,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.sap.sgs.phosphor.fosstars.model.RatingRepository;
+import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.feature.example.ExampleFeatures;
 import com.sap.sgs.phosphor.fosstars.model.math.DoubleInterval;
 import com.sap.sgs.phosphor.fosstars.model.qa.TestVectorResult.Status;
@@ -14,8 +18,11 @@ import com.sap.sgs.phosphor.fosstars.model.rating.example.SecurityRatingExample;
 import com.sap.sgs.phosphor.fosstars.model.rating.example.SecurityRatingExampleVerification;
 import com.sap.sgs.phosphor.fosstars.model.value.BooleanValue;
 import com.sap.sgs.phosphor.fosstars.model.value.IntegerValue;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import org.junit.Test;
 
 public class ScoreVerifierTest {
@@ -27,6 +34,7 @@ public class ScoreVerifierTest {
       .set(new BooleanValue(ExampleFeatures.SECURITY_REVIEW_DONE_EXAMPLE, false))
       .set(new BooleanValue(ExampleFeatures.STATIC_CODE_ANALYSIS_DONE_EXAMPLE, false))
       .expectedScore(DoubleInterval.init().from(9).to(10).make())
+      .alias("test")
       .make();
 
   private static final List<TestVector> TEST_VECTORS = new ArrayList<>();
@@ -37,7 +45,7 @@ public class ScoreVerifierTest {
   }
 
   @Test
-  public void failedVectors() {
+  public void testWithFailedTestVectors() {
     ScoreVerifier verifier = new ScoreVerifier(
         RatingRepository.INSTANCE.rating(SecurityRatingExample.class).score(),
         TEST_VECTORS);
@@ -50,19 +58,83 @@ public class ScoreVerifierTest {
       if (result.failed()) {
         assertEquals(FAILING_TEST_VECTOR, result.vector);
         assertEquals(Status.FAILED, result.status);
-        assertFalse(result.vector.expectedScore().contains(result.scoreValue));
+        assertFalse(result.vector.expectedScore().contains(result.scoreValue.get()));
       } else {
         assertNotEquals(FAILING_TEST_VECTOR, result.vector);
         assertEquals(Status.PASSED, result.status);
-        assertTrue(result.vector.expectedScore().contains(result.scoreValue));
+        assertTrue(result.vector.expectedScore().contains(result.scoreValue.get()));
       }
       assertNotNull(result.message);
       assertFalse(result.message.isEmpty());
     }
   }
 
+  @Test
+  public void testWithNotApplicableScoreValue() {
+    List<TestVector> vectors = Arrays.asList(
+        TestVectorBuilder.newTestVector()
+            .alias("1")
+            .set(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 1))
+            .set(new IntegerValue(ExampleFeatures.NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE, 1))
+            .set(new BooleanValue(ExampleFeatures.SECURITY_REVIEW_DONE_EXAMPLE, false))
+            .set(new BooleanValue(ExampleFeatures.STATIC_CODE_ANALYSIS_DONE_EXAMPLE, false))
+            .expectNotApplicableScore()
+            .make(),
+        TestVectorBuilder.newTestVector()
+            .alias("2")
+            .set(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 1))
+            .set(new IntegerValue(ExampleFeatures.NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE, 1))
+            .set(new BooleanValue(ExampleFeatures.SECURITY_REVIEW_DONE_EXAMPLE, false))
+            .set(new BooleanValue(ExampleFeatures.STATIC_CODE_ANALYSIS_DONE_EXAMPLE, false))
+            .expectedScore(DoubleInterval.init().from(0.0).to(2.0).make())
+            .make(),
+        TestVectorBuilder.newTestVector()
+            .alias("3")
+            .set(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 1))
+            .set(new IntegerValue(ExampleFeatures.NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE, 1))
+            .set(new BooleanValue(ExampleFeatures.SECURITY_REVIEW_DONE_EXAMPLE, false))
+            .set(new BooleanValue(ExampleFeatures.STATIC_CODE_ANALYSIS_DONE_EXAMPLE, false))
+            .expectNotApplicableScore()
+            .make(),
+        TestVectorBuilder.newTestVector()
+            .alias("3")
+            .set(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 1))
+            .set(new IntegerValue(ExampleFeatures.NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE, 1))
+            .set(new BooleanValue(ExampleFeatures.SECURITY_REVIEW_DONE_EXAMPLE, false))
+            .set(new BooleanValue(ExampleFeatures.STATIC_CODE_ANALYSIS_DONE_EXAMPLE, false))
+            .expectedScore(DoubleInterval.init().from(0.0).to(2.0).make())
+            .make()
+    );
+
+    Score score = mock(Score.class);
+    when(score.calculate(any(Set.class)))
+        .thenReturn(
+            new ScoreValue(score).set(5.0),
+            new ScoreValue(score).makeNotApplicable(),
+            new ScoreValue(score).makeNotApplicable(),
+            new ScoreValue(score).set(1.0));
+
+    ScoreVerifier verifier = new ScoreVerifier(score, vectors);
+
+    List<TestVectorResult> results = verifier.run();
+
+    assertEquals(4, results.size());
+    assertEquals(vectors.get(0), results.get(0).vector);
+    assertEquals(Status.FAILED, results.get(0).status);
+    assertFalse(results.get(0).scoreValue.isNotApplicable());
+    assertEquals(vectors.get(1), results.get(1).vector);
+    assertEquals(Status.FAILED, results.get(1).status);
+    assertTrue(results.get(1).scoreValue.isNotApplicable());
+    assertEquals(vectors.get(2), results.get(2).vector);
+    assertEquals(Status.PASSED, results.get(2).status);
+    assertTrue(results.get(2).scoreValue.isNotApplicable());
+    assertEquals(vectors.get(3), results.get(3).vector);
+    assertEquals(Status.PASSED, results.get(3).status);
+    assertFalse(results.get(3).scoreValue.isNotApplicable());
+  }
+
   @Test(expected = VerificationFailedException.class)
-  public void run() throws VerificationFailedException {
+  public void testThatVerificationFails() throws VerificationFailedException {
     ScoreVerifier verifier = new ScoreVerifier(
         RatingRepository.INSTANCE.rating(SecurityRatingExample.class).score(),
         TEST_VECTORS);

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorBuilderTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorBuilderTest.java
@@ -18,6 +18,7 @@ public class TestVectorBuilderTest {
         .set(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 10))
         .expectedLabel(SecurityLabelExample.AWESOME)
         .expectedScore(DoubleInterval.init().from(1).to(4).open().make())
+        .alias("test")
         .make();
 
     assertNotNull(vector);

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorResultTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorResultTest.java
@@ -2,6 +2,7 @@ package com.sap.sgs.phosphor.fosstars.model.qa;
 
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.allUnknown;
 import static com.sap.sgs.phosphor.fosstars.model.qa.TestVectorBuilder.newTestVector;
+import static com.sap.sgs.phosphor.fosstars.model.score.example.ExampleScores.PROJECT_ACTIVITY_SCORE_EXAMPLE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -11,6 +12,7 @@ import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures;
 import com.sap.sgs.phosphor.fosstars.model.math.DoubleInterval;
 import com.sap.sgs.phosphor.fosstars.model.qa.TestVectorResult.Status;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import org.junit.Test;
 
 public class TestVectorResultTest {
@@ -28,10 +30,13 @@ public class TestVectorResultTest {
         .set(allUnknown(OssFeatures.HAS_SECURITY_TEAM))
         .expectedScore(ALMOST_MIN)
         .expectedLabel(TestLabel.BAD)
+        .alias("bad")
         .make();
-    TestVectorResult testVectorResult
-        = new TestVectorResult(vector, 0, 5.0, Status.PASSED, "Alles kaputt!");
+    TestVectorResult testVectorResult = new TestVectorResult(
+        vector, 0, new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE).set(0.5),
+        Status.FAILED, "Alles kaputt!");
     assertEquals(0, testVectorResult.index);
+    assertEquals(Status.FAILED, testVectorResult.status);
     assertEquals("Alles kaputt!", testVectorResult.message);
     assertEquals(ALMOST_MIN, testVectorResult.vector.expectedScore());
     assertEquals(TestLabel.BAD, testVectorResult.vector.expectedLabel());
@@ -44,18 +49,21 @@ public class TestVectorResultTest {
             .set(allUnknown(OssFeatures.HAS_SECURITY_TEAM))
             .expectedScore(ALMOST_MIN)
             .expectedLabel(TestLabel.BAD)
+            .alias("1")
             .make();
     TestVector sameTestVector =
         newTestVector()
             .set(allUnknown(OssFeatures.HAS_SECURITY_TEAM))
             .expectedScore(ALMOST_MIN)
             .expectedLabel(TestLabel.BAD)
+            .alias("1")
             .make();
     TestVector differentTestVector =
         newTestVector()
             .set(allUnknown(OssFeatures.HAS_SECURITY_TEAM))
             .expectedScore(ALMOST_MIN)
             .expectedLabel(TestLabel.GOOD)
+            .alias("2")
             .make();
 
     assertEquals(testVector, sameTestVector);
@@ -66,11 +74,19 @@ public class TestVectorResultTest {
     assertNotEquals(sameTestVector.hashCode(), differentTestVector.hashCode());
 
     assertEquals(
-        new TestVectorResult(testVector, 0, 4.0, Status.PASSED,"Alles kaputt!"),
-        new TestVectorResult(testVector, 0, 4.0, Status.PASSED,"Alles kaputt!"));
+        new TestVectorResult(testVector, 0,
+            new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE).set(4.0),
+            Status.PASSED,"Alles gut!"),
+        new TestVectorResult(testVector, 0,
+            new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE).set(4.0),
+            Status.PASSED,"Alles gut!"));
     assertEquals(
-        new TestVectorResult(testVector, 0, 4.0, Status.PASSED,"Alles kaputt!"),
-        new TestVectorResult(sameTestVector, 0, 4.0, Status.PASSED,"Alles kaputt!"));
+        new TestVectorResult(testVector, 0,
+            new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE).set(4.0),
+            Status.PASSED,"Alles gut!"),
+        new TestVectorResult(sameTestVector, 0,
+            new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE).set(4.0),
+            Status.PASSED,"Alles gut!"));
   }
 
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/rating/NotApplicableLabelTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/rating/NotApplicableLabelTest.java
@@ -1,0 +1,41 @@
+package com.sap.sgs.phosphor.fosstars.model.rating;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.junit.Test;
+
+public class NotApplicableLabelTest {
+
+  @Test
+  public void name() {
+    assertFalse(new NotApplicableLabel().name().isEmpty());
+  }
+
+  @Test
+  public void isNotApplicable() {
+    assertTrue(new NotApplicableLabel().isNotApplicable());
+  }
+
+  @Test
+  public void equalsAndHashCode() {
+    NotApplicableLabel one = new NotApplicableLabel();
+    NotApplicableLabel two = new NotApplicableLabel();
+    assertEquals(one, one);
+    assertTrue(one.equals(two) && two.equals(one));
+    assertEquals(one.hashCode(), two.hashCode());
+  }
+
+  @Test
+  public void serializationAndDeserialization() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    NotApplicableLabel label = new NotApplicableLabel();
+    NotApplicableLabel clone = mapper.readValue(
+        mapper.writeValueAsBytes(label), NotApplicableLabel.class);
+    assertEquals(label, clone);
+  }
+
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTuningWithCMAESTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTuningWithCMAESTest.java
@@ -65,6 +65,7 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(UnknownValue.of(USES_LGTM))
           .set(UnknownValue.of(WORST_LGTM_GRADE))
           .expectedScore(DoubleInterval.closed(Score.MIN, 0.1))
+          .alias("one")
           .make(),
 
       // very bad project
@@ -85,6 +86,7 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(USES_LGTM.value(false))
           .set(WORST_LGTM_GRADE.unknown())
           .expectedScore(DoubleInterval.closed(1.0, 4.0))
+          .alias("two")
           .make(),
 
       // very good project
@@ -105,6 +107,7 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(USES_LGTM.value(true))
           .set(WORST_LGTM_GRADE.value(LgtmGrade.A_PLUS))
           .expectedScore(DoubleInterval.init().from(9.0).to(Score.MAX).make())
+          .alias("three")
           .make()
   ));
 

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/NotApplicableValueTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/NotApplicableValueTest.java
@@ -1,0 +1,61 @@
+package com.sap.sgs.phosphor.fosstars.model.value;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.example.ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE;
+import static com.sap.sgs.phosphor.fosstars.model.feature.example.ExampleFeatures.NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.junit.Test;
+
+public class NotApplicableValueTest {
+
+  @Test
+  public void isUnknown() {
+    assertTrue(NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).isUnknown());
+  }
+
+  @Test
+  public void isNotApplicable() {
+    assertTrue(NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).isNotApplicable());
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void get() {
+    NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).get();
+  }
+
+  @Test
+  public void equalsAndHashCode() {
+    NotApplicableValue one = NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
+    NotApplicableValue two = NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
+
+    assertEquals(one, one);
+    assertTrue(one.equals(two) && two.equals(one));
+    assertEquals(one.hashCode(), two.hashCode());
+
+    NotApplicableValue three = NotApplicableValue.of(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE);
+    assertNotEquals(one, three);
+
+    UnknownValue four = UnknownValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
+    assertNotEquals(one, four);
+  }
+
+  @Test
+  public void toStringIsNotEmpty() {
+    assertFalse(NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).toString().isEmpty());
+  }
+
+  @Test
+  public void serializationAndDeserialization() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    NotApplicableValue value = NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
+    NotApplicableValue clone = mapper.readValue(
+        mapper.writeValueAsBytes(value), NotApplicableValue.class);
+    assertEquals(value, clone);
+    assertEquals(value.hashCode(), clone.hashCode());
+  }
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValueTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValueTest.java
@@ -123,7 +123,7 @@ public class ScoreValueTest {
     notes.add("second note");
 
     ScoreValue value = new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE, 5.0, 1.0, 10.0,
-        Collections.emptyList(), notes);
+        Collections.emptyList(), notes, false, false);
     assertNotNull(value.explanation());
     assertEquals(2, value.explanation().size());
     assertTrue(value.explanation().containsAll(notes));

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/UnknownValueTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/UnknownValueTest.java
@@ -4,16 +4,16 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.example.ExampleFeature
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.sgs.phosphor.fosstars.model.Value;
+import java.io.IOException;
 import org.junit.Test;
 
 public class UnknownValueTest {
 
   @Test
   public void getFeature() {
-    Feature feature = NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE;
-    Value value = new UnknownValue(feature);
+    Value value = new UnknownValue(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
     assertEquals(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, value.feature());
   }
 
@@ -25,5 +25,15 @@ public class UnknownValueTest {
   @Test(expected = UnsupportedOperationException.class)
   public void get() {
     new UnknownValue<>(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).get();
+  }
+
+  @Test
+  public void serializationAndDeserialization() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    UnknownValue value = UnknownValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
+    UnknownValue clone = mapper.readValue(
+        mapper.writeValueAsBytes(value), UnknownValue.class);
+    assertEquals(value, clone);
+    assertEquals(value.hashCode(), clone.hashCode());
   }
 }


### PR DESCRIPTION
Here is a list of main updates:

- Added a new `Value.isNotApplicable()` method.
- Added a new `NotApplicableValue` class.
- Updated implementations of the `Value` interface to implement the new method.
- Added a new `Label.isNotApplicable()` method and a new `NotApplicableLabel` class.
- Updated the `TestVector` and `TestVectorBuilder` classes to understand not-applicable score values.
- Updated verifiers to expect not-applicable values
- Updated the `AverageCompositeScore` and `WeightedCompositeScore` classes to take into account not-applicable score values.
- Updated the `TuningWithCMAES` class to expect not-applicable values.
- Updated the `PrettyPrinter` to expect not-applicable values.
- Updated tests.

This closes #97 