### PR TITLE
 Added new NoHttpToolScore to ProjectSecurityTestingScore

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/Score.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/Score.java
@@ -11,6 +11,7 @@ import com.sap.sgs.phosphor.fosstars.model.score.example.SecurityTestingScoreExa
 import com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.DependencyScanScore;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.LgtmScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.NoHttpToolScore;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.OssSecurityScore;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore;
@@ -47,6 +48,7 @@ import java.util.Set;
     @JsonSubTypes.Type(value = OssSecurityScore.class),
     @JsonSubTypes.Type(value = DependencyScanScore.class),
     @JsonSubTypes.Type(value = LgtmScore.class),
+    @JsonSubTypes.Type(value = NoHttpToolScore.class),
 })
 public interface Score extends Feature<Double> {
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/AbstractVerification.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/AbstractVerification.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -163,17 +165,42 @@ public abstract class AbstractVerification {
   }
 
   /**
+   * Loads a list of test vectors from a YAML file.
+   *
+   * @param filename The filename.
+   * @return A list of loaded test vectors.
+   * @throws IOException If something went wrong (file doesn't exist, the content is wrong, etc).
+   */
+  public static List<TestVector> loadTestVectorsFromYaml(Path filename) throws IOException {
+    Objects.requireNonNull(filename, "Filename can't be null!");
+    return loadTestVectorsFromYaml(Files.newInputStream(filename));
+  }
+
+  /**
    * Loads a list of test vectors from YAML.
    *
    * @param is An input stream with YAML.
    * @return A list of test vectors.
    * @throws IOException If something went wrong.
    */
-  public static List<TestVector> loadTestVectorsFromYamlResource(InputStream is)
-      throws IOException {
-
+  public static List<TestVector> loadTestVectorsFromYaml(InputStream is) throws IOException {
     Objects.requireNonNull(is, "Input stream can't be null!");
     return YAML_OBJECT_MAPPER.readValue(is, TEST_VECTOR_LIST_TYPE_REFERENCE);
+  }
+
+  /**
+   * Stores a list of test vectors to a YAML file.
+   *
+   * @param vectors The test vectors.
+   * @param filename The filename.
+   * @throws IOException If something went wrong.
+   */
+  public static void storeTestVectorsToYaml(List<TestVector> vectors, Path filename)
+      throws IOException {
+
+    Objects.requireNonNull(vectors, "Test vectors can't be null!");
+    Objects.requireNonNull(filename, "Filename can't be null!");
+    Files.write(filename, YAML_OBJECT_MAPPER.writeValueAsBytes(vectors));
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingVerification.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingVerification.java
@@ -36,7 +36,7 @@ class OssSecurityRatingVerification extends RatingVerification {
     try (InputStream is = OssSecurityRatingVerification.class
         .getResourceAsStream(TEST_VECTORS_YAML)) {
 
-      return new OssSecurityRatingVerification(rating, loadTestVectorsFromYamlResource(is));
+      return new OssSecurityRatingVerification(rating, loadTestVectorsFromYaml(is));
     }
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/CommunityCommitmentScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/CommunityCommitmentScore.java
@@ -98,7 +98,7 @@ public class CommunityCommitmentScore extends FeatureBasedScore {
      */
     static Verification createFor(CommunityCommitmentScore score) throws IOException {
       try (InputStream is = Verification.class.getResourceAsStream(TEST_VECTORS_YAML)) {
-        return new Verification(score, loadTestVectorsFromYamlResource(is));
+        return new Verification(score, loadTestVectorsFromYaml(is));
       }
     }
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScore.java
@@ -74,7 +74,7 @@ public class DependencyScanScore extends FeatureBasedScore {
      */
     static Verification createFor(DependencyScanScore score) throws IOException {
       try (InputStream is = Verification.class.getResourceAsStream(TEST_VECTORS_YAML)) {
-        return new Verification(score, loadTestVectorsFromYamlResource(is));
+        return new Verification(score, loadTestVectorsFromYaml(is));
       }
     }
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScore.java
@@ -109,7 +109,7 @@ public class LgtmScore extends FeatureBasedScore {
      */
     static Verification createFor(LgtmScore score) throws IOException {
       try (InputStream is = Verification.class.getResourceAsStream(TEST_VECTORS_YAML)) {
-        return new Verification(score, loadTestVectorsFromYamlResource(is));
+        return new Verification(score, loadTestVectorsFromYaml(is));
       }
     }
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/NoHttpToolScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/NoHttpToolScore.java
@@ -1,0 +1,108 @@
+package com.sap.sgs.phosphor.fosstars.model.score.oss;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
+import static com.sap.sgs.phosphor.fosstars.model.other.Utils.findValue;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.GRADLE;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.MAVEN;
+
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.qa.ScoreVerification;
+import com.sap.sgs.phosphor.fosstars.model.qa.TestVector;
+import com.sap.sgs.phosphor.fosstars.model.score.FeatureBasedScore;
+import com.sap.sgs.phosphor.fosstars.model.value.PackageManagers;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * <p>The score shows if an open-source project uses nohttp tool
+ * to catch usage of insecure HTTP protocol.</p>
+ *
+ * <p>The score is based on the following features:
+ * <ul>
+ *   <li>{@link com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#USES_NOHTTP}</li>
+ *   <li>{@link com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#PACKAGE_MANAGERS}</li>
+ * </ul>
+ * </p>
+ *
+ * @see <a href="https://github.com/spring-io/nohttp">nohttp</a>
+ */
+public class NoHttpToolScore extends FeatureBasedScore {
+
+  /**
+   * Initializes a new score.
+   */
+  NoHttpToolScore() {
+    super("If a project uses nohttp tool", USES_NOHTTP, PACKAGE_MANAGERS);
+  }
+
+  @Override
+  public ScoreValue calculate(Value... values) {
+    Value<Boolean> usesNoHttp = findValue(values, USES_NOHTTP,
+        "Hey! You have to tell me if the project uses nohttp tool!");
+    Value<PackageManagers> packageManagers = findValue(values, PACKAGE_MANAGERS,
+        "Hey! You have to tell me which package managers the project uses!");
+
+    ScoreValue scoreValue = scoreValue(MIN, usesNoHttp, packageManagers);
+
+    // if nohttp is used, then return the max score value, and the min value otherwise
+    if (!usesNoHttp.isUnknown()) {
+      return usesNoHttp.get() ? scoreValue.set(MAX) : scoreValue;
+    }
+
+    // now we don't know if nohttp is used or not
+    // if we don't know anything about package managers, then return the min value
+    if (packageManagers.isUnknown()) {
+      return scoreValue;
+    }
+
+    // the can be integrated with Maven or Gradle
+    // return N/A if other package managers are used
+    if (!packageManagers.get().containsAny(MAVEN, GRADLE)) {
+      return scoreValue.makeNotApplicable();
+    }
+
+    // otherwise, return the min value
+    return scoreValue;
+  }
+
+  /**
+   * This class implements a verification procedure for {@link NoHttpToolScore}.
+   * The class loads test vectors,
+   * and provides methods to verify a {@link NoHttpToolScore}
+   * against those test vectors.
+   */
+  public static class Verification extends ScoreVerification {
+
+    /**
+     * A name of a resource which contains the test vectors.
+     */
+    private static final String TEST_VECTORS_YAML = "NoHttpToolScoreTestVectors.yml";
+
+    /**
+     * Initializes a {@link Verification}
+     * for a {@link NoHttpToolScore}.
+     *
+     * @param score A score to be verified.
+     * @param vectors A list of test vectors.
+     */
+    public Verification(NoHttpToolScore score, List<TestVector> vectors) {
+      super(score, vectors);
+    }
+
+    /**
+     * Creates an instance of {@link Verification} for a specified score. The method loads test
+     * vectors from a default resource.
+     *
+     * @param score The score to be verified.
+     * @return An instance of {@link NoHttpToolScore}.
+     */
+    static Verification createFor(NoHttpToolScore score) throws IOException {
+      try (InputStream is = Verification.class.getResourceAsStream(TEST_VECTORS_YAML)) {
+        return new Verification(score, loadTestVectorsFromYaml(is));
+      }
+    }
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore.java
@@ -65,7 +65,7 @@ public class OssSecurityScore extends WeightedCompositeScore {
      */
     static Verification createFor(OssSecurityScore score) throws IOException {
       try (InputStream is = Verification.class.getResourceAsStream(TEST_VECTORS_YAML)) {
-        return new Verification(score, loadTestVectorsFromYamlResource(is));
+        return new Verification(score, loadTestVectorsFromYaml(is));
       }
     }
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectActivityScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectActivityScore.java
@@ -244,7 +244,7 @@ public class ProjectActivityScore extends FeatureBasedScore {
      */
     static Verification createFor(ProjectActivityScore score) throws IOException {
       try (InputStream is = Verification.class.getResourceAsStream(TEST_VECTORS_YAML)) {
-        return new Verification(score, loadTestVectorsFromYamlResource(is));
+        return new Verification(score, loadTestVectorsFromYaml(is));
       }
     }
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectPopularityScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectPopularityScore.java
@@ -170,7 +170,7 @@ public class ProjectPopularityScore extends FeatureBasedScore {
      */
     static Verification createFor(ProjectPopularityScore score) throws IOException {
       try (InputStream is = Verification.class.getResourceAsStream(TEST_VECTORS_YAML)) {
-        return new Verification(score, loadTestVectorsFromYamlResource(is));
+        return new Verification(score, loadTestVectorsFromYaml(is));
       }
     }
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityAwarenessScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityAwarenessScore.java
@@ -123,7 +123,7 @@ public class ProjectSecurityAwarenessScore extends FeatureBasedScore {
      */
     static Verification createFor(ProjectSecurityAwarenessScore score) throws IOException {
       try (InputStream is = Verification.class.getResourceAsStream(TEST_VECTORS_YAML)) {
-        return new Verification(score, loadTestVectorsFromYamlResource(is));
+        return new Verification(score, loadTestVectorsFromYaml(is));
       }
     }
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScore.java
@@ -60,7 +60,7 @@ public class ProjectSecurityTestingScore extends AverageCompositeScore {
      */
     static Verification createFor(ProjectSecurityTestingScore score) throws IOException {
       try (InputStream is = Verification.class.getResourceAsStream(TEST_VECTORS_YAML)) {
-        return new Verification(score, loadTestVectorsFromYamlResource(is));
+        return new Verification(score, loadTestVectorsFromYaml(is));
       }
     }
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScore.java
@@ -12,6 +12,7 @@ import java.util.List;
  * <ul>
  *  <li>{@link DependencyScanScore}</li>
  *  <li>{@link LgtmScore}</li>
+ *  <li>{@link NoHttpToolScore}</li>
  * </ul>
  * There is plenty room for improvements.
  * The score can take into account a lot of other information.
@@ -24,7 +25,8 @@ public class ProjectSecurityTestingScore extends AverageCompositeScore {
   ProjectSecurityTestingScore() {
     super("How well security testing is done for an open-source project",
         new DependencyScanScore(),
-        new LgtmScore());
+        new LgtmScore(),
+        new NoHttpToolScore());
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/UnpatchedVulnerabilitiesScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/UnpatchedVulnerabilitiesScore.java
@@ -153,7 +153,7 @@ public class UnpatchedVulnerabilitiesScore extends FeatureBasedScore {
      */
     static Verification createFor(UnpatchedVulnerabilitiesScore score) throws IOException {
       try (InputStream is = Verification.class.getResourceAsStream(TEST_VECTORS_YAML)) {
-        return new Verification(score, loadTestVectorsFromYamlResource(is));
+        return new Verification(score, loadTestVectorsFromYaml(is));
       }
     }
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScore.java
@@ -145,7 +145,7 @@ public class VulnerabilityLifetimeScore extends FeatureBasedScore {
      */
     static Verification createFor(VulnerabilityLifetimeScore score) throws IOException {
       try (InputStream is = Verification.class.getResourceAsStream(TEST_VECTORS_YAML)) {
-        return new Verification(score, loadTestVectorsFromYamlResource(is));
+        return new Verification(score, loadTestVectorsFromYaml(is));
       }
     }
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/PackageManagers.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/PackageManagers.java
@@ -86,6 +86,28 @@ public class PackageManagers {
     packageManagers.add(packageManager);
   }
 
+  /**
+   * Check if the collection has at least one of the specified package managers.
+   *
+   * @param packageManagers The package managers.
+   * @return True if the collection contains at least one of the package managers, false otherwise.
+   */
+  public boolean containsAny(PackageManager... packageManagers) {
+    Objects.requireNonNull(packageManagers, "Package manager can't be null!");
+
+    if (packageManagers.length == 0) {
+      throw new IllegalArgumentException("Package managers can't be empty!");
+    }
+
+    for (PackageManager packageManager : packageManagers) {
+      if (this.packageManagers.contains(packageManager)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
@@ -1,4 +1,6 @@
 ---
+
+# all unknown
 - values:
   - type: "UnknownValue"
     feature:
@@ -60,6 +62,14 @@
     feature:
       type: "BooleanFeature"
       name: "If an open-source project is supported by a company"
+  - type: "UnknownValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project uses nohttp tool"
+  - type: "UnknownValue"
+    feature:
+      type: "PackageManagersFeature"
+      name: "A set of package managers"
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -71,7 +81,9 @@
   expectedLabel:
   - "OssSecurityRating$SecurityLabel"
   - "BAD"
-  alias: "test_vector_0"
+  alias: "all_unknown"
+
+#
 - values:
   - type: "DateValue"
     feature:
@@ -156,6 +168,18 @@
       type: "BooleanFeature"
       name: "If an open-source project has a security policy"
     flag: false
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project uses nohttp tool"
+    flag: true
+  - type: "PackageManagersValue"
+    feature:
+      type: "PackageManagersFeature"
+      name: "A set of package managers"
+    packageManagers:
+      packageManagers:
+        - "MAVEN"
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -167,7 +191,7 @@
   expectedLabel:
   - "OssSecurityRating$SecurityLabel"
   - "BAD"
-  alias: "test_vector_1"
+  alias: "bad"
 - values:
   - type: "BooleanValue"
     feature:
@@ -269,6 +293,18 @@
       type: "BooleanFeature"
       name: "If an open-source project is regularly scanned for vulnerable dependencies"
     flag: true
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project uses nohttp tool"
+    flag: false
+  - type: "PackageManagersValue"
+    feature:
+      type: "PackageManagersFeature"
+      name: "A set of package managers"
+    packageManagers:
+      packageManagers:
+        - "GRADLE"
   expectedScore:
     type: "DoubleInterval"
     from: 9.0
@@ -280,13 +316,14 @@
   expectedLabel:
   - "OssSecurityRating$SecurityLabel"
   - "GOOD"
-  alias: "test_vector_2"
+  alias: "good"
+
 - values:
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
       name: "If an open-source project has a security policy"
-    flag: true
+    flag: false
   - type: "DateValue"
     feature:
       type: "DateFeature"
@@ -296,728 +333,12 @@
     feature:
       type: "PositiveIntegerFeature"
       name: "Number of watchers for a GitHub repository"
-    number: 5000
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of contributors in the last three months"
-    number: 50
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses LGTM"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security team"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is supported by a company"
-    flag: true
-  - type: "LgtmGradeValue"
-    feature:
-      type: "LgtmGradeFeature"
-      name: "The worst LGTM grade of a project"
-    value: "A+"
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of stars for a GitHub repository"
-    number: 15000
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of commits in the last three months"
-    number: 1000
-  - type: "VulnerabilitiesValue"
-    vulnerabilities:
-      entries:
-      - id: "VULN-123-1"
-        cvss:
-          version: "V3"
-          value: 9.0
-        references: []
-        resolution: "PATCHED"
-        introduced: "2019-01-01"
-        fixed: "2019-01-03"
-      - id: "VULN-124-2"
-        cvss:
-          version: "V3"
-          value: 7.0
-        references: []
-        resolution: "PATCHED"
-        introduced: "2018-11-28"
-        fixed: "2018-12-02"
-      - id: "VULN-125-3"
-        cvss:
-          version: "V3"
-          value: 3.0
-        references: []
-        resolution: "PATCHED"
-        introduced: "2017-07-04"
-        fixed: "2017-07-08"
-    feature:
-      type: "VulnerabilitiesInProject"
-      name: "Info about vulnerabilities in open-source project"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Eclipse Foundation"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses verified signed commits"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is regularly scanned for vulnerable dependencies"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Apache Foundation"
-    flag: true
-  expectedScore:
-    type: "DoubleInterval"
-    from: 9.0
-    openLeft: false
-    negativeInfinity: false
-    to: 10.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel:
-  - "OssSecurityRating$SecurityLabel"
-  - "GOOD"
-  alias: "test_vector_3"
-- values:
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security policy"
-    flag: true
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-21T23:00:00.000+0000"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Apache Foundation"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of watchers for a GitHub repository"
-    number: 5000
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of contributors in the last three months"
-    number: 50
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses LGTM"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security team"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is supported by a company"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Eclipse Foundation"
-    flag: true
-  - type: "LgtmGradeValue"
-    feature:
-      type: "LgtmGradeFeature"
-      name: "The worst LGTM grade of a project"
-    value: "A+"
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of stars for a GitHub repository"
-    number: 15000
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of commits in the last three months"
-    number: 1000
-  - type: "VulnerabilitiesValue"
-    vulnerabilities:
-      entries:
-      - id: "VULN-123-1"
-        cvss:
-          version: "V3"
-          value: 9.0
-        references: []
-        resolution: "PATCHED"
-        introduced: "2019-01-01"
-        fixed: "2019-01-03"
-      - id: "VULN-124-2"
-        cvss:
-          version: "V3"
-          value: 7.0
-        references: []
-        resolution: "PATCHED"
-        introduced: "2018-11-28"
-        fixed: "2018-12-02"
-      - id: "VULN-125-3"
-        cvss:
-          version: "V3"
-          value: 3.0
-        references: []
-        resolution: "PATCHED"
-        introduced: "2017-07-04"
-        fixed: "2017-07-08"
-    feature:
-      type: "VulnerabilitiesInProject"
-      name: "Info about vulnerabilities in open-source project"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses verified signed commits"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is regularly scanned for vulnerable dependencies"
-    flag: true
-  expectedScore:
-    type: "DoubleInterval"
-    from: 9.0
-    openLeft: false
-    negativeInfinity: false
-    to: 10.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel:
-  - "OssSecurityRating$SecurityLabel"
-  - "GOOD"
-  alias: "test_vector_4"
-- values:
-  - type: "VulnerabilitiesValue"
-    vulnerabilities:
-      entries: []
-    feature:
-      type: "VulnerabilitiesInProject"
-      name: "Info about vulnerabilities in open-source project"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security policy"
-    flag: true
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-21T23:00:00.000+0000"
-  - type: "LgtmGradeValue"
-    feature:
-      type: "LgtmGradeFeature"
-      name: "The worst LGTM grade of a project"
-    value: "A"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Apache Foundation"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of watchers for a GitHub repository"
-    number: 5000
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of contributors in the last three months"
-    number: 50
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses LGTM"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security team"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is supported by a company"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of stars for a GitHub repository"
-    number: 15000
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of commits in the last three months"
-    number: 1000
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Eclipse Foundation"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses verified signed commits"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is regularly scanned for vulnerable dependencies"
-    flag: true
-  expectedScore:
-    type: "DoubleInterval"
-    from: 8.0
-    openLeft: false
-    negativeInfinity: false
-    to: 10.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel:
-  - "OssSecurityRating$SecurityLabel"
-  - "GOOD"
-  alias: "test_vector_5"
-- values:
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security policy"
-    flag: true
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-21T23:00:00.000+0000"
-  - type: "LgtmGradeValue"
-    feature:
-      type: "LgtmGradeFeature"
-      name: "The worst LGTM grade of a project"
-    value: "A"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Apache Foundation"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of watchers for a GitHub repository"
-    number: 5000
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of contributors in the last three months"
-    number: 50
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses LGTM"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security team"
-    flag: true
-  - type: "VulnerabilitiesValue"
-    vulnerabilities:
-      entries:
-      - id: "VULN-126-4"
-        cvss:
-          version: "V3"
-          value: 9.0
-        references: []
-        resolution: "PATCHED"
-        introduced: "2019-01-01"
-        fixed: "2019-01-12"
-      - id: "VULN-127-5"
-        cvss:
-          version: "V3"
-          value: 7.0
-        references: []
-        resolution: "PATCHED"
-        introduced: "2018-11-28"
-        fixed: "2018-12-10"
-      - id: "VULN-128-6"
-        cvss:
-          version: "V3"
-          value: 3.0
-        references: []
-        resolution: "PATCHED"
-        introduced: "2017-07-04"
-        fixed: "2017-07-10"
-    feature:
-      type: "VulnerabilitiesInProject"
-      name: "Info about vulnerabilities in open-source project"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is supported by a company"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of stars for a GitHub repository"
-    number: 15000
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of commits in the last three months"
-    number: 1000
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Eclipse Foundation"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses verified signed commits"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is regularly scanned for vulnerable dependencies"
-    flag: true
-  expectedScore:
-    type: "DoubleInterval"
-    from: 8.0
-    openLeft: false
-    negativeInfinity: false
-    to: 10.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel:
-  - "OssSecurityRating$SecurityLabel"
-  - "GOOD"
-  alias: "test_vector_6"
-- values:
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-21T23:00:00.000+0000"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses verified signed commits"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is regularly scanned for vulnerable dependencies"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Apache Foundation"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of watchers for a GitHub repository"
-    number: 5000
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of contributors in the last three months"
-    number: 50
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security team"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses LGTM"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is supported by a company"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of stars for a GitHub repository"
-    number: 15000
-  - type: "VulnerabilitiesValue"
-    vulnerabilities:
-      entries:
-      - id: "VULN-137-15"
-        cvss:
-          version: "V3"
-          value: 5.0
-        references: []
-        resolution: "UNPATCHED"
-        introduced: null
-        fixed: null
-      - id: "VULN-138-16"
-        cvss:
-          version: "V3"
-          value: 6.0
-        references: []
-        resolution: "UNPATCHED"
-        introduced: null
-        fixed: null
-    feature:
-      type: "VulnerabilitiesInProject"
-      name: "Info about vulnerabilities in open-source project"
-  - type: "UnknownValue"
-    feature:
-      type: "LgtmGradeFeature"
-      name: "The worst LGTM grade of a project"
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of commits in the last three months"
-    number: 1000
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Eclipse Foundation"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security policy"
-    flag: false
-  expectedScore:
-    type: "DoubleInterval"
-    from: 3.0
-    openLeft: false
-    negativeInfinity: false
-    to: 5.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_7"
-- values:
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-21T23:00:00.000+0000"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses verified signed commits"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is regularly scanned for vulnerable dependencies"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Apache Foundation"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of watchers for a GitHub repository"
-    number: 5000
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of contributors in the last three months"
-    number: 50
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security team"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses LGTM"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is supported by a company"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of stars for a GitHub repository"
-    number: 15000
-  - type: "VulnerabilitiesValue"
-    vulnerabilities:
-      entries:
-      - id: "VULN-134-12"
-        cvss:
-          version: "V3"
-          value: 9.5
-        references: []
-        resolution: "UNPATCHED"
-        introduced: null
-        fixed: null
-    feature:
-      type: "VulnerabilitiesInProject"
-      name: "Info about vulnerabilities in open-source project"
-  - type: "UnknownValue"
-    feature:
-      type: "LgtmGradeFeature"
-      name: "The worst LGTM grade of a project"
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of commits in the last three months"
-    number: 1000
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Eclipse Foundation"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security policy"
-    flag: false
-  expectedScore:
-    type: "DoubleInterval"
-    from: 3.0
-    openLeft: false
-    negativeInfinity: false
-    to: 5.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_8"
-- values:
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of watchers for a GitHub repository"
-    number: 2
-  - type: "VulnerabilitiesValue"
-    vulnerabilities:
-      entries: []
-    feature:
-      type: "VulnerabilitiesInProject"
-      name: "Info about vulnerabilities in open-source project"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security policy"
-    flag: true
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-21T23:00:00.000+0000"
-  - type: "LgtmGradeValue"
-    feature:
-      type: "LgtmGradeFeature"
-      name: "The worst LGTM grade of a project"
-    value: "A"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Apache Foundation"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses LGTM"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security team"
-    flag: true
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of commits in the last three months"
     number: 500
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is supported by a company"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of stars for a GitHub repository"
-    number: 23
   - type: "IntegerValue"
     feature:
       type: "PositiveIntegerFeature"
       name: "Number of contributors in the last three months"
-    number: 2
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Eclipse Foundation"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses verified signed commits"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is regularly scanned for vulnerable dependencies"
-    flag: true
-  expectedScore:
-    type: "DoubleInterval"
-    from: 6.0
-    openLeft: false
-    negativeInfinity: false
-    to: 7.5
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_9"
-- values:
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of watchers for a GitHub repository"
-    number: 2
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security policy"
-    flag: true
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-21T23:00:00.000+0000"
-  - type: "LgtmGradeValue"
-    feature:
-      type: "LgtmGradeFeature"
-      name: "The worst LGTM grade of a project"
-    value: "A"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Apache Foundation"
-    flag: false
+    number: 5
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
@@ -1027,98 +348,62 @@
     feature:
       type: "BooleanFeature"
       name: "If an open-source project has a security team"
+    flag: false
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If an open-source project is supported by a company"
     flag: true
+  - type: "LgtmGradeValue"
+    feature:
+      type: "LgtmGradeFeature"
+      name: "The worst LGTM grade of a project"
+    value: "A+"
+  - type: "IntegerValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of stars for a GitHub repository"
+    number: 15000
   - type: "IntegerValue"
     feature:
       type: "PositiveIntegerFeature"
       name: "Number of commits in the last three months"
-    number: 500
+    number: 1000
   - type: "VulnerabilitiesValue"
     vulnerabilities:
       entries:
-      - id: "VULN-126-4"
+      - id: "VULN-123-1"
         cvss:
           version: "V3"
           value: 9.0
         references: []
         resolution: "PATCHED"
         introduced: "2019-01-01"
-        fixed: "2019-01-12"
-      - id: "VULN-127-5"
+        fixed: "2019-01-03"
+      - id: "VULN-124-2"
         cvss:
           version: "V3"
           value: 7.0
         references: []
         resolution: "PATCHED"
         introduced: "2018-11-28"
-        fixed: "2018-12-10"
-      - id: "VULN-128-6"
+        fixed: "2018-12-02"
+      - id: "VULN-125-3"
         cvss:
           version: "V3"
           value: 3.0
         references: []
         resolution: "PATCHED"
         introduced: "2017-07-04"
-        fixed: "2017-07-10"
+        fixed: "2017-07-08"
     feature:
       type: "VulnerabilitiesInProject"
       name: "Info about vulnerabilities in open-source project"
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
-      name: "If an open-source project is supported by a company"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of stars for a GitHub repository"
-    number: 23
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of contributors in the last three months"
-    number: 2
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
       name: "If an open-source project belongs to Eclipse Foundation"
     flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses verified signed commits"
-    flag: true
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is regularly scanned for vulnerable dependencies"
-    flag: true
-  expectedScore:
-    type: "DoubleInterval"
-    from: 6.0
-    openLeft: false
-    negativeInfinity: false
-    to: 7.5
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_10"
-- values:
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-21T23:00:00.000+0000"
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of commits in the last three months"
-    number: 2000
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of contributors in the last three months"
-    number: 20
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
@@ -1133,277 +418,19 @@
     feature:
       type: "BooleanFeature"
       name: "If an open-source project belongs to Apache Foundation"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of watchers for a GitHub repository"
-    number: 7
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security team"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses LGTM"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is supported by a company"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of stars for a GitHub repository"
-    number: 89
-  - type: "VulnerabilitiesValue"
-    vulnerabilities:
-      entries:
-      - id: "VULN-134-12"
-        cvss:
-          version: "V3"
-          value: 9.5
-        references: []
-        resolution: "UNPATCHED"
-        introduced: null
-        fixed: null
-    feature:
-      type: "VulnerabilitiesInProject"
-      name: "Info about vulnerabilities in open-source project"
-  - type: "UnknownValue"
-    feature:
-      type: "LgtmGradeFeature"
-      name: "The worst LGTM grade of a project"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Eclipse Foundation"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security policy"
-    flag: false
-  expectedScore:
-    type: "DoubleInterval"
-    from: 1.0
-    openLeft: false
-    negativeInfinity: false
-    to: 3.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel:
-  - "OssSecurityRating$SecurityLabel"
-  - "BAD"
-  alias: "test_vector_11"
-- values:
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-21T23:00:00.000+0000"
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of commits in the last three months"
-    number: 2000
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of contributors in the last three months"
-    number: 20
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses verified signed commits"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is regularly scanned for vulnerable dependencies"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Apache Foundation"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of watchers for a GitHub repository"
-    number: 7
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security team"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses LGTM"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is supported by a company"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of stars for a GitHub repository"
-    number: 89
-  - type: "UnknownValue"
-    feature:
-      type: "LgtmGradeFeature"
-      name: "The worst LGTM grade of a project"
-  - type: "VulnerabilitiesValue"
-    vulnerabilities:
-      entries:
-      - id: "VULN-139-17"
-        cvss:
-          version: "V3"
-          value: 9.0
-        references: []
-        resolution: "UNPATCHED"
-        introduced: null
-        fixed: null
-      - id: "VULN-140-18"
-        cvss:
-          version: "V3"
-          value: 10.0
-        references: []
-        resolution: "UNPATCHED"
-        introduced: null
-        fixed: null
-    feature:
-      type: "VulnerabilitiesInProject"
-      name: "Info about vulnerabilities in open-source project"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Eclipse Foundation"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security policy"
-    flag: false
-  expectedScore:
-    type: "DoubleInterval"
-    from: 0.0
-    openLeft: false
-    negativeInfinity: false
-    to: 3.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel:
-  - "OssSecurityRating$SecurityLabel"
-  - "BAD"
-  alias: "test_vector_12"
-- values:
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project has a security policy"
-    flag: true
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-21T23:00:00.000+0000"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is regularly scanned for vulnerable dependencies"
-    flag: false
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of watchers for a GitHub repository"
-    number: 1000
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses LGTM"
     flag: true
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
-      name: "If an open-source project has a security team"
-    flag: true
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of contributors in the last three months"
-    number: 42
-  - type: "VulnerabilitiesValue"
-    vulnerabilities:
-      entries:
-      - id: "VULN-126-4"
-        cvss:
-          version: "V3"
-          value: 9.0
-        references: []
-        resolution: "PATCHED"
-        introduced: "2019-01-01"
-        fixed: "2019-01-12"
-      - id: "VULN-127-5"
-        cvss:
-          version: "V3"
-          value: 7.0
-        references: []
-        resolution: "PATCHED"
-        introduced: "2018-11-28"
-        fixed: "2018-12-10"
-      - id: "VULN-128-6"
-        cvss:
-          version: "V3"
-          value: 3.0
-        references: []
-        resolution: "PATCHED"
-        introduced: "2017-07-04"
-        fixed: "2017-07-10"
-    feature:
-      type: "VulnerabilitiesInProject"
-      name: "Info about vulnerabilities in open-source project"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project is supported by a company"
+      name: "If a project uses nohttp tool"
     flag: false
-  - type: "IntegerValue"
+  - type: "PackageManagersValue"
     feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of commits in the last three months"
-    number: 1000
-  - type: "IntegerValue"
-    feature:
-      type: "PositiveIntegerFeature"
-      name: "Number of stars for a GitHub repository"
-    number: 10000
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Eclipse Foundation"
-    flag: false
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If a project uses verified signed commits"
-    flag: true
-  - type: "LgtmGradeValue"
-    feature:
-      type: "LgtmGradeFeature"
-      name: "The worst LGTM grade of a project"
-    value: "B"
-  - type: "BooleanValue"
-    feature:
-      type: "BooleanFeature"
-      name: "If an open-source project belongs to Apache Foundation"
-    flag: true
+      type: "PackageManagersFeature"
+      name: "A set of package managers"
+    packageManagers:
+      packageManagers:
+        - "MAVEN"
   expectedScore:
     type: "DoubleInterval"
     from: 6.0
@@ -1412,5 +439,7 @@
     to: 9.0
     openRight: false
     positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_13"
+  expectedLabel:
+  - "OssSecurityRating$SecurityLabel"
+  - "MODERATE"
+  alias: "moderate"

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/NoHttpToolScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/NoHttpToolScoreTestVectors.yml
@@ -1,0 +1,21 @@
+---
+- values:
+  - type: "UnknownValue"
+    feature:
+      type: "PackageManagersFeature"
+      name: "A set of package managers"
+  - type: "UnknownValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project uses nohttp tool"
+  expectedScore:
+    type: "DoubleInterval"
+    from: 0.0
+    openLeft: false
+    negativeInfinity: false
+    to: 10.0
+    openRight: false
+    positiveInfinity: false
+  expectedLabel: null
+  alias: "1"
+  expectedNotApplicableScore: false

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/NoHttpToolScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/NoHttpToolScoreTestVectors.yml
@@ -1,4 +1,6 @@
 ---
+
+# all unknown
 - values:
   - type: "UnknownValue"
     feature:
@@ -11,11 +13,131 @@
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
+    to: 1.0
     openLeft: false
-    negativeInfinity: false
-    to: 10.0
     openRight: false
+    negativeInfinity: false
     positiveInfinity: false
   expectedLabel: null
-  alias: "1"
+  alias: "all_unknown"
   expectedNotApplicableScore: false
+
+# uses nohttp
+- values:
+    - type: "BooleanValue"
+      feature:
+        type: "BooleanFeature"
+        name: "If a project uses nohttp tool"
+      flag: true
+    - type: "PackageManagersValue"
+      feature:
+        type: "PackageManagersFeature"
+        name: "A set of package managers"
+      packageManagers:
+        packageManagers:
+          - "MAVEN"
+  expectedScore:
+    type: "DoubleInterval"
+    from: 9.0
+    to: 10.0
+    openLeft: false
+    openRight: false
+    negativeInfinity: false
+    positiveInfinity: false
+  expectedLabel: null
+  alias: "uses_nohttp"
+  expectedNotApplicableScore: false
+
+# doesn't use nohttp
+- values:
+    - type: "BooleanValue"
+      feature:
+        type: "BooleanFeature"
+        name: "If a project uses nohttp tool"
+      flag: false
+    - type: "PackageManagersValue"
+      feature:
+        type: "PackageManagersFeature"
+        name: "A set of package managers"
+      packageManagers:
+        packageManagers:
+          - "GRADLE"
+  expectedScore:
+    type: "DoubleInterval"
+    from: 0.0
+    to: 1.0
+    openLeft: false
+    openRight: false
+    negativeInfinity: false
+    positiveInfinity: false
+  expectedLabel: null
+  alias: "does_not_use_nohttp"
+  expectedNotApplicableScore: false
+
+# doesn't know whether nohttp is used or not, but it may be used with Maven
+- values:
+    - type: "PackageManagersValue"
+      feature:
+        type: "PackageManagersFeature"
+        name: "A set of package managers"
+      packageManagers:
+        packageManagers:
+          - "MAVEN"
+    - type: "UnknownValue"
+      feature:
+        type: "BooleanFeature"
+        name: "If a project uses nohttp tool"
+  expectedScore:
+    type: "DoubleInterval"
+    from: 0.0
+    to: 1.0
+    openLeft: false
+    openRight: false
+    negativeInfinity: false
+    positiveInfinity: false
+  expectedLabel: null
+  alias: "unknown_but_maven"
+  expectedNotApplicableScore: false
+
+# doesn't know whether nohttp is used or not, but it may be used with Gradle
+- values:
+    - type: "PackageManagersValue"
+      feature:
+        type: "PackageManagersFeature"
+        name: "A set of package managers"
+      packageManagers:
+        packageManagers:
+          - "GRADLE"
+    - type: "UnknownValue"
+      feature:
+        type: "BooleanFeature"
+        name: "If a project uses nohttp tool"
+  expectedScore:
+    type: "DoubleInterval"
+    from: 0.0
+    to: 1.0
+    openLeft: false
+    openRight: false
+    negativeInfinity: false
+    positiveInfinity: false
+  expectedLabel: null
+  alias: "unknown_but_gradle"
+  expectedNotApplicableScore: false
+
+# doesn't know whether nohttp is used or not, but it may be used
+- values:
+    - type: "PackageManagersValue"
+      feature:
+        type: "PackageManagersFeature"
+        name: "A set of package managers"
+      packageManagers:
+        packageManagers:
+          - "NPM"
+    - type: "UnknownValue"
+      feature:
+        type: "BooleanFeature"
+        name: "If a project uses nohttp tool"
+  expectedScore: null
+  expectedLabel: null
+  alias: "unknown_but_unsupported_package_manager"
+  expectedNotApplicableScore: true

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTestVectors.yml
@@ -1,4 +1,6 @@
 ---
+
+#
 - values:
   - type: "ScoreValue"
     score:
@@ -9,6 +11,8 @@
         name: "How a project scans its dependencies for vulnerabilities"
       - type: "LgtmScore"
         name: "How a project addresses issues reported by LGTM"
+      - type: "NoHttpToolScore"
+        name: "If a project uses nohttp tool"
     value: 0.0
     weight: 1.0
     confidence: 10.0
@@ -78,6 +82,8 @@
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_0"
+
+#
 - values:
   - type: "ScoreValue"
     score:
@@ -88,6 +94,8 @@
         name: "How a project scans its dependencies for vulnerabilities"
       - type: "LgtmScore"
         name: "How a project addresses issues reported by LGTM"
+      - type: "NoHttpToolScore"
+        name: "If a project uses nohttp tool"
     value: 0.0
     weight: 1.0
     confidence: 10.0
@@ -157,6 +165,8 @@
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_1"
+
+#
 - values:
   - type: "ScoreValue"
     score:
@@ -176,6 +186,8 @@
         name: "How a project scans its dependencies for vulnerabilities"
       - type: "LgtmScore"
         name: "How a project addresses issues reported by LGTM"
+      - type: "NoHttpToolScore"
+        name: "If a project uses nohttp tool"
     value: 5.0
     weight: 1.0
     confidence: 10.0
@@ -236,6 +248,8 @@
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_2"
+
+#
 - values:
   - type: "ScoreValue"
     score:
@@ -246,6 +260,8 @@
         name: "How a project scans its dependencies for vulnerabilities"
       - type: "LgtmScore"
         name: "How a project addresses issues reported by LGTM"
+      - type: "NoHttpToolScore"
+        name: "If a project uses nohttp tool"
     value: 0.0
     weight: 1.0
     confidence: 10.0
@@ -315,6 +331,8 @@
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_3"
+
+
 - values:
   - type: "ScoreValue"
     score:
@@ -325,6 +343,8 @@
         name: "How a project scans its dependencies for vulnerabilities"
       - type: "LgtmScore"
         name: "How a project addresses issues reported by LGTM"
+      - type: "NoHttpToolScore"
+        name: "If a project uses nohttp tool"
     value: 0.0
     weight: 1.0
     confidence: 10.0
@@ -394,6 +414,8 @@
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_4"
+
+#
 - values:
   - type: "ScoreValue"
     score:
@@ -404,6 +426,8 @@
         name: "How a project scans its dependencies for vulnerabilities"
       - type: "LgtmScore"
         name: "How a project addresses issues reported by LGTM"
+      - type: "NoHttpToolScore"
+        name: "If a project uses nohttp tool"
     value: 8.0
     weight: 1.0
     confidence: 10.0
@@ -473,6 +497,8 @@
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_5"
+
+#
 - values:
   - type: "ScoreValue"
     score:
@@ -492,6 +518,8 @@
         name: "How a project scans its dependencies for vulnerabilities"
       - type: "LgtmScore"
         name: "How a project addresses issues reported by LGTM"
+      - type: "NoHttpToolScore"
+        name: "If a project uses nohttp tool"
     value: 10.0
     weight: 1.0
     confidence: 10.0
@@ -552,6 +580,8 @@
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_6"
+
+#
 - values:
   - type: "ScoreValue"
     score:
@@ -562,6 +592,8 @@
         name: "How a project scans its dependencies for vulnerabilities"
       - type: "LgtmScore"
         name: "How a project addresses issues reported by LGTM"
+      - type: "NoHttpToolScore"
+        name: "If a project uses nohttp tool"
     value: 0.0
     weight: 1.0
     confidence: 10.0
@@ -631,6 +663,8 @@
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_7"
+
+#
 - values:
   - type: "ScoreValue"
     score:
@@ -650,6 +684,8 @@
         name: "How a project scans its dependencies for vulnerabilities"
       - type: "LgtmScore"
         name: "How a project addresses issues reported by LGTM"
+      - type: "NoHttpToolScore"
+        name: "If a project uses nohttp tool"
     value: 10.0
     weight: 1.0
     confidence: 10.0
@@ -710,6 +746,8 @@
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_8"
+
+#
 - values:
   - type: "ScoreValue"
     score:
@@ -729,6 +767,8 @@
         name: "How a project scans its dependencies for vulnerabilities"
       - type: "LgtmScore"
         name: "How a project addresses issues reported by LGTM"
+      - type: "NoHttpToolScore"
+        name: "If a project uses nohttp tool"
     value: 10.0
     weight: 1.0
     confidence: 10.0

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore_1_0.json
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore_1_0.json
@@ -11,6 +11,9 @@
       }, {
         "type" : "LgtmScore",
         "name" : "How a project addresses issues reported by LGTM"
+      }, {
+        "type" : "NoHttpToolScore",
+        "name" : "If a project uses nohttp tool"
       } ]
     },
     "weight" : {

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScoreTestVectors.yml
@@ -1,4 +1,6 @@
 ---
+
+# only min values
 - values:
   - type: "ScoreValue"
     score:
@@ -13,6 +15,15 @@
     score:
       type: "DependencyScanScore"
       name: "How a project scans its dependencies for vulnerabilities"
+    value: 0.0
+    weight: 1.0
+    confidence: 10.0
+    usedValues: []
+    explanation: []
+  - type: "ScoreValue"
+    score:
+      type: "NoHttpToolScore"
+      name: "If a project uses nohttp tool"
     value: 0.0
     weight: 1.0
     confidence: 10.0
@@ -27,7 +38,9 @@
     openRight: false
     positiveInfinity: false
   expectedLabel: null
-  alias: "test_vector_0"
+  alias: "all_min"
+
+#
 - values:
   - type: "ScoreValue"
     score:
@@ -47,16 +60,27 @@
     confidence: 10.0
     usedValues: []
     explanation: []
+  - type: "ScoreValue"
+    score:
+      type: "NoHttpToolScore"
+      name: "If a project uses nohttp tool"
+    value: 10.0
+    weight: 1.0
+    confidence: 10.0
+    usedValues: []
+    explanation: []
   expectedScore:
     type: "DoubleInterval"
-    from: 5.0
+    from: 6.0
     openLeft: false
     negativeInfinity: false
-    to: 5.0
+    to: 7.0
     openRight: false
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_1"
+
+#
 - values:
   - type: "ScoreValue"
     score:
@@ -76,16 +100,27 @@
     confidence: 10.0
     usedValues: []
     explanation: []
+  - type: "ScoreValue"
+    score:
+      type: "NoHttpToolScore"
+      name: "If a project uses nohttp tool"
+    value: 0.0
+    weight: 1.0
+    confidence: 10.0
+    usedValues: []
+    explanation: []
   expectedScore:
     type: "DoubleInterval"
-    from: 5.0
+    from: 3.0
     openLeft: false
     negativeInfinity: false
-    to: 5.0
+    to: 4.0
     openRight: false
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_2"
+
+#
 - values:
   - type: "ScoreValue"
     score:
@@ -105,16 +140,27 @@
     confidence: 10.0
     usedValues: []
     explanation: []
+  - type: "ScoreValue"
+    score:
+      type: "NoHttpToolScore"
+      name: "If a project uses nohttp tool"
+    value: 0.0
+    weight: 1.0
+    confidence: 10.0
+    usedValues: []
+    explanation: []
   expectedScore:
     type: "DoubleInterval"
-    from: 5.0
+    from: 3.0
     openLeft: false
     negativeInfinity: false
-    to: 5.0
+    to: 4.0
     openRight: false
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_3"
+
+# all max values
 - values:
   - type: "ScoreValue"
     score:
@@ -129,6 +175,15 @@
     score:
       type: "LgtmScore"
       name: "How a project addresses issues reported by LGTM"
+    value: 10.0
+    weight: 1.0
+    confidence: 10.0
+    usedValues: []
+    explanation: []
+  - type: "ScoreValue"
+    score:
+      type: "NoHttpToolScore"
+      name: "If a project uses nohttp tool"
     value: 10.0
     weight: 1.0
     confidence: 10.0
@@ -144,3 +199,44 @@
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_4"
+
+# NoHttpToolScore is N/A
+- values:
+    - type: "ScoreValue"
+      score:
+        type: "DependencyScanScore"
+        name: "How a project scans its dependencies for vulnerabilities"
+      value: 3.0
+      weight: 1.0
+      confidence: 10.0
+      usedValues: []
+      explanation: []
+    - type: "ScoreValue"
+      score:
+        type: "LgtmScore"
+        name: "How a project addresses issues reported by LGTM"
+      value: 7.0
+      weight: 1.0
+      confidence: 10.0
+      usedValues: []
+      explanation: []
+    - type: "ScoreValue"
+      score:
+        type: "NoHttpToolScore"
+        name: "If a project uses nohttp tool"
+      value: 0.0
+      weight: 1.0
+      confidence: 0.0
+      usedValues: []
+      explanation: []
+      isNotApplicable: true
+  expectedScore:
+    type: "DoubleInterval"
+    from: 5.0
+    openLeft: false
+    negativeInfinity: false
+    to: 10.0
+    openRight: false
+    positiveInfinity: false
+  expectedLabel: null
+  alias: "nohttp_tool_not_applicable"

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/NoHttpToolScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/NoHttpToolScoreTest.java
@@ -1,0 +1,64 @@
+package com.sap.sgs.phosphor.fosstars.model.score.oss;
+
+import static com.sap.sgs.phosphor.fosstars.TestUtils.assertScore;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
+import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+import static com.sap.sgs.phosphor.fosstars.model.qa.TestVectorBuilder.newTestVector;
+
+import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.qa.TestVector;
+import com.sap.sgs.phosphor.fosstars.model.qa.VerificationFailedException;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.NoHttpToolScore.Verification;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class NoHttpToolScoreTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithoutUsesNoHttpValue() {
+    new NoHttpToolScore().calculate(PACKAGE_MANAGERS.unknown());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithoutPackageManagersValue() {
+    new NoHttpToolScore().calculate(USES_NOHTTP.unknown());
+  }
+
+  @Test
+  public void testWithoutAllUnknown() {
+    assertScore(
+        Score.INTERVAL,
+        new NoHttpToolScore(),
+        setOf(USES_NOHTTP.unknown(), PACKAGE_MANAGERS.unknown()));
+  }
+
+  @Test
+  public void testVerification() throws VerificationFailedException, IOException {
+    List<TestVector> vectors = Arrays.asList(
+        newTestVector()
+            .alias("1")
+            .expectedScore(Score.INTERVAL)
+            .set(USES_NOHTTP.unknown())
+            .set(PACKAGE_MANAGERS.unknown())
+            .make()
+    );
+
+    Path file = Files.createTempFile("NoHttpToolScoreTestVectors", "test");
+    try {
+      Verification.storeTestVectorsToYaml(vectors, file);
+
+      Verification verification = new Verification(
+          new NoHttpToolScore(),
+          Verification.loadTestVectorsFromYaml(file));
+
+      verification.run();
+    } finally {
+      Files.delete(file);
+    }
+  }
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/NoHttpToolScoreVerification.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/NoHttpToolScoreVerification.java
@@ -1,0 +1,14 @@
+package com.sap.sgs.phosphor.fosstars.model.score.oss;
+
+import com.sap.sgs.phosphor.fosstars.model.qa.VerificationFailedException;
+import java.io.IOException;
+import org.junit.Test;
+
+public class NoHttpToolScoreVerification {
+
+  @Test
+  public void verify() throws IOException, VerificationFailedException {
+    NoHttpToolScore.Verification.createFor(new NoHttpToolScore()).run();
+  }
+
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
@@ -8,14 +8,17 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_WATCHERS_ON_GITHUB;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_VERIFIED_SIGNED_COMMITS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_LGTM_GRADE;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.MAVEN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -27,6 +30,7 @@ import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.other.Utils;
 import com.sap.sgs.phosphor.fosstars.model.value.LgtmGrade;
+import com.sap.sgs.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
 import java.io.IOException;
@@ -76,7 +80,9 @@ public class OssSecurityScoreTest {
         PROJECT_START_DATE.value(new Date()),
         USES_VERIFIED_SIGNED_COMMITS.value(false),
         USES_LGTM.value(true),
-        WORST_LGTM_GRADE.value(LgtmGrade.B));
+        WORST_LGTM_GRADE.value(LgtmGrade.B),
+        USES_NOHTTP.value(false),
+        PACKAGE_MANAGERS.value(new PackageManagers(MAVEN)));
     ScoreValue scoreValue = score.calculate(values);
     assertTrue(Score.INTERVAL.contains(scoreValue.get()));
     assertEquals(Confidence.MAX, scoreValue.confidence(), DELTA);

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTuningWithCMAESTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTuningWithCMAESTest.java
@@ -8,15 +8,18 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_WATCHERS_ON_GITHUB;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_VERIFIED_SIGNED_COMMITS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_LGTM_GRADE;
 import static com.sap.sgs.phosphor.fosstars.model.qa.RatingVerification.loadTestVectorsFromCsvResource;
 import static com.sap.sgs.phosphor.fosstars.model.qa.TestVectorBuilder.newTestVector;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.MAVEN;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -25,6 +28,7 @@ import com.sap.sgs.phosphor.fosstars.model.math.DoubleInterval;
 import com.sap.sgs.phosphor.fosstars.model.qa.TestVector;
 import com.sap.sgs.phosphor.fosstars.model.qa.VerificationFailedException;
 import com.sap.sgs.phosphor.fosstars.model.value.LgtmGrade;
+import com.sap.sgs.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.sgs.phosphor.fosstars.model.value.UnknownValue;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
 import java.io.IOException;
@@ -64,6 +68,8 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(UnknownValue.of(USES_VERIFIED_SIGNED_COMMITS))
           .set(UnknownValue.of(USES_LGTM))
           .set(UnknownValue.of(WORST_LGTM_GRADE))
+          .set(UnknownValue.of(USES_NOHTTP))
+          .set(UnknownValue.of(PACKAGE_MANAGERS))
           .expectedScore(DoubleInterval.closed(Score.MIN, 0.1))
           .alias("one")
           .make(),
@@ -85,6 +91,8 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(USES_VERIFIED_SIGNED_COMMITS.value(false))
           .set(USES_LGTM.value(false))
           .set(WORST_LGTM_GRADE.unknown())
+          .set(USES_NOHTTP.value(false))
+          .set(PACKAGE_MANAGERS.unknown())
           .expectedScore(DoubleInterval.closed(1.0, 4.0))
           .alias("two")
           .make(),
@@ -106,6 +114,8 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(USES_VERIFIED_SIGNED_COMMITS.value(true))
           .set(USES_LGTM.value(true))
           .set(WORST_LGTM_GRADE.value(LgtmGrade.A_PLUS))
+          .set(USES_NOHTTP.value(true))
+          .set(PACKAGE_MANAGERS.value(new PackageManagers(MAVEN)))
           .expectedScore(DoubleInterval.init().from(9.0).to(Score.MAX).make())
           .alias("three")
           .make()

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScoreTest.java
@@ -25,21 +25,24 @@ public class ProjectSecurityTestingScoreTest {
         PROJECT_SECURITY_TESTING,
         setOf(
             PROJECT_SECURITY_TESTING.score(LgtmScore.class).value(Score.MIN),
-            PROJECT_SECURITY_TESTING.score(DependencyScanScore.class).value(Score.MIN)));
+            PROJECT_SECURITY_TESTING.score(DependencyScanScore.class).value(Score.MIN),
+            PROJECT_SECURITY_TESTING.score(NoHttpToolScore.class).value(Score.MIN)));
 
     assertScore(
         Score.INTERVAL,
         PROJECT_SECURITY_TESTING,
         setOf(
             PROJECT_SECURITY_TESTING.score(LgtmScore.class).value(Score.MAX),
-            PROJECT_SECURITY_TESTING.score(DependencyScanScore.class).value(Score.MAX)));
+            PROJECT_SECURITY_TESTING.score(DependencyScanScore.class).value(Score.MAX),
+            PROJECT_SECURITY_TESTING.score(NoHttpToolScore.class).value(Score.MAX)));
   }
 
   @Test
   public void explanation() {
     ScoreValue value = PROJECT_SECURITY_TESTING.calculate(
         PROJECT_SECURITY_TESTING.score(LgtmScore.class).value(Score.MAX / 3),
-        PROJECT_SECURITY_TESTING.score(DependencyScanScore.class).value(Score.MAX / 5));
+        PROJECT_SECURITY_TESTING.score(DependencyScanScore.class).value(Score.MAX / 5),
+        PROJECT_SECURITY_TESTING.score(NoHttpToolScore.class).value(Score.MAX / 2));
 
     assertTrue(value.score().description().isEmpty());
     assertTrue(value.explanation().isEmpty());

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinterTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinterTest.java
@@ -9,15 +9,19 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_WATCHERS_ON_GITHUB;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_GITHUB_FOR_DEVELOPMENT;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_VERIFIED_SIGNED_COMMITS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_LGTM_GRADE;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.GRADLE;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.MAVEN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -28,6 +32,7 @@ import com.sap.sgs.phosphor.fosstars.model.RatingRepository;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 import com.sap.sgs.phosphor.fosstars.model.value.LgtmGrade;
+import com.sap.sgs.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
 import java.util.Date;
@@ -56,7 +61,9 @@ public class PrettyPrinterTest {
         USES_VERIFIED_SIGNED_COMMITS.value(false),
         USES_LGTM.value(true),
         WORST_LGTM_GRADE.value(LgtmGrade.A),
-        USES_GITHUB_FOR_DEVELOPMENT.value(false));
+        USES_GITHUB_FOR_DEVELOPMENT.value(false),
+        USES_NOHTTP.value(false),
+        PACKAGE_MANAGERS.value(new PackageManagers(MAVEN)));
     
     RatingValue ratingValue = rating.calculate(values);
 
@@ -100,7 +107,9 @@ public class PrettyPrinterTest {
         USES_VERIFIED_SIGNED_COMMITS.value(false),
         USES_LGTM.value(true),
         WORST_LGTM_GRADE.value(LgtmGrade.A),
-        USES_GITHUB_FOR_DEVELOPMENT.value(false));
+        USES_GITHUB_FOR_DEVELOPMENT.value(false),
+        USES_NOHTTP.value(true),
+        PACKAGE_MANAGERS.value(new PackageManagers(GRADLE)));
     RatingValue ratingValue = rating.calculate(values);
 
     PrettyPrinter printer = new PrettyPrinter();


### PR DESCRIPTION
Here is a list of main updates:

- Added a new `NoHttpToolScore` based on `USES_NOHTTP` and `PACKAGE_MANAGERS` features.
- Added `NoHttpToolScore` to `ProjectSecurityTestingScore`.
- Updated tests and test vectors.

This closes #96
