### PR TITLE
Consolidate caching in the existing data providers

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/AbstractCachingDataProvider.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/AbstractCachingDataProvider.java
@@ -1,0 +1,91 @@
+package com.sap.sgs.phosphor.fosstars.data;
+
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.value.UnknownValue;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * <p>This is a base class for data providers that would like to check the cache
+ * before trying to fetch values for a number of features.</p>
+ *
+ * @param <T> A type of the objects for which the data provider can fetch data.
+ */
+public abstract class AbstractCachingDataProvider<T> extends AbstractDataProvider<T> {
+
+  /**
+   * This is a template method that checks for cached values
+   * before asking the child classes to fetch the data.
+   * If all supported features are already available in the cache, then the method just
+   * adds them to the resulting value set and exits. Otherwise, the method calls
+   * the {@link #fetchValuesFor(Object)} method to fetch the data.
+   *
+   * @param object The object for which the values need to be fetched.
+   * @param values The resulting set of values to be updated.
+   * @return The same data provider.
+   * @throws IOException If something went wrong.
+   */
+  @Override
+  public final AbstractCachingDataProvider<T> doUpdate(T object, ValueSet values)
+      throws IOException {
+
+    // get a list of features which are supported by the data provider
+    Set<Feature> features = supportedFeatures();
+
+    // look for values for the supported features in the cache
+    // unknown values don't count
+    Set<Value> cachedValues = new HashSet<>();
+    for (Feature feature : features) {
+      Optional<Value> something = cache.get(object, feature);
+      Value value = something.orElse(UnknownValue.of(feature));
+      if (!value.isUnknown()) {
+        cachedValues.add(value);
+      }
+    }
+
+    // put the cached values to the resulting set of values
+    for (Value value : cachedValues) {
+      values.update(value);
+    }
+
+    // if there is a cached known value for each feature, then we're done
+    if (cachedValues.size() == features.size()) {
+      return this;
+    }
+
+    // otherwise, try to find values for all features
+    Set<Value> updatedValues = fetchValuesFor(object);
+
+    // put the fetched values to the cache
+    // and update the resulting set of values
+    for (Value value : updatedValues) {
+      cache.put(object, value, expiration());
+      values.update(value);
+    }
+
+    return this;
+  }
+
+  /**
+   * Fetch values for an object.
+   *
+   * @param object The object
+   * @return A set of values for the object.
+   * @throws IOException If something went wrong.
+   */
+  protected abstract Set<Value> fetchValuesFor(T object) throws IOException;
+
+  /**
+   * Returns an expiration date for cache entries.
+   */
+  protected Date expiration() {
+    return Date.from(Instant.now().plus(1, ChronoUnit.DAYS)); // tomorrow
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/AbstractDataProvider.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/AbstractDataProvider.java
@@ -1,11 +1,19 @@
 package com.sap.sgs.phosphor.fosstars.data;
 
+import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * This is a base class for data providers that holds commons stuff such as a logger, a cache,
+ * a callback, etc.
+ *
+ * @param <T> A type of the objects for which the data provider can fetch data.
+ */
 public abstract class AbstractDataProvider<T> implements DataProvider<T> {
 
   /**
@@ -23,12 +31,30 @@ public abstract class AbstractDataProvider<T> implements DataProvider<T> {
    */
   protected UserCallback callback = NoUserCallback.INSTANCE;
 
+  /**
+   * <p>This is a template method that does a couple of checks for the parameters and then
+   * calls the {@link #doUpdate(Object, ValueSet)} method.</p>
+   *
+   * <p>The {@link #doUpdate(Object, ValueSet)} method fetched the data and adds it
+   * to the resulting set of feature values. The method has to be implemented
+   * by the child classes.</p>
+   *
+   * @param object The object.
+   * @param values The resulting set of values.
+   * @return The same data provider.
+   * @throws IOException If something went wrong.
+   */
   @Override
-  public AbstractDataProvider<T> update(T object, ValueSet values) throws IOException {
+  public final AbstractDataProvider<T> update(T object, ValueSet values) throws IOException {
     Objects.requireNonNull(object, "Hey! Object can't be null!");
     Objects.requireNonNull(values, "Hey! Values can't be null!");
     return doUpdate(object, values);
   }
+
+  /**
+   * Returns a set of features that the provider can fill out.
+   */
+  protected abstract Set<Feature> supportedFeatures();
 
   /**
    * Gathers data about an object and updates a specified set of values.
@@ -57,5 +83,4 @@ public abstract class AbstractDataProvider<T> implements DataProvider<T> {
     this.cache = Objects.requireNonNull(cache, "Hey! Cache can't be null!");
     return this;
   }
-
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/CachedSingleFeatureGitHubDataProvider.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/CachedSingleFeatureGitHubDataProvider.java
@@ -1,0 +1,47 @@
+package com.sap.sgs.phosphor.fosstars.data.github;
+
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import org.kohsuke.github.GitHub;
+
+/**
+ * This is a base class for data providers that fill out a single feature for a project on GitHub.
+ */
+public abstract class CachedSingleFeatureGitHubDataProvider extends GitHubCachingDataProvider {
+
+  /**
+   * Initializes a data provider.
+   *
+   * @param github An interface to the GitHub API.
+   */
+  public CachedSingleFeatureGitHubDataProvider(GitHub github) {
+    super(github);
+  }
+
+  @Override
+  protected final Set<Value> fetchValuesFor(GitHubProject project) throws IOException {
+    return Collections.singleton(fetchValueFor(project));
+  }
+
+  @Override
+  protected final Set<Feature> supportedFeatures() {
+    return Collections.singleton(supportedFeature());
+  }
+
+  /**
+   * Returns a feature that the provider can fill out.
+   */
+  protected abstract Feature supportedFeature();
+
+  /**
+   * Fetch a feature value for a project.
+   *
+   * @param project The project.
+   * @return The value.
+   */
+  protected abstract Value fetchValueFor(GitHubProject project) throws IOException;
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/FirstCommit.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/FirstCommit.java
@@ -2,8 +2,8 @@ package com.sap.sgs.phosphor.fosstars.data.github;
 
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.FIRST_COMMIT_DATE;
 
+import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Value;
-import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import java.util.Date;
@@ -14,7 +14,7 @@ import org.kohsuke.github.GitHub;
 /**
  * This data provider returns a date of the first commit.
  */
-public class FirstCommit extends AbstractGitHubDataProvider {
+public class FirstCommit extends CachedSingleFeatureGitHubDataProvider {
 
   /**
    * Initializes a data provider.
@@ -26,13 +26,14 @@ public class FirstCommit extends AbstractGitHubDataProvider {
   }
 
   @Override
-  protected FirstCommit doUpdate(GitHubProject project, ValueSet values) throws IOException {
+  protected Feature supportedFeature() {
+    return FIRST_COMMIT_DATE;
+  }
+
+  @Override
+  protected Value fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out when the first commit was done ...");
-
-    Value<Date> firstCommit = firstCommitDate(project);
-    values.update(firstCommit);
-
-    return this;
+    return firstCommitDate(project);
   }
 
   /**
@@ -41,18 +42,12 @@ public class FirstCommit extends AbstractGitHubDataProvider {
    * @return An instance of {@link Value} which contains a date of the first commit.
    * @throws IOException If something went wrong.
    */
-  Value<Date> firstCommitDate(GitHubProject project) throws IOException {
-    Optional<Value> something = cache.get(project, FIRST_COMMIT_DATE);
-    if (something.isPresent()) {
-      return something.get();
-    }
-
-    Value<Date> value = FIRST_COMMIT_DATE.unknown();
+  private Value<Date> firstCommitDate(GitHubProject project) throws IOException {
     Optional<GHCommit> firstCommit = gitHubDataFetcher().firstCommitFor(project, github);
     if (firstCommit.isPresent()) {
-      value = FIRST_COMMIT_DATE.value(firstCommit.get().getCommitDate());
+      return FIRST_COMMIT_DATE.value(firstCommit.get().getCommitDate());
     }
-    cache.put(project, value, tomorrow());
-    return value;
+
+    return FIRST_COMMIT_DATE.unknown();
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubCachingDataProvider.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubCachingDataProvider.java
@@ -1,15 +1,16 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
-import com.sap.sgs.phosphor.fosstars.data.AbstractDataProvider;
+import com.sap.sgs.phosphor.fosstars.data.AbstractCachingDataProvider;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubDataFetcher;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.util.Objects;
 import org.kohsuke.github.GitHub;
 
 /**
- * Base class for data providers which get data from GitHub.
+ * This is a base class for data providers that would like to check the cache
+ * before trying to fetch values for a project on GitHub.
  */
-public abstract class AbstractGitHubDataProvider extends AbstractDataProvider<GitHubProject> {
+public abstract class GitHubCachingDataProvider extends AbstractCachingDataProvider<GitHubProject> {
 
   /**
    * An interface to the GitHub API.
@@ -21,14 +22,11 @@ public abstract class AbstractGitHubDataProvider extends AbstractDataProvider<Gi
    *
    * @param github An interface to the GitHub API.
    */
-  public AbstractGitHubDataProvider(GitHub github) {
+  public GitHubCachingDataProvider(GitHub github) {
     this.github = Objects.requireNonNull(
         github, "Oh no! You gave me a null instead of a GitHub instance!");
   }
 
-  /**
-   * The method always returns false, so that all child classes can't be interactive.
-   */
   @Override
   public final boolean interactive() {
     return false;
@@ -40,4 +38,5 @@ public abstract class AbstractGitHubDataProvider extends AbstractDataProvider<Gi
   protected GitHubDataFetcher gitHubDataFetcher() {
     return GitHubDataFetcher.instance();
   }
+
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/HasCompanySupport.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/HasCompanySupport.java
@@ -3,7 +3,8 @@ package com.sap.sgs.phosphor.fosstars.data.github;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
 
 import com.sap.sgs.phosphor.fosstars.data.json.CompanySupportStorage;
-import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import org.kohsuke.github.GitHub;
@@ -11,7 +12,7 @@ import org.kohsuke.github.GitHub;
 /**
  * This data provider check if an open-source project is supported by a company.
  */
-public class HasCompanySupport extends AbstractGitHubDataProvider {
+public class HasCompanySupport extends CachedSingleFeatureGitHubDataProvider {
 
   /**
    * Where the info about open-source projects is stored.
@@ -30,9 +31,13 @@ public class HasCompanySupport extends AbstractGitHubDataProvider {
   }
 
   @Override
-  protected HasCompanySupport doUpdate(GitHubProject project, ValueSet values) {
+  protected Feature supportedFeature() {
+    return SUPPORTED_BY_COMPANY;
+  }
+
+  @Override
+  protected Value fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project is supported by a company ...");
-    values.update(SUPPORTED_BY_COMPANY.value(company.supports(project.url())));
-    return this;
+    return SUPPORTED_BY_COMPANY.value(company.supports(project.url()));
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/HasSecurityTeam.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/HasSecurityTeam.java
@@ -4,7 +4,8 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SE
 
 import com.sap.sgs.phosphor.fosstars.data.UserCallback;
 import com.sap.sgs.phosphor.fosstars.data.json.SecurityTeamStorage;
-import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import org.kohsuke.github.GitHub;
@@ -14,7 +15,7 @@ import org.kohsuke.github.GitHub;
  * project belongs to an organization which provides a security team such as Apache Software
  * Foundation. Next, it tries to ask a user if {@link UserCallback} is available.
  */
-public class HasSecurityTeam extends AbstractGitHubDataProvider {
+public class HasSecurityTeam extends CachedSingleFeatureGitHubDataProvider {
 
   /**
    * Where info about security teams are stored.
@@ -32,15 +33,16 @@ public class HasSecurityTeam extends AbstractGitHubDataProvider {
   }
 
   @Override
-  protected HasSecurityTeam doUpdate(GitHubProject project, ValueSet values) {
+  protected Feature supportedFeature() {
+    return HAS_SECURITY_TEAM;
+  }
+
+  @Override
+  protected Value fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project has a security team ...");
-
     if (securityTeam.existsFor(project.url())) {
-      values.update(HAS_SECURITY_TEAM.value(true));
-    } else {
-      values.update(HAS_SECURITY_TEAM.unknown());
+      HAS_SECURITY_TEAM.value(true);
     }
-
-    return this;
+    return HAS_SECURITY_TEAM.unknown();
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/InfoAboutVulnerabilities.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/InfoAboutVulnerabilities.java
@@ -1,0 +1,72 @@
+package com.sap.sgs.phosphor.fosstars.data.github;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
+
+import com.sap.sgs.phosphor.fosstars.data.DataProvider;
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
+import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
+import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.kohsuke.github.GitHub;
+
+/**
+ * This data provider tries to fill out the
+ * {@link com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#VULNERABILITIES} feature.
+ * It is based on the following data providers:
+ * <ul>
+ *   <li>{@link UnpatchedVulnerabilities}</li>
+ *   <li>{@link VulnerabilitiesFromNvd}</li>
+ * </ul>
+ * The data provider cache a value for
+ * the {@link com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#VULNERABILITIES} feature.
+ */
+public class InfoAboutVulnerabilities extends CachedSingleFeatureGitHubDataProvider {
+
+  /**
+   * A list of underlying data providers.
+   */
+  private List<DataProvider<GitHubProject>> providers;
+
+  /**
+   * Initializes a data provider.
+   *
+   * @param github An interface to the GitHub API.
+   */
+  public InfoAboutVulnerabilities(GitHub github) throws IOException {
+    super(github);
+    providers = Arrays.asList(
+        new UnpatchedVulnerabilities(github),
+        new VulnerabilitiesFromNvd(github));
+  }
+
+  @Override
+  protected Feature supportedFeature() {
+    return VULNERABILITIES;
+  }
+
+  @Override
+  protected Value fetchValueFor(GitHubProject project) throws IOException {
+    Vulnerabilities allVulnerabilities = new Vulnerabilities();
+    for (DataProvider<GitHubProject> provider : providers) {
+      ValueSet subset = new ValueHashSet();
+      provider.set(callback).set(cache).update(project, subset);
+
+      for (Value value : subset.toArray()) {
+        if (value.isUnknown()) {
+          continue;
+        }
+
+        if (value.get() instanceof Vulnerabilities) {
+          allVulnerabilities.add((Vulnerabilities) value.get());
+        }
+      }
+    }
+
+    return VULNERABILITIES.value(allVulnerabilities);
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/IsApache.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/IsApache.java
@@ -2,15 +2,17 @@ package com.sap.sgs.phosphor.fosstars.data.github;
 
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.IS_APACHE;
 
-import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
+import java.io.IOException;
 import org.kohsuke.github.GitHub;
 
 /**
  * The data provider tries to figure out if an open-source project belongs to the Apache Software
  * Foundation.
  */
-public class IsApache extends AbstractGitHubDataProvider {
+public class IsApache extends CachedSingleFeatureGitHubDataProvider {
 
   /**
    * Initializes a data provider.
@@ -22,10 +24,14 @@ public class IsApache extends AbstractGitHubDataProvider {
   }
 
   @Override
-  protected IsApache doUpdate(GitHubProject project, ValueSet values) {
+  protected Feature supportedFeature() {
+    return IS_APACHE;
+  }
+
+  @Override
+  protected Value fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project belongs to the Apache Software Foundation ...");
-    values.update(IS_APACHE.value("apache".equalsIgnoreCase(project.organization().name())));
-    return this;
+    return IS_APACHE.value("apache".equalsIgnoreCase(project.organization().name()));
   }
 
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/IsEclipse.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/IsEclipse.java
@@ -2,15 +2,17 @@ package com.sap.sgs.phosphor.fosstars.data.github;
 
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.IS_ECLIPSE;
 
-import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
+import java.io.IOException;
 import org.kohsuke.github.GitHub;
 
 /**
  * The data provider tries to figure out if an open-source project belongs to the Eclipse Software
  * Foundation.
  */
-public class IsEclipse extends AbstractGitHubDataProvider {
+public class IsEclipse extends CachedSingleFeatureGitHubDataProvider {
 
   /**
    * Initializes a data provider.
@@ -22,9 +24,13 @@ public class IsEclipse extends AbstractGitHubDataProvider {
   }
 
   @Override
-  protected IsEclipse doUpdate(GitHubProject project, ValueSet values) {
+  protected Feature supportedFeature() {
+    return IS_ECLIPSE;
+  }
+
+  @Override
+  protected Value fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project belongs to the Eclipse Software Foundation ...");
-    values.update(IS_ECLIPSE.value("eclipse".equalsIgnoreCase(project.organization().name())));
-    return this;
+    return IS_ECLIPSE.value("eclipse".equalsIgnoreCase(project.organization().name()));
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/NumberOfCommits.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/NumberOfCommits.java
@@ -2,19 +2,17 @@ package com.sap.sgs.phosphor.fosstars.data.github;
 
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_COMMITS_LAST_THREE_MONTHS;
 
+import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Value;
-import com.sap.sgs.phosphor.fosstars.model.ValueSet;
-import com.sap.sgs.phosphor.fosstars.model.value.IntegerValue;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import java.util.Date;
-import java.util.Optional;
 import org.kohsuke.github.GitHub;
 
 /**
  * This data provider returns a number of commits last 3 months.
  */
-public class NumberOfCommits extends AbstractGitHubDataProvider {
+public class NumberOfCommits extends CachedSingleFeatureGitHubDataProvider {
 
   /**
    * 3 months in millis.
@@ -31,22 +29,17 @@ public class NumberOfCommits extends AbstractGitHubDataProvider {
   }
 
   @Override
-  protected NumberOfCommits doUpdate(GitHubProject project, ValueSet values) throws IOException {
+  protected Feature supportedFeature() {
+    return NUMBER_OF_COMMITS_LAST_THREE_MONTHS;
+  }
+
+  @Override
+  protected Value fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Counting how many commits have been done in the last three months ...");
 
-    Optional<Value> something = cache.get(project, NUMBER_OF_COMMITS_LAST_THREE_MONTHS);
-    if (something.isPresent()) {
-      values.update(something.get());
-      return this;
-    }
-
+    // TODO: define a date in a modern way
     Date date = new Date(System.currentTimeMillis() - DELTA);
-
-    Value<Integer> numberOfCommits = new IntegerValue(NUMBER_OF_COMMITS_LAST_THREE_MONTHS,
+    return NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(
         gitHubDataFetcher().commitsAfter(date, project, github).size());
-    values.update(numberOfCommits);
-    cache.put(project, numberOfCommits, tomorrow());
-
-    return this;
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/NumberOfStars.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/NumberOfStars.java
@@ -2,17 +2,16 @@ package com.sap.sgs.phosphor.fosstars.data.github;
 
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
 
+import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Value;
-import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
-import java.util.Optional;
 import org.kohsuke.github.GitHub;
 
 /**
  * This data provider returns a number of stars for a project.
  */
-public class NumberOfStars extends AbstractGitHubDataProvider {
+public class NumberOfStars extends CachedSingleFeatureGitHubDataProvider {
 
   /**
    * Initializes a data provider.
@@ -24,10 +23,8 @@ public class NumberOfStars extends AbstractGitHubDataProvider {
   }
 
   @Override
-  protected NumberOfStars doUpdate(GitHubProject project, ValueSet values) throws IOException {
-    logger.info("Counting how many stars the project has ...");
-    values.update(starsOf(project));
-    return this;
+  protected Feature supportedFeature() {
+    return NUMBER_OF_GITHUB_STARS;
   }
 
   /**
@@ -37,16 +34,11 @@ public class NumberOfStars extends AbstractGitHubDataProvider {
    * @return The number of stars.
    * @throws IOException If something went wrong.
    */
-  private Value<Integer> starsOf(GitHubProject project) throws IOException {
-    Optional<Value> something = cache.get(project, NUMBER_OF_GITHUB_STARS);
-    if (something.isPresent()) {
-      return something.get();
-    }
-
-    Value<Integer> value = NUMBER_OF_GITHUB_STARS
-        .value(gitHubDataFetcher().repositoryFor(project, github).getStargazersCount());
-
-    cache.put(project, value);
-    return value;
+  @Override
+  protected Value fetchValueFor(GitHubProject project) throws IOException {
+    logger.info("Counting how many stars the project has ...");
+    return NUMBER_OF_GITHUB_STARS.value(
+        gitHubDataFetcher().repositoryFor(project, github).getStargazersCount());
   }
+
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/NumberOfWatchers.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/NumberOfWatchers.java
@@ -2,17 +2,16 @@ package com.sap.sgs.phosphor.fosstars.data.github;
 
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_WATCHERS_ON_GITHUB;
 
+import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Value;
-import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
-import java.util.Optional;
 import org.kohsuke.github.GitHub;
 
 /**
  * This data provider returns a number of watchers for a project.
  */
-public class NumberOfWatchers extends AbstractGitHubDataProvider {
+public class NumberOfWatchers extends CachedSingleFeatureGitHubDataProvider {
 
   /**
    * Initializes a data provider.
@@ -24,10 +23,8 @@ public class NumberOfWatchers extends AbstractGitHubDataProvider {
   }
 
   @Override
-  protected NumberOfWatchers doUpdate(GitHubProject project, ValueSet values) throws IOException {
-    logger.info("Counting how many watchers the project has ...");
-    values.update(watchersOf(project));
-    return this;
+  protected Feature supportedFeature() {
+    return NUMBER_OF_WATCHERS_ON_GITHUB;
   }
 
   /**
@@ -37,16 +34,10 @@ public class NumberOfWatchers extends AbstractGitHubDataProvider {
    * @return The number of watchers.
    * @throws IOException If something went wrong.
    */
-  private Value<Integer> watchersOf(GitHubProject project) throws IOException {
-    Optional<Value> something = cache.get(project, NUMBER_OF_WATCHERS_ON_GITHUB);
-    if (something.isPresent()) {
-      return something.get();
-    }
-
-    Value<Integer> value = NUMBER_OF_WATCHERS_ON_GITHUB
-        .value(gitHubDataFetcher().repositoryFor(project, github).getSubscribersCount());
-
-    cache.put(project, value);
-    return value;
+  @Override
+  protected Value fetchValueFor(GitHubProject project) throws IOException {
+    logger.info("Counting how many watchers the project has ...");
+    return NUMBER_OF_WATCHERS_ON_GITHUB.value(
+        gitHubDataFetcher().repositoryFor(project, github).getSubscribersCount());
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/ScansForVulnerableDependencies.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/ScansForVulnerableDependencies.java
@@ -1,0 +1,58 @@
+package com.sap.sgs.phosphor.fosstars.data.github;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
+
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.kohsuke.github.GitHub;
+
+/**
+ * This data provider tries to fill out the
+ * {@link
+ * com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#SCANS_FOR_VULNERABLE_DEPENDENCIES}.
+ * feature.
+ * It is based on a number of data providers:
+ * <ul>
+ *   <li>{@link UsesOwaspDependencyCheck}</li>
+ *   <li>{@link UsesSnykDependencyCheck}</li>
+ * </ul>
+ */
+public class ScansForVulnerableDependencies extends CachedSingleFeatureGitHubDataProvider {
+
+  private final List<CachedSingleFeatureGitHubDataProvider> providers;
+
+  /**
+   * Initializes a data provider.
+   *
+   * @param github An interface to the GitHub API.
+   */
+  public ScansForVulnerableDependencies(GitHub github) {
+    super(github);
+    providers = Arrays.asList(
+        new UsesOwaspDependencyCheck(github),
+        new UsesSnykDependencyCheck(github)
+    );
+    // TODO: include UsesDependabot provider
+  }
+
+  @Override
+  protected Feature supportedFeature() {
+    return SCANS_FOR_VULNERABLE_DEPENDENCIES;
+  }
+
+  @Override
+  protected Value fetchValueFor(GitHubProject project) throws IOException {
+    for (CachedSingleFeatureGitHubDataProvider provider : providers) {
+      Value value = provider.fetchValueFor(project);
+      if (!value.isUnknown() && Boolean.TRUE.equals(value.get())) {
+        return SCANS_FOR_VULNERABLE_DEPENDENCIES.value(true);
+      }
+    }
+
+    return SCANS_FOR_VULNERABLE_DEPENDENCIES.unknown();
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/SecurityReviewForProject.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/SecurityReviewForProject.java
@@ -1,7 +1,10 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SECURITY_REVIEWS_DONE;
+
 import com.sap.sgs.phosphor.fosstars.data.json.SecurityReviewStorage;
-import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.value.SecurityReviewsDoneValue;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
@@ -13,7 +16,7 @@ import org.kohsuke.github.GitHub;
  *       which contains info about known security teams.
  *       SecurityReviewForProject may be converted to a data provider.
  */
-public class SecurityReviewForProject extends AbstractGitHubDataProvider {
+public class SecurityReviewForProject extends CachedSingleFeatureGitHubDataProvider {
 
   /**
    * Where the info about security review is stored.
@@ -32,9 +35,13 @@ public class SecurityReviewForProject extends AbstractGitHubDataProvider {
   }
 
   @Override
-  protected SecurityReviewForProject doUpdate(GitHubProject project, ValueSet values) {
+  protected Feature supportedFeature() {
+    return SECURITY_REVIEWS_DONE;
+  }
+
+  @Override
+  protected Value fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if any security review has been done for the project ...");
-    values.update(new SecurityReviewsDoneValue(storage.get(project.url())));
-    return this;
+    return new SecurityReviewsDoneValue(storage.get(project.url()));
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesGithubForDevelopment.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesGithubForDevelopment.java
@@ -2,12 +2,11 @@ package com.sap.sgs.phosphor.fosstars.data.github;
 
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_GITHUB_FOR_DEVELOPMENT;
 
+import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Value;
-import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.model.value.BooleanValue;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
-import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
@@ -17,7 +16,7 @@ import org.kohsuke.github.GitHub;
  * would be based on mirror url is null or empty. This will ensure whether the underlying project is
  * a mirror project or not.
  */
-public class UsesGithubForDevelopment extends AbstractGitHubDataProvider {
+public class UsesGithubForDevelopment extends CachedSingleFeatureGitHubDataProvider {
 
   /**
    * Initializes a data provider.
@@ -29,21 +28,14 @@ public class UsesGithubForDevelopment extends AbstractGitHubDataProvider {
   }
 
   @Override
-  protected UsesGithubForDevelopment doUpdate(GitHubProject project, ValueSet values)
-      throws IOException {
+  protected Feature supportedFeature() {
+    return USES_GITHUB_FOR_DEVELOPMENT;
+  }
+
+  @Override
+  protected Value fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project uses GitHub as the main development platform ...");
-
-    Optional<Value> something = cache.get(project, USES_GITHUB_FOR_DEVELOPMENT);
-    if (something.isPresent()) {
-      values.update(something.get());
-      return this;
-    }
-
-    Value<Boolean> usesGithubForDevelopment = usesGithubForDevelopment(project);
-    values.update(usesGithubForDevelopment);
-    cache.put(project, usesGithubForDevelopment, tomorrow());
-
-    return this;
+    return usesGithubForDevelopment(project);
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesOwaspDependencyCheck.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesOwaspDependencyCheck.java
@@ -1,10 +1,8 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
-import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
-
+import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Value;
-import com.sap.sgs.phosphor.fosstars.model.ValueSet;
-import com.sap.sgs.phosphor.fosstars.model.value.BooleanValue;
+import com.sap.sgs.phosphor.fosstars.model.feature.BooleanFeature;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,11 +18,15 @@ import org.kohsuke.github.GitHub;
 
 /**
  * This data provider checks if an open-source project uses OWASP Dependency Check Maven plugin to
- * scan dependencies for known vulnerabilities. If it does, the provider sets {@link
- * com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#SCANS_FOR_VULNERABLE_DEPENDENCIES}
- * to true.
+ * scan dependencies for known vulnerabilities.
  */
-public class UsesOwaspDependencyCheck extends AbstractGitHubDataProvider {
+public class UsesOwaspDependencyCheck extends CachedSingleFeatureGitHubDataProvider {
+
+  /**
+   * A feature which is filled out by the provider.
+   */
+  public static final Feature<Boolean> USES_OWASP_DEPENDENCY_CHECK
+      = new BooleanFeature("If a project uses OWASP Dependency Check");
 
   /**
    * Initializes a data provider.
@@ -36,17 +38,16 @@ public class UsesOwaspDependencyCheck extends AbstractGitHubDataProvider {
   }
 
   @Override
-  protected UsesOwaspDependencyCheck doUpdate(GitHubProject project, ValueSet values)
-      throws IOException {
+  protected Feature supportedFeature() {
+    return USES_OWASP_DEPENDENCY_CHECK;
+  }
 
+  @Override
+  protected Value<Boolean> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project uses OWASP Dependency Check ...");
-
     GHRepository repository = gitHubDataFetcher().repositoryFor(project, github);
     boolean answer = checkMaven(repository) || checkGradle(repository);
-    Value<Boolean> value = new BooleanValue(SCANS_FOR_VULNERABLE_DEPENDENCIES, answer);
-    values.update(value);
-
-    return this;
+    return USES_OWASP_DEPENDENCY_CHECK.value(answer);
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesSnykDependencyCheck.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesSnykDependencyCheck.java
@@ -1,19 +1,24 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
-import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
 
-import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.feature.BooleanFeature;
 import com.sap.sgs.phosphor.fosstars.model.value.UnknownValue;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import org.kohsuke.github.GitHub;
 
 /**
  * This data provider checks if an open-source project uses OWASP Dependency Check Maven plugin to
- * scan dependencies for known vulnerabilities. If it does, the provider sets {@link
- * com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#SCANS_FOR_VULNERABLE_DEPENDENCIES}
- * to true.
+ * scan dependencies for known vulnerabilities.
  */
-public class UsesSnykDependencyCheck extends AbstractGitHubDataProvider {
+public class UsesSnykDependencyCheck extends CachedSingleFeatureGitHubDataProvider {
+
+  /**
+   * A feature which is filled out by the provider.
+   */
+  public static final Feature<Boolean> USES_SNYK
+      = new BooleanFeature("If a project uses Snyk");
 
   /**
    * Initializes a data provider.
@@ -24,12 +29,15 @@ public class UsesSnykDependencyCheck extends AbstractGitHubDataProvider {
     super(github);
   }
 
-  // TODO: implement UsesSnykDependencyCheck.update() method
   @Override
-  protected UsesSnykDependencyCheck doUpdate(GitHubProject project, ValueSet values) {
+  protected Feature supportedFeature() {
+    return USES_SNYK;
+  }
+
+  // TODO: implement UsesSnykDependencyCheck.fetchValueFor() method
+  @Override
+  protected Value<Boolean> fetchValueFor(GitHubProject project) {
     logger.info("Figuring out if the project uses Snyk ...");
-    // TODO: check the cache
-    values.update(UnknownValue.of(SCANS_FOR_VULNERABLE_DEPENDENCIES));
-    return this;
+    return UnknownValue.of(USES_SNYK);
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutSecurityTeam.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutSecurityTeam.java
@@ -2,10 +2,13 @@ package com.sap.sgs.phosphor.fosstars.data.interactive;
 
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_TEAM;
 
+import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.model.value.BooleanValue;
 import com.sap.sgs.phosphor.fosstars.tool.YesNoSkipQuestion;
 import com.sap.sgs.phosphor.fosstars.tool.YesNoSkipQuestion.Answer;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * This data provider asks a user about security teams.
@@ -35,5 +38,10 @@ public class AskAboutSecurityTeam<T> extends AbstractInteractiveDataProvider<T> 
     // TODO: store the answer in the SecurityTeamStorage
 
     return this;
+  }
+
+  @Override
+  protected Set<Feature> supportedFeatures() {
+    return Collections.singleton(HAS_SECURITY_TEAM);
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutUnpatchedVulnerabilities.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutUnpatchedVulnerabilities.java
@@ -7,6 +7,7 @@ import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.UNKNOWN_FI
 import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.UNKNOWN_INTRODUCED_DATE;
 import static com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion.Answer.YES;
 
+import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.model.value.CVSS;
@@ -16,6 +17,8 @@ import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Resolution;
 import com.sap.sgs.phosphor.fosstars.tool.InputURL;
 import com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion;
 import com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion.Answer;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * This data provider asks a user about unpatched vulnerabilities.
@@ -61,5 +64,10 @@ public class AskAboutUnpatchedVulnerabilities<T> extends AbstractInteractiveData
    */
   private static Value<Vulnerabilities> knownVulnerabilities(ValueSet values) {
     return values.of(VULNERABILITIES).orElseGet(() -> VULNERABILITIES.value(new Vulnerabilities()));
+  }
+
+  @Override
+  protected Set<Feature> supportedFeatures() {
+    return Collections.singleton(VULNERABILITIES);
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorage.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorage.java
@@ -67,8 +67,8 @@ public class UnpatchedVulnerabilitiesStorage extends AbstractJsonStorage {
    *         project.
    * @throws MalformedURLException If the URL is not valid.
    */
-  public Vulnerabilities get(String url) throws MalformedURLException {
-    return get(new URL(url));
+  public Vulnerabilities getFor(String url) throws MalformedURLException {
+    return getFor(new URL(url));
   }
 
   /**
@@ -78,7 +78,7 @@ public class UnpatchedVulnerabilitiesStorage extends AbstractJsonStorage {
    * @return An instance of {@link Vulnerabilities} with all known unpatched vulnerabilities for the
    *         project.
    */
-  public Vulnerabilities get(URL url) {
+  public Vulnerabilities getFor(URL url) {
     Vulnerabilities vulnerabilities = projectVulnerabilities.get(url);
     if (vulnerabilities == null) {
       return new Vulnerabilities();

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/feature/oss/VulnerabilitiesInProject.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/feature/oss/VulnerabilitiesInProject.java
@@ -23,7 +23,7 @@ public class VulnerabilitiesInProject extends AbstractFeature<Vulnerabilities> {
   /**
    * Initializes a new feature.
    */
-  VulnerabilitiesInProject() {
+  public VulnerabilitiesInProject() {
     super("Info about vulnerabilities in open-source project");
   }
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubDataCache.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubDataCache.java
@@ -24,7 +24,7 @@ public class GitHubDataCache<T> implements DataCache<GitHubProject, T> {
   /**
    * This constant means that the value has no expiration date.
    */
-  public static final Date NO_EXPIRATION = null;
+  private static final Date NO_EXPIRATION = null;
 
   /**
    * A map of cache entries.
@@ -56,11 +56,21 @@ public class GitHubDataCache<T> implements DataCache<GitHubProject, T> {
 
   @Override
   public void put(GitHubProject project, T value, Date expiration) {
-    entries.put(project, new GitHubData<T>(value, expiration));
+    entries.put(project, new GitHubData<>(value, expiration));
   }
 
+  /**
+   * Returns a size of the cache.
+   */
   public int size() {
     return entries.size();
+  }
+
+  /**
+   * Returns the maximum size of the cache.
+   */
+  public int maxSize() {
+    return entries.maxSize();
   }
 
   @Override
@@ -81,7 +91,7 @@ public class GitHubDataCache<T> implements DataCache<GitHubProject, T> {
   }
 
   /**
-   * Clear cache.
+   * Clear the cache.
    */
   public void clear() {
     entries.clear();
@@ -109,7 +119,7 @@ public class GitHubDataCache<T> implements DataCache<GitHubProject, T> {
      * @param data from GitHub project.
      * @param expiration date decided from {@link GitHubDataCache}.
      */
-    public GitHubData(T data, Date expiration) {
+    private GitHubData(T data, Date expiration) {
       this.data = data;
       this.expiration = expiration;
     }
@@ -119,7 +129,7 @@ public class GitHubDataCache<T> implements DataCache<GitHubProject, T> {
      * 
      * @return true if expired. Otherwise, false.
      */
-    public boolean expired() {
+    private boolean expired() {
       Date now = new Date();
       return expiration != null && now.after(expiration);
     }
@@ -127,7 +137,7 @@ public class GitHubDataCache<T> implements DataCache<GitHubProject, T> {
     /**
      * Returns the cached GitHub data.
      */
-    public T get() {
+    private T get() {
       return data;
     }
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubDataFetcher.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubDataFetcher.java
@@ -2,6 +2,8 @@ package com.sap.sgs.phosphor.fosstars.tool.github;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
@@ -21,7 +23,7 @@ public class GitHubDataFetcher {
   /**
    * The singleton instance.
    */
-  private static GitHubDataFetcher INSTANCE;
+  private static final GitHubDataFetcher INSTANCE = new GitHubDataFetcher();
 
   /**
    * {@link Comparator} which compares {@link Date} object.
@@ -37,12 +39,12 @@ public class GitHubDataFetcher {
   /**
    * A limited capacity cache to store all the commits of a {@link GitHubProject}.
    */
-  public final GitHubDataCache<List<GHCommit>> commitsCache = new GitHubDataCache<>();
+  final GitHubDataCache<List<GHCommit>> commitsCache = new GitHubDataCache<>();
 
   /**
    * A limited capacity cache to store the repository of a {@link GitHubProject}.
    */
-  public final GitHubDataCache<GHRepository> repositoryCache = new GitHubDataCache<>();
+  final GitHubDataCache<GHRepository> repositoryCache = new GitHubDataCache<>();
 
   /**
    * A private constructor for singleton pattern.
@@ -57,9 +59,6 @@ public class GitHubDataFetcher {
    * @return instance of this data pull helper.
    */
   public static GitHubDataFetcher instance() {
-    if (INSTANCE == null) {
-      INSTANCE = new GitHubDataFetcher();
-    }
     return INSTANCE;
   }
   
@@ -82,7 +81,7 @@ public class GitHubDataFetcher {
 
     List<GHCommit> commits = new ArrayList<>(commitsFor(repositoryFor(project, github)));
     commits.sort(BY_COMMIT_DATE.reversed());
-    commitsCache.put(project, commits, tomorrow());
+    commitsCache.put(project, commits, expiration());
     return commits;
   }
 
@@ -113,7 +112,7 @@ public class GitHubDataFetcher {
     }
 
     GHRepository repository = github.getRepository(project.path());
-    repositoryCache.put(project, repository, tomorrow());
+    repositoryCache.put(project, repository, expiration());
     return repository;
   }
 
@@ -158,9 +157,9 @@ public class GitHubDataFetcher {
   }
 
   /**
-   * Returns a date for tomorrow.
+   * Returns an expiration date for cache entries.
    */
-  private static Date tomorrow() {
-    return new Date(System.currentTimeMillis() + 24 * 60 * 60 * 1000L);
+  protected Date expiration() {
+    return Date.from(Instant.now().plus(1, ChronoUnit.DAYS)); // tomorrow
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SingleSecurityRatingCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SingleSecurityRatingCalculator.java
@@ -1,12 +1,10 @@
 package com.sap.sgs.phosphor.fosstars.tool.github;
 
-import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
-
-import com.sap.sgs.phosphor.fosstars.data.CompositeDataProvider;
 import com.sap.sgs.phosphor.fosstars.data.DataProvider;
 import com.sap.sgs.phosphor.fosstars.data.github.HasCompanySupport;
 import com.sap.sgs.phosphor.fosstars.data.github.HasSecurityPolicy;
 import com.sap.sgs.phosphor.fosstars.data.github.HasSecurityTeam;
+import com.sap.sgs.phosphor.fosstars.data.github.InfoAboutVulnerabilities;
 import com.sap.sgs.phosphor.fosstars.data.github.IsApache;
 import com.sap.sgs.phosphor.fosstars.data.github.IsEclipse;
 import com.sap.sgs.phosphor.fosstars.data.github.LgtmDataProvider;
@@ -15,12 +13,9 @@ import com.sap.sgs.phosphor.fosstars.data.github.NumberOfContributors;
 import com.sap.sgs.phosphor.fosstars.data.github.NumberOfStars;
 import com.sap.sgs.phosphor.fosstars.data.github.NumberOfWatchers;
 import com.sap.sgs.phosphor.fosstars.data.github.ProjectStarted;
+import com.sap.sgs.phosphor.fosstars.data.github.ScansForVulnerableDependencies;
 import com.sap.sgs.phosphor.fosstars.data.github.SecurityReviewForProject;
-import com.sap.sgs.phosphor.fosstars.data.github.UnpatchedVulnerabilities;
-import com.sap.sgs.phosphor.fosstars.data.github.UsesOwaspDependencyCheck;
 import com.sap.sgs.phosphor.fosstars.data.github.UsesSignedCommits;
-import com.sap.sgs.phosphor.fosstars.data.github.UsesSnykDependencyCheck;
-import com.sap.sgs.phosphor.fosstars.data.github.VulnerabilitiesFromNvd;
 import com.sap.sgs.phosphor.fosstars.data.interactive.AskAboutSecurityTeam;
 import com.sap.sgs.phosphor.fosstars.data.interactive.AskAboutUnpatchedVulnerabilities;
 import com.sap.sgs.phosphor.fosstars.model.RatingRepository;
@@ -108,16 +103,14 @@ class SingleSecurityRatingCalculator extends AbstractRatingCalculator {
         new HasCompanySupport(github),
         new HasSecurityPolicy(github),
         new SecurityReviewForProject(github),
-        new UnpatchedVulnerabilities(github),
-        new VulnerabilitiesFromNvd(github),
+        new InfoAboutVulnerabilities(github),
         new IsApache(github),
         new IsEclipse(github),
         new LgtmDataProvider(github),
         new UsesSignedCommits(github),
-        new CompositeDataProvider<>(
-            new UsesOwaspDependencyCheck(github),
-            new UsesSnykDependencyCheck(github))
-            .stopWhenFilledOut(SCANS_FOR_VULNERABLE_DEPENDENCIES),
+        new ScansForVulnerableDependencies(github),
+
+        // currently interactive data provider have to be added to the end, see issue #133
         new AskAboutSecurityTeam<>(),
         new AskAboutUnpatchedVulnerabilities<>()
     );

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/AbstractCachingDataProviderTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/AbstractCachingDataProviderTest.java
@@ -1,0 +1,140 @@
+package com.sap.sgs.phosphor.fosstars.data;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.example.ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE;
+import static com.sap.sgs.phosphor.fosstars.model.feature.example.ExampleFeatures.SECURITY_REVIEW_DONE_EXAMPLE;
+import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+
+public class AbstractCachingDataProviderTest {
+
+  @Test
+  public void testProviderWithSingleFeature() throws IOException {
+    CachingDataProviderForSingleFeature provider = new CachingDataProviderForSingleFeature();
+    provider.set(new StandardValueCache());
+
+    assertFalse(provider.interactive());
+    assertEquals(1, provider.supportedFeatures().size());
+    assertTrue(provider.supportedFeatures().contains(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE));
+
+    for (int i = 0; i < 10; i++) {
+      ValueSet values = new ValueHashSet();
+      provider.update("test", values);
+      assertEquals(1, values.size());
+      assertTrue(values.has(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE));
+      assertTrue(values.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).isPresent());
+      assertEquals(42, values.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).get().get());
+
+      // make sure that the cache is used
+      assertEquals(1, provider.counter);
+    }
+  }
+
+  @Test
+  public void testProviderWithMultipleFeatures() throws IOException {
+    CachingDataProviderForMultipleFeatures provider = new CachingDataProviderForMultipleFeatures();
+    provider.set(new StandardValueCache());
+
+    assertFalse(provider.interactive());
+    assertEquals(2, provider.supportedFeatures().size());
+    assertTrue(provider.supportedFeatures().contains(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE));
+    assertTrue(provider.supportedFeatures().contains(SECURITY_REVIEW_DONE_EXAMPLE));
+
+    ValueSet values = new ValueHashSet();
+    provider.update("test", values);
+    assertEquals(2, values.size());
+    assertTrue(values.has(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE));
+    assertTrue(values.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).isPresent());
+    assertEquals(42, values.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).get().get());
+    assertTrue(values.has(SECURITY_REVIEW_DONE_EXAMPLE));
+    assertTrue(values.of(SECURITY_REVIEW_DONE_EXAMPLE).isPresent());
+    assertTrue(values.of(SECURITY_REVIEW_DONE_EXAMPLE).get().isUnknown());
+
+    // since the provider was called for the first time, it should have tried to fetch data
+    assertEquals(1, provider.counter);
+
+    provider.update("test", values);
+    assertEquals(2, values.size());
+    assertTrue(values.has(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE));
+    assertTrue(values.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).isPresent());
+    assertEquals(42, values.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).get().get());
+    assertTrue(values.has(SECURITY_REVIEW_DONE_EXAMPLE));
+    assertTrue(values.of(SECURITY_REVIEW_DONE_EXAMPLE).isPresent());
+    assertFalse(values.of(SECURITY_REVIEW_DONE_EXAMPLE).get().isUnknown());
+    assertEquals(Boolean.TRUE, values.of(SECURITY_REVIEW_DONE_EXAMPLE).get().get());
+
+    // since one of the values was unknown after the first call,
+    // the provider should have attempted to fetch values one more time
+    assertEquals(2, provider.counter);
+
+    provider.update("test", values);
+
+    // since all the values were known, only cached values should have been used
+    // therefore, the provider should not have attempted to fetch data
+    assertEquals(2, provider.counter);
+  }
+
+  private static class CachingDataProviderForSingleFeature
+      extends AbstractCachingDataProvider<String> {
+
+    int counter = 0;
+
+    @Override
+    public boolean interactive() {
+      return false;
+    }
+
+    @Override
+    protected Set<Feature> supportedFeatures() {
+      return Collections.singleton(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
+    }
+
+    @Override
+    protected Set<Value> fetchValuesFor(String object) {
+      counter++;
+      return Collections.singleton(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(42));
+    }
+  }
+
+  private static class CachingDataProviderForMultipleFeatures
+      extends AbstractCachingDataProvider<String> {
+
+    int counter = 0;
+
+    @Override
+    public boolean interactive() {
+      return false;
+    }
+
+    @Override
+    protected Set<Feature> supportedFeatures() {
+      return setOf(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, SECURITY_REVIEW_DONE_EXAMPLE);
+    }
+
+    @Override
+    protected Set<Value> fetchValuesFor(String object) {
+      Set<Value> values = new HashSet<>();
+      values.add(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(42));
+
+      if (counter == 0) {
+        values.add(SECURITY_REVIEW_DONE_EXAMPLE.unknown());
+      } else {
+        values.add(SECURITY_REVIEW_DONE_EXAMPLE.value(true));
+      }
+
+      counter++;
+      return values;
+    }
+  }
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorageTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorageTest.java
@@ -41,7 +41,7 @@ public class UnpatchedVulnerabilitiesStorageTest {
     try {
       storage.store(filename);
       storage = UnpatchedVulnerabilitiesStorage.load(filename);
-      Vulnerabilities vulnerabilities = storage.get(projectUrl);
+      Vulnerabilities vulnerabilities = storage.getFor(projectUrl);
       assertEquals(1, vulnerabilities.entries().size());
       assertTrue(vulnerabilities.entries().contains(new Vulnerability("https://bugtracker/1")));
     } finally {
@@ -52,7 +52,7 @@ public class UnpatchedVulnerabilitiesStorageTest {
   @Test
   public void testApachePOI() throws IOException {
     UnpatchedVulnerabilitiesStorage storage = UnpatchedVulnerabilitiesStorage.load();
-    Vulnerabilities vulnerabilities = storage.get("https://github.com/apache/poi");
+    Vulnerabilities vulnerabilities = storage.getFor("https://github.com/apache/poi");
     assertNotNull(vulnerabilities);
     assertTrue(vulnerabilities.entries().isEmpty());
   }
@@ -60,7 +60,7 @@ public class UnpatchedVulnerabilitiesStorageTest {
   @Test
   public void testApacheBatik() throws IOException {
     UnpatchedVulnerabilitiesStorage storage = UnpatchedVulnerabilitiesStorage.load();
-    Vulnerabilities vulnerabilities = storage.get("https://github.com/apache/batik");
+    Vulnerabilities vulnerabilities = storage.getFor("https://github.com/apache/batik");
     assertNotNull(vulnerabilities);
     assertEquals(1, vulnerabilities.entries().size());
   }
@@ -68,7 +68,7 @@ public class UnpatchedVulnerabilitiesStorageTest {
   @Test
   public void testOdata4j() throws IOException {
     UnpatchedVulnerabilitiesStorage storage = UnpatchedVulnerabilitiesStorage.load();
-    Vulnerabilities vulnerabilities = storage.get("https://github.com/odata4j/odata4j");
+    Vulnerabilities vulnerabilities = storage.getFor("https://github.com/odata4j/odata4j");
     assertNotNull(vulnerabilities);
     assertEquals(3, vulnerabilities.entries().size());
   }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubDataCacheTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubDataCacheTest.java
@@ -1,56 +1,61 @@
 package com.sap.sgs.phosphor.fosstars.tool.github;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
 import org.junit.Test;
 
 public class GitHubDataCacheTest {
 
   @Test
-  public void testPut() throws IOException {
-    GitHubDataCache<String> gitHubDataCache = new GitHubDataCache<String>();
+  public void testPut() {
+    GitHubDataCache<String> cache = new GitHubDataCache<>();
     
-    String test = "test1";
-    GitHubProject project = new GitHubProject(new GitHubOrganization(test), test);
-    gitHubDataCache.put(project, test);
-    assertTrue(gitHubDataCache.size() == 1);
-    assertTrue(gitHubDataCache.get(project).get().equals(test));
+    String data = "data to be cached";
+    GitHubProject project = new GitHubProject(new GitHubOrganization(data), data);
+    cache.put(project, data);
+    assertEquals(1, cache.size());
+    String cached = cache.get(project).orElseThrow(RuntimeException::new);
+    assertEquals(data, cached);
 
-    GitHubProject project2 = new GitHubProject(new GitHubOrganization(test), test);
-    test = "test2";
-    gitHubDataCache.put(project2, test);
-    assertTrue(gitHubDataCache.size() == 1);
-    assertTrue(gitHubDataCache.get(project2).get().equals(test));
+    // fill out the cache
+    for (int i = 1, cacheSize = cache.size(); cacheSize < cache.maxSize(); cacheSize++, i++) {
+      project = new GitHubProject(String.format("org%d", i), String.format("project%d", i));
+      data = String.format("data%d", i);
+      cache.put(project, data);
+    }
 
-    test = "test3";
-    GitHubProject project3 = new GitHubProject(new GitHubOrganization(test), test);
-    gitHubDataCache.put(project3, test);
-    assertTrue(gitHubDataCache.size() == 2);
-    assertTrue(gitHubDataCache.get(project3).get().equals(test));
+    assertEquals(cache.size(), cache.maxSize());
 
-    test = "test4";
-    GitHubProject project4 = new GitHubProject(new GitHubOrganization(test), test);
-    gitHubDataCache.put(project4, test);
-    assertTrue(gitHubDataCache.size() == 3);
-    assertTrue(gitHubDataCache.get(project4).get().equals(test));
+    // try to add one more item
+    project = new GitHubProject("one", "more");
+    data = "extra data";
+    cache.put(project, data);
+    assertEquals(cache.size(), cache.maxSize());
+    cached = cache.get(project).orElseThrow(RuntimeException::new);
+    assertEquals(data, cached);
+  }
 
-    test = "test5";
-    GitHubProject project5 = new GitHubProject(new GitHubOrganization(test), test);
-    gitHubDataCache.put(project5, test);
-    assertTrue(gitHubDataCache.size() == 4);
-    assertTrue(gitHubDataCache.get(project5).get().equals(test));
+  @Test
+  public void testClear() {
+    GitHubDataCache<String> cache = new GitHubDataCache<>();
 
-    test = "test6";
-    GitHubProject project6 = new GitHubProject(new GitHubOrganization(test), test);
-    gitHubDataCache.put(project6, test);
-    assertTrue(gitHubDataCache.size() == 5);
-    assertTrue(gitHubDataCache.get(project6).get().equals(test));
+    String data = "data to be cached";
+    GitHubProject project = new GitHubProject(new GitHubOrganization(data), data);
+    cache.put(project, data);
+    assertEquals(1, cache.size());
+    String cached = cache.get(project).orElseThrow(RuntimeException::new);
+    assertEquals(data, cached);
 
-    test = "test7";
-    GitHubProject project7 = new GitHubProject(new GitHubOrganization(test), test);
-    gitHubDataCache.put(project7, test);
-    assertTrue(gitHubDataCache.size() == 5);
-    assertTrue(gitHubDataCache.get(project7).get().equals(test));
+    // fill out the cache
+    for (int i = 1, cacheSize = cache.size(); cacheSize < cache.maxSize(); cacheSize++, i++) {
+      project = new GitHubProject(String.format("org%d", i), String.format("project%d", i));
+      data = String.format("data%d", i);
+      cache.put(project, data);
+    }
+
+    assertEquals(cache.size(), cache.maxSize());
+
+    cache.clear();
+    assertEquals(0, cache.size());
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubDataFetcherTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubDataFetcherTest.java
@@ -2,7 +2,6 @@ package com.sap.sgs.phosphor.fosstars.tool.github;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -18,50 +17,36 @@ public class GitHubDataFetcherTest {
   public void repositoryCache() throws IOException {
     GitHub github = mock(GitHub.class);
 
-    GitHubDataFetcher gitHubDataFetcher = gitHubDataFetcher();
-    gitHubDataFetcher.repositoryCache.clear();
+    GitHubDataFetcher fetcher = GitHubDataFetcher.instance();
+    fetcher.repositoryCache.clear();
 
-    GHRepository expectedRepo = mock(GHRepository.class);
-    GitHubProject project = mock(GitHubProject.class);
-    when(github.getRepository(any())).thenReturn(expectedRepo);
+    GHRepository repository = mock(GHRepository.class);
+    GitHubProject firstProject = new GitHubProject("first", "project");
+    when(github.getRepository(any())).thenReturn(repository);
 
-    GHRepository actualRepo1 = gitHubDataFetcher.repositoryFor(project, github);
-    assertNotNull(actualRepo1);
-    assertTrue(gitHubDataFetcher.repositoryCache.size() == 1);
-    assertEquals(expectedRepo, actualRepo1);
-    
-    GHRepository actualRepo2 = gitHubDataFetcher.repositoryFor(project, github);
-    assertNotNull(actualRepo2);
-    assertTrue(gitHubDataFetcher.repositoryCache.size() == 1);
-    assertEquals(expectedRepo, actualRepo2);
+    GHRepository fetchedRepository = fetcher.repositoryFor(firstProject, github);
+    assertEquals(1, fetcher.repositoryCache.size());
+    assertEquals(repository, fetchedRepository);
 
-    GitHubProject project3 = mock(GitHubProject.class);
-    GHRepository actualRepo3 = gitHubDataFetcher.repositoryFor(project3, github);
-    assertNotNull(actualRepo3);
-    assertTrue(gitHubDataFetcher.repositoryCache.size() == 2);
+    // fill out the cache for repositories
+    int i = 0;
+    while (fetcher.repositoryCache.size() < fetcher.repositoryCache.maxSize()) {
+      GitHubProject project = new GitHubProject(
+          String.format("org%d", i), String.format("project%d", i));
+      fetcher.repositoryFor(project, github);
+      i++;
+    }
 
-    GitHubProject project4 = mock(GitHubProject.class);
-    GHRepository actualRepo4 = gitHubDataFetcher.repositoryFor(project4, github);
-    assertNotNull(actualRepo4);
-    assertTrue(gitHubDataFetcher.repositoryCache.size() == 3);
+    assertEquals(fetcher.repositoryCache.maxSize(), fetcher.repositoryCache.size());
+    assertNotNull(fetcher.repositoryFor(firstProject, github));
 
-    GitHubProject project5 = mock(GitHubProject.class);
-    GHRepository actualRepo5 = gitHubDataFetcher.repositoryFor(project5, github);
-    assertNotNull(actualRepo5);
-    assertTrue(gitHubDataFetcher.repositoryCache.size() == 4);
+    // try to add one more
+    i++;
+    GitHubProject latestProject = new GitHubProject(
+        String.format("org%d", i), String.format("project%d", i));
+    fetcher.repositoryFor(latestProject, github);
+    assertEquals(fetcher.repositoryCache.maxSize(), fetcher.repositoryCache.size());
 
-    GitHubProject project6 = mock(GitHubProject.class);
-    GHRepository actualRepo6 = gitHubDataFetcher.repositoryFor(project6, github);
-    assertNotNull(actualRepo6);
-    assertTrue(gitHubDataFetcher.repositoryCache.size() == 5);
-
-    GitHubProject project7 = mock(GitHubProject.class);
-    GHRepository actualRepo7 = gitHubDataFetcher.repositoryFor(project7, github);
-    assertNotNull(actualRepo7);
-    assertTrue(gitHubDataFetcher.repositoryCache.size() == 5);
-  }
-
-  private GitHubDataFetcher gitHubDataFetcher() {
-    return GitHubDataFetcher.instance();
+    assertNotNull(fetcher.repositoryFor(latestProject, github));
   }
 }


### PR DESCRIPTION
Here is a list of main updates:

- The existing data providers have been simplified by moving the caching
  steps to new `AbstractCachingDataProvider`, `CachedSingleFeatureGitHubDataProvider`
  and `GitHubCachingDataProvider` classes.
- Added a new `InfoAboutVulnerabilities` data provider that now caches
  the `VULNERABILITIES` feature so that the `UnpatchedVulnerabilities` and
  `VulnerabilitiesFromNvd` providers don't need to worry about it.
- Added a new `ScansForVulnerableDependencies` data provider that now
  caches the `SCANS_FOR_VULNERABLE_DEPENDENCIES` feature so that the
  underlying data providers don't need to worry about it.
- Updated tests.

This closes #110