### PR TITLE
Make UsesGithubForDevelopment data provider smarter

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesGithubForDevelopment.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesGithubForDevelopment.java
@@ -7,19 +7,75 @@ import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.value.BooleanValue;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 import org.apache.commons.lang3.StringUtils;
+import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 
 /**
- * This data provider checks if a project uses GitHub as a main development platform. The check
- * would be based on mirror url is null or empty. This will ensure whether the underlying project is
- * a mirror project or not.
+ * This data provider tries to figure out if a project uses GitHub for development.
  */
 public class UsesGithubForDevelopment extends CachedSingleFeatureGitHubDataProvider {
 
   /**
-   * Initializes a data provider.
+   * This threshold shows how many checks have to be passed to say that a project uses GitHub
+   * for development.
+   */
+  static final double CONFIDENCE_THRESHOLD = 0.7;
+
+  /**
+   * This threshold shows how many commits have to point to existing GitHub user names
+   * to say that commits are mostly done by users on GitHub.
+   */
+  private static final double RESOLVED_USERS_THRESHOLD = 0.9;
+
+  private static final List<Check> CHECKS = Arrays.asList(
+
+      // check if the repository doesn't have an explicit link to the original repository
+      (repository, commits) -> StringUtils.isEmpty(repository.getMirrorUrl()),
+
+      // check if the description mentions "mirror"
+      (repository, commits) -> !repository.getDescription().toLowerCase().contains("mirror"),
+
+      // if GitHub issues are enabled, then it's likely that the project uses GitHub
+      (repository, commits) -> repository.hasIssues(),
+
+      // if GitHub pages are enabled, then it's likely that the project uses GitHub
+      (repository, commits) -> repository.hasPages(),
+
+      // if GitHub Wiki is enabled, then it's likely that the project uses GitHub
+      (repository, commits) -> repository.hasWiki(),
+
+      // if one of the three options for pull requests is enabled, then it looks like
+      // that the project uses pull requests
+      (repository, commits) ->  repository.isAllowMergeCommit()
+          || repository.isAllowRebaseMerge() || repository.isAllowSquashMerge(),
+
+      // check if repository is not archived
+      (repository, commits) ->  !repository.isArchived(),
+
+      // check if the project doesn't have an explicit link to an SVN repository
+      (repository, commits) ->  StringUtils.isEmpty(repository.getSvnUrl()),
+
+      // check if most of user names in the latest commits are valid GitHub users
+      (repository, commits) ->  {
+        if (commits.isEmpty()) {
+          return false;
+        }
+        int resolved = commits.stream()
+            .map(commit -> canResolveUsersFor(commit) ? 1 : 0)
+            .reduce(0, Integer::sum);
+        return resolved / commits.size() >= RESOLVED_USERS_THRESHOLD;
+      }
+  );
+  
+  /**
+   * Initializes a data providerepository.
    *
    * @param github An interface to the GitHub API.
    */
@@ -39,16 +95,20 @@ public class UsesGithubForDevelopment extends CachedSingleFeatureGitHubDataProvi
   }
 
   /**
-   * Checks if the project uses GitHub as a main development platform.
+   * Checks if a project uses GitHub as a main development platform.
    *
-   * @param project of type {@link GitHubProject}.
-   * @return {@link BooleanValue} value of the feature.
+   * @param project The project to be checked.
+   * @return {@link BooleanValue} of the feature.
    */
   private Value<Boolean> usesGithubForDevelopment(GitHubProject project) {
-    // TODO: This is just a basic check, more constraints have to be considered in the future with
-    //       more clarity. Please refer https://github.com/SAP/fosstars-rating-core/issues/122
     try {
-      return USES_GITHUB_FOR_DEVELOPMENT.value(!isMirror(project));
+      GHRepository repository = gitHubDataFetcher().repositoryFor(project, github);
+
+      Date threeMonthsAgo = Date.from(Instant.now().minus(3, ChronoUnit.MONTHS));
+      List<GHCommit> commits = gitHubDataFetcher().commitsAfter(threeMonthsAgo, project, github);
+
+      return USES_GITHUB_FOR_DEVELOPMENT.value(
+          usesGitHubForDevelopment(repository, commits, CONFIDENCE_THRESHOLD));
     } catch (IOException e) {
       logger.warn("Couldn't fetch data, something went wrong!", e);
       return USES_GITHUB_FOR_DEVELOPMENT.unknown();
@@ -56,14 +116,59 @@ public class UsesGithubForDevelopment extends CachedSingleFeatureGitHubDataProvi
   }
 
   /**
-   * Checks if the input GitHub project is a mirror or an original project.
+   * The method checks if it looks like that a project uses GitHub as a main development platform.
+   * The method runs a number of checks for the project. If most of the checks pass,
+   * then the method concludes that the projects uses GitHub for development.
    * 
-   * @param project of type {@link GitHubProject}.
-   * @return true if the project is a mirror project. Otherwise, false.
-   * @throws IOException may throw an exception during REST call to GitHub API.
+   * @param repository The project's repository.
+   * @param commits The project's commit history.
+   * @return True if it looks like that the project uses GitHub, false otherwise.
+   *
    */
-  private boolean isMirror(GitHubProject project) throws IOException {
-    GHRepository repository = gitHubDataFetcher().repositoryFor(project, github);
-    return StringUtils.isNotEmpty(repository.getMirrorUrl());
+  static boolean usesGitHubForDevelopment(
+      GHRepository repository, List<GHCommit> commits, double threshold) {
+
+    int points = CHECKS.stream()
+        .map(check -> check.run(repository, commits) ? 1 : 0)
+        .reduce(0, Integer::sum);
+
+    return points / CHECKS.size() >= threshold;
+  }
+
+  /**
+   * Checks if user names from a commit point to existing GitHub users.
+   *
+   * @param commit The commit to be checked.
+   * @return True if user names from the commit can be resolved to existing GitHub users,
+   *         false otherwise.
+   */
+  private static boolean canResolveUsersFor(GHCommit commit) {
+    if (commit == null) {
+      return false;
+    }
+
+    try {
+      commit.getCommitter();
+      commit.getAuthor();
+    } catch (IOException e) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * An interface for a check for a project.
+   */
+  interface Check {
+
+    /**
+     * Runs the check for a repository and commit history.
+     * 
+     * @param repository The repository,
+     * @param commits The commit history.
+     * @return Returns true if the check is passed, false otherwise.
+     */
+    boolean run(GHRepository repository, List<GHCommit> commits);
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesGithubForDevelopmentTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesGithubForDevelopmentTest.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
+import static com.sap.sgs.phosphor.fosstars.data.github.UsesGithubForDevelopment.CONFIDENCE_THRESHOLD;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_GITHUB_FOR_DEVELOPMENT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -12,98 +13,133 @@ import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProjectValueCache;
 import java.io.IOException;
-import org.apache.commons.lang3.StringUtils;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
 
 public class UsesGithubForDevelopmentTest {
 
-  @Test
-  public void testWithMirrorUrl() throws IOException {
-    GitHub github = mock(GitHub.class);
+  private static class RepositoryMockBuilder {
 
-    UsesGithubForDevelopment provider = new UsesGithubForDevelopment(github);
-    provider = spy(provider);
-    when(provider.cache()).thenReturn(new GitHubProjectValueCache());
+    GHRepository repository;
+    List<GHCommit> commits;
+    Set<Integer> passedChecks;
 
-    GHRepository repository = mock(GHRepository.class);
-    GitHubDataFetcher fetcher = mock(GitHubDataFetcher.class);
-    when(provider.gitHubDataFetcher()).thenReturn(fetcher);
+    private final List<Consumer<Boolean>> checks = Arrays.asList(
+        passed -> when(repository.getMirrorUrl())
+          .thenReturn(passed ? null : "https://other.com/org/project"),
+        passed -> when(repository.getDescription())
+          .thenReturn(passed ? "This is the main repository" : "This is a mirror"),
+        passed -> when(repository.hasIssues()).thenReturn(passed),
+        passed -> when(repository.hasPages()).thenReturn(passed),
+        passed -> when(repository.hasWiki()).thenReturn(passed),
+        passed -> when(repository.isAllowMergeCommit()).thenReturn(passed),
+        passed -> when(repository.isArchived()).thenReturn(!passed),
+        passed -> when(repository.getSvnUrl())
+            .thenReturn(passed ? null : "svn://other.com/org/project"),
+        passed -> {
+          try {
+            commits.clear();
+            GHCommit commit = mock(GHCommit.class);
+            if (passed) {
+              GHUser user = mock(GHUser.class);
+              when(commit.getCommitter()).thenReturn(user);
+              when(commit.getAuthor()).thenReturn(user);
+            } else {
+              when(commit.getCommitter()).thenThrow(new IOException());
+            }
+            commits.add(commit);
+          } catch (IOException e) {
+            throw new UncheckedIOException("This should not happen", e);
+          }
+        }
+    );
 
-    GitHubProject project = mock(GitHubProject.class);
-    when(fetcher.repositoryFor(project, github)).thenReturn(repository);
-    when(repository.getMirrorUrl()).thenReturn("https://other.scm.com/org/original_repository");
+    RepositoryMockBuilder() {
+      init();
+    }
 
-    ValueHashSet values = new ValueHashSet();
-    assertEquals(0, values.size());
+    final void init() {
+      repository = mock(GHRepository.class);
+      commits = new ArrayList<>();
+      passedChecks = new HashSet<>();
+      checks.forEach(check -> check.accept(false));
+    }
 
-    provider.update(project, values);
+    int allChecks() {
+      return checks.size();
+    }
 
-    assertEquals(1, values.size());
-    assertTrue(values.has(USES_GITHUB_FOR_DEVELOPMENT));
-    assertTrue(values.of(USES_GITHUB_FOR_DEVELOPMENT).isPresent());
-    assertFalse(values.of(USES_GITHUB_FOR_DEVELOPMENT).get().isUnknown());
-    assertEquals(USES_GITHUB_FOR_DEVELOPMENT.value(false),
-        values.of(USES_GITHUB_FOR_DEVELOPMENT).get());
+    int passedChecks() {
+      return passedChecks.size();
+    }
+
+    void passCheck(int i) {
+      checks.get(i).accept(true);
+      passedChecks.add(i);
+    }
+
+    GHRepository repository() {
+      return repository;
+    }
+
+    List<GHCommit> commits() {
+      return commits;
+    }
+
   }
 
   @Test
-  public void testWithoutMirrorUrl() throws IOException {
-    GitHub github = mock(GitHub.class);
+  public void testVariousChecks() {
+    Random random = new Random();
+    random.setSeed(0);
 
-    UsesGithubForDevelopment provider = new UsesGithubForDevelopment(github);
-    provider = spy(provider);
-    when(provider.cache()).thenReturn(new GitHubProjectValueCache());
+    RepositoryMockBuilder builder = new RepositoryMockBuilder();
 
-    GHRepository repository = mock(GHRepository.class);
-    GitHubDataFetcher fetcher = mock(GitHubDataFetcher.class);
-    when(provider.gitHubDataFetcher()).thenReturn(fetcher);
-
-    GitHubProject project = mock(GitHubProject.class);
-    when(fetcher.repositoryFor(project, github)).thenReturn(repository);
-    when(repository.getMirrorUrl()).thenReturn(null);
-
-    ValueHashSet values = new ValueHashSet();
-    assertEquals(0, values.size());
-
-    provider.update(project, values);
-
-    assertEquals(1, values.size());
-    assertTrue(values.has(USES_GITHUB_FOR_DEVELOPMENT));
-    assertTrue(values.of(USES_GITHUB_FOR_DEVELOPMENT).isPresent());
-    assertFalse(values.of(USES_GITHUB_FOR_DEVELOPMENT).get().isUnknown());
-    assertEquals(USES_GITHUB_FOR_DEVELOPMENT.value(true),
-        values.of(USES_GITHUB_FOR_DEVELOPMENT).get());
+    int i = 0;
+    while (i < builder.allChecks()) {
+      builder.init();
+      random.ints(i, 0, builder.allChecks())
+          .forEach(builder::passCheck);
+      boolean expected = builder.passedChecks() / builder.allChecks() >= CONFIDENCE_THRESHOLD;
+      assertEquals(
+          expected,
+          UsesGithubForDevelopment.usesGitHubForDevelopment(
+              builder.repository(), builder.commits(), CONFIDENCE_THRESHOLD));
+      i++;
+    }
   }
 
   @Test
-  public void testWithEmptyMirrorUrl() throws IOException {
-    GitHub github = mock(GitHub.class);
+  public void testAllPassedChecks() {
+    RepositoryMockBuilder builder = new RepositoryMockBuilder();
+    for (int i = 0; i < builder.allChecks(); i++) {
+      builder.passCheck(i);
+    }
+    assertEquals(builder.allChecks(), builder.passedChecks());
+    assertTrue(
+        UsesGithubForDevelopment.usesGitHubForDevelopment(
+            builder.repository(), builder.commits(), 0.99));
+  }
 
-    UsesGithubForDevelopment provider = new UsesGithubForDevelopment(github);
-    provider = spy(provider);
-    when(provider.cache()).thenReturn(new GitHubProjectValueCache());
-
-    GHRepository repository = mock(GHRepository.class);
-    GitHubDataFetcher fetcher = mock(GitHubDataFetcher.class);
-    when(provider.gitHubDataFetcher()).thenReturn(fetcher);
-
-    GitHubProject project = mock(GitHubProject.class);
-    when(fetcher.repositoryFor(project, github)).thenReturn(repository);
-    when(repository.getMirrorUrl()).thenReturn(StringUtils.EMPTY);
-
-    ValueHashSet values = new ValueHashSet();
-    assertEquals(0, values.size());
-
-    provider.update(project, values);
-
-    assertEquals(1, values.size());
-    assertTrue(values.has(USES_GITHUB_FOR_DEVELOPMENT));
-    assertTrue(values.of(USES_GITHUB_FOR_DEVELOPMENT).isPresent());
-    assertFalse(values.of(USES_GITHUB_FOR_DEVELOPMENT).get().isUnknown());
-    assertEquals(USES_GITHUB_FOR_DEVELOPMENT.value(true),
-        values.of(USES_GITHUB_FOR_DEVELOPMENT).get());
+  @Test
+  public void testAllFailedChecks() {
+    RepositoryMockBuilder builder = new RepositoryMockBuilder();
+    assertFalse(
+        UsesGithubForDevelopment.usesGitHubForDevelopment(
+            builder.repository(), builder.commits(), 0.01));
   }
 
   @Test
@@ -128,5 +164,12 @@ public class UsesGithubForDevelopmentTest {
     assertTrue(values.has(USES_GITHUB_FOR_DEVELOPMENT));
     assertTrue(values.of(USES_GITHUB_FOR_DEVELOPMENT).isPresent());
     assertTrue(values.of(USES_GITHUB_FOR_DEVELOPMENT).get().isUnknown());
+  }
+
+  @Before
+  @After
+  public void cleanup() {
+    GitHubDataFetcher.instance().repositoryCache().clear();
+    GitHubDataFetcher.instance().commitsCache().clear();
   }
 }


### PR DESCRIPTION
Here is a list of updates:

- Updated the `UsesGithubForDevelopment` data provider to consider
  multiple facts about a project.
- Updated `UsesGithubForDevelopmentTest`.

This closes #122