### PR TITLE
Move GitHubDataFetcher to the com.sap.sgs.phosphor.fosstars.data.github package

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/AbstractGitHubDataProvider.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/AbstractGitHubDataProvider.java
@@ -1,7 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
 import com.sap.sgs.phosphor.fosstars.data.AbstractDataProvider;
-import com.sap.sgs.phosphor.fosstars.tool.github.GitHubDataFetcher;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.util.Objects;
 import org.kohsuke.github.GitHub;

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubCachingDataProvider.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubCachingDataProvider.java
@@ -1,7 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
 import com.sap.sgs.phosphor.fosstars.data.AbstractCachingDataProvider;
-import com.sap.sgs.phosphor.fosstars.tool.github.GitHubDataFetcher;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.util.Objects;
 import org.kohsuke.github.GitHub;

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubDataFetcher.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubDataFetcher.java
@@ -1,5 +1,7 @@
-package com.sap.sgs.phosphor.fosstars.tool.github;
+package com.sap.sgs.phosphor.fosstars.data.github;
 
+import com.sap.sgs.phosphor.fosstars.tool.github.GitHubDataCache;
+import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Instant;

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesDependabot.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesDependabot.java
@@ -4,7 +4,6 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_D
 
 import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Value;
-import com.sap.sgs.phosphor.fosstars.tool.github.GitHubDataFetcher;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import java.time.Duration;

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubDataFetcherTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubDataFetcherTest.java
@@ -1,4 +1,4 @@
-package com.sap.sgs.phosphor.fosstars.tool.github;
+package com.sap.sgs.phosphor.fosstars.data.github;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import org.junit.Test;
 import org.kohsuke.github.GHRepository;

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/HasSecurityPolicyTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/HasSecurityPolicyTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
-import com.sap.sgs.phosphor.fosstars.tool.github.GitHubDataFetcher;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProjectValueCache;
 import java.io.IOException;

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/NumberOfContributorsTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/NumberOfContributorsTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
-import com.sap.sgs.phosphor.fosstars.tool.github.GitHubDataFetcher;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProjectValueCache;
 import java.io.IOException;

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/PackageManagementTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/PackageManagementTest.java
@@ -20,7 +20,6 @@ import com.sap.sgs.phosphor.fosstars.model.value.Languages;
 import com.sap.sgs.phosphor.fosstars.model.value.PackageManager;
 import com.sap.sgs.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
-import com.sap.sgs.phosphor.fosstars.tool.github.GitHubDataFetcher;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProjectValueCache;
 import java.io.IOException;

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/ProgrammingLanguagesTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/ProgrammingLanguagesTest.java
@@ -12,7 +12,6 @@ import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.model.value.Language;
 import com.sap.sgs.phosphor.fosstars.model.value.Languages;
 import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
-import com.sap.sgs.phosphor.fosstars.tool.github.GitHubDataFetcher;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import java.util.HashMap;

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesDependabotTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesDependabotTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
-import com.sap.sgs.phosphor.fosstars.tool.github.GitHubDataFetcher;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProjectValueCache;
 import java.io.IOException;

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesGithubForDevelopmentTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesGithubForDevelopmentTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
-import com.sap.sgs.phosphor.fosstars.tool.github.GitHubDataFetcher;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProjectValueCache;
 import java.io.IOException;

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesSignedCommitTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesSignedCommitTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
-import com.sap.sgs.phosphor.fosstars.tool.github.GitHubDataFetcher;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProjectValueCache;
 import java.io.IOException;


### PR DESCRIPTION
The `GitHubDataFetcher` fetches data from GitHub and mainly used by the classes from the `com.sap.sgs.phosphor.fosstars.data.github`. Let's move it to there.

This closes #134