### PR TITLE
Updated DependencyScanScore to use new features

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/PackageManagement.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/PackageManagement.java
@@ -142,7 +142,7 @@ public class PackageManagement extends CachedSingleFeatureGitHubDataProvider {
    */
   private Value<PackageManagers> packageManagers(GitHubProject project) throws IOException {
     PackageManagers possiblePackageManagers = new PackageManagers();
-    for (Language language : languages(project).get()) {
+    for (Language language : languages(project)) {
       if (KNOWN_PACKAGE_MANAGERS.containsKey(language)) {
         possiblePackageManagers.add(KNOWN_PACKAGE_MANAGERS.get(language));
       }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/Value.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/Value.java
@@ -62,6 +62,15 @@ public interface Value<T> {
   T get();
 
   /**
+   * Returns the value if it is known and applicable,
+   * otherwise a specified default value.
+   *
+   * @param other The default value.
+   * @return The value of the default value.
+   */
+  T orElse(T other);
+
+  /**
    * Call a processor to process the value if it's known.
    *
    * @param processor The processor to be called.

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AbstractScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AbstractScore.java
@@ -182,6 +182,29 @@ public abstract class AbstractScore implements Score {
   }
 
   /**
+   * Looks for a value of a specified feature in a list of values.
+   *
+   * @param feature The feature.
+   * @param values The list of values.
+   * @param <T> A type of the feature.
+   * @return A value for the specified feature if it's in the list.
+   * @throws IllegalArgumentException If a value was not found.
+   */
+  protected <T> Value<T> find(Feature<T> feature, Value... values) {
+    Objects.requireNonNull(values, "Oh no! Feature values can't be null!");
+    Objects.requireNonNull(feature, "Oh no! Feature can't be null!");
+
+    for (Value value : values) {
+      if (feature.equals(value.feature())) {
+        return value;
+      }
+    }
+
+    throw new IllegalArgumentException(
+        String.format("Oh no! We could not find feature: %s", feature.name()));
+  }
+
+  /**
    * The method tries to get a value for a specified score. First, the method checks
    * if the set of values already contains a value for the specified score. If yes, the method
    * just returns the existing value. Otherwise, the method tries to calculate a value

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScore.java
@@ -1,7 +1,27 @@
 package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
-import static com.sap.sgs.phosphor.fosstars.model.other.Utils.findValue;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_GITHUB_FOR_DEVELOPMENT;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.CPP;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.C_SHARP;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.F_SHARP;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVA;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVASCRIPT;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.PHP;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.PYTHON;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.RUBY;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.SCALA;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.VISUALBASIC;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.COMPOSER;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.DOTNET;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.MAVEN;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.NPM;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.PIP;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.RUBYGEMS;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.YARN;
 
 import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.Value;
@@ -9,37 +29,106 @@ import com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures;
 import com.sap.sgs.phosphor.fosstars.model.qa.ScoreVerification;
 import com.sap.sgs.phosphor.fosstars.model.qa.TestVectors;
 import com.sap.sgs.phosphor.fosstars.model.score.FeatureBasedScore;
+import com.sap.sgs.phosphor.fosstars.model.value.Languages;
+import com.sap.sgs.phosphor.fosstars.model.value.PackageManager;
+import com.sap.sgs.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * <p>The score just wraps the {@link OssFeatures#SCANS_FOR_VULNERABLE_DEPENDENCIES} feature.
- * If the feature is true, then it returns {@link Score#MAX}. otherwise {@link Score#MIN}.</p>
- * <p>The score needs to be extended with more features.</p>
+ * The scores assesses how well an open-source project scans dependencies for known vulnerabilities.
+ * It is based on the following features:
+ * <ul>
+ *   <li>{@link OssFeatures#SCANS_FOR_VULNERABLE_DEPENDENCIES}</li>
+ *   <li>{@link OssFeatures#USES_DEPENDABOT}</li>
+ *   <li>{@link OssFeatures#USES_GITHUB_FOR_DEVELOPMENT}</li>
+ *   <li>{@link OssFeatures#LANGUAGES}</li>
+ *   <li>{@link OssFeatures#PACKAGE_MANAGERS}</li>
+ * </ul>
  */
 public class DependencyScanScore extends FeatureBasedScore {
+
+  /**
+   * The supported package ecosystems and languages
+   * that GitHub can detect vulnerabilities and dependencies for.
+   *
+   * @see <a href="https://help.github.com/en/github/managing-security-vulnerabilities/about-security-alerts-for-vulnerable-dependencies#alerts-and-automated-security-updates-for-vulnerable-dependencies">
+   *   Alerts and automated security updates for vulnerable dependencies</a>
+   * @see <a href="https://help.github.com/en/github/visualizing-repository-data-with-graphs/listing-the-packages-that-a-repository-depends-on#supported-package-ecosystems">
+   *   Supported package ecosystems</a>
+   */
+  private static final Map<PackageManager, Languages> SUPPORTED_LANGUAGES = new HashMap<>();
+
+  static {
+    SUPPORTED_LANGUAGES.put(MAVEN, Languages.of(JAVA, SCALA));
+    SUPPORTED_LANGUAGES.put(NPM, Languages.of(JAVASCRIPT));
+    SUPPORTED_LANGUAGES.put(YARN, Languages.of(JAVASCRIPT));
+    SUPPORTED_LANGUAGES.put(DOTNET, Languages.of(C_SHARP, F_SHARP, CPP, VISUALBASIC));
+    SUPPORTED_LANGUAGES.put(PIP, Languages.of(PYTHON));
+    SUPPORTED_LANGUAGES.put(RUBYGEMS, Languages.of(RUBY));
+    SUPPORTED_LANGUAGES.put(COMPOSER, Languages.of(PHP));
+  }
+
+  /**
+   * A score value that is returned if it's likely
+   * that a project uses the security alerts on GitHub.
+   */
+  private static final double GITHUB_ALERTS_SCORE_VALUE = 6.0;
 
   /**
    * Initializes a new {@link DependencyScanScore}.
    */
   DependencyScanScore() {
     super("How a project scans its dependencies for vulnerabilities",
-        SCANS_FOR_VULNERABLE_DEPENDENCIES);
+        SCANS_FOR_VULNERABLE_DEPENDENCIES,
+        USES_DEPENDABOT,
+        USES_GITHUB_FOR_DEVELOPMENT,
+        PACKAGE_MANAGERS,
+        LANGUAGES);
   }
 
   @Override
   public ScoreValue calculate(Value... values) {
-    Value<Boolean> scansDependencies = findValue(values, SCANS_FOR_VULNERABLE_DEPENDENCIES,
-        "Hey! You have to tell me if the project scans for vulnerable dependencies!");
+    Value<Boolean> scansDependencies = find(SCANS_FOR_VULNERABLE_DEPENDENCIES, values);
+    Value<Boolean> usesDependabot = find(USES_DEPENDABOT, values);
+    Value<Boolean> usesGithub = find(USES_GITHUB_FOR_DEVELOPMENT, values);
+    Value<Languages> languages = find(LANGUAGES, values);
+    Value<PackageManagers> packageManagers = find(PACKAGE_MANAGERS, values);
 
-    if (scansDependencies.isUnknown()) {
-      return scoreValue(Score.MIN, scansDependencies);
+    ScoreValue scoreValue = scoreValue(Score.MIN,
+        scansDependencies, usesDependabot, usesGithub, packageManagers, languages);
+
+    // if the project scans for vulnerable dependencies,
+    // then we're happy
+    if (scansDependencies.orElse(false)) {
+      return scoreValue.set(Score.MAX);
     }
 
-    return scoreValue(
-        scansDependencies.get().equals(true) ? Score.MAX : Score.MIN,
-        scansDependencies);
+    // if the project uses Dependabot,
+    // then we're happy
+    if (usesDependabot.orElse(false)) {
+      return scoreValue.set(Score.MAX);
+    }
+
+    // if the projects uses GitHub for development,
+    // then there is a chance that it takes advantage of security alerts
+    // although we can't tell for sure
+    if (usesGithub.orElse(false)) {
+      Languages usedLanguages = languages.orElse(Languages.empty());
+      for (PackageManager packageManager : packageManagers.orElse(PackageManagers.empty())) {
+        Languages supportedLanguages
+            = SUPPORTED_LANGUAGES.getOrDefault(packageManager, Languages.empty());
+        if (supportedLanguages.containsAnyOf(usedLanguages)) {
+          return scoreValue.set(GITHUB_ALERTS_SCORE_VALUE);
+        }
+      }
+    }
+
+    // otherwise, return the minimal score
+    return scoreValue;
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/AbstractValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/AbstractValue.java
@@ -64,6 +64,11 @@ public abstract class AbstractValue<T> implements Value<T> {
   }
 
   @Override
+  public T orElse(T other) {
+    return isUnknown() || isNotApplicable() ? other : get();
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ExpiringValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ExpiringValue.java
@@ -67,6 +67,11 @@ public class ExpiringValue<T> implements Value<T> {
   }
 
   @Override
+  public T orElse(T other) {
+    return value.orElse(other);
+  }
+
+  @Override
   public Value<T> processIfKnown(Processor<T> processor) {
     value.processIfKnown(processor);
     return this;

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Languages.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Languages.java
@@ -1,10 +1,13 @@
 package com.sap.sgs.phosphor.fosstars.model.value;
 
+import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -12,12 +15,22 @@ import java.util.stream.Collectors;
 /**
  * A set of programming languages.
  */
-public class Languages {
+public class Languages implements Iterable<Language> {
 
   /**
    * A set of languages.
    */
-  private final Set<Language> languages;
+  private final Set<Language> elements;
+
+  /**
+   * Creates a collection of languages.
+   *
+   * @param languages The languages.
+   * @return A collection of the specified languages.
+   */
+  public static Languages of(Language... languages) {
+    return new Languages(setOf(languages));
+  }
 
   /**
    * Returns an empty set of languages.
@@ -32,9 +45,9 @@ public class Languages {
    * @param languages A set of languages.
    */
   @JsonCreator
-  public Languages(@JsonProperty("languages") Set<Language> languages) {
+  public Languages(@JsonProperty("elements") Set<Language> languages) {
     Objects.requireNonNull(languages, "Languages can't be null!");
-    this.languages = EnumSet.copyOf(languages);
+    this.elements = EnumSet.copyOf(languages);
   }
 
   /**
@@ -50,15 +63,25 @@ public class Languages {
    * Returns a number of languages in the set.
    */
   public int size() {
-    return languages.size();
+    return elements.size();
+  }
+
+  public boolean contains(Languages languages) {
+    for (Language language : languages) {
+      if (this.elements.contains(language)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /**
    * Returns the languages.
    */
-  @JsonGetter("languages")
+  @JsonGetter("elements")
   public Set<Language> get() {
-    return EnumSet.copyOf(languages);
+    return EnumSet.copyOf(elements);
   }
 
   @Override
@@ -70,16 +93,21 @@ public class Languages {
       return false;
     }
     Languages other = (Languages) o;
-    return Objects.equals(languages, other.languages);
+    return Objects.equals(elements, other.elements);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(languages);
+    return Objects.hash(elements);
   }
 
   @Override
   public String toString() {
-    return languages.stream().map(Enum::toString).collect(Collectors.joining(", "));
+    return elements.stream().map(Enum::toString).collect(Collectors.joining(", "));
+  }
+
+  @Override
+  public Iterator<Language> iterator() {
+    return elements.iterator();
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Languages.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Languages.java
@@ -5,8 +5,7 @@ import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Arrays;
-import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
@@ -47,7 +46,7 @@ public class Languages implements Iterable<Language> {
   @JsonCreator
   public Languages(@JsonProperty("elements") Set<Language> languages) {
     Objects.requireNonNull(languages, "Languages can't be null!");
-    this.elements = EnumSet.copyOf(languages);
+    this.elements = new HashSet<>(languages);
   }
 
   /**
@@ -56,7 +55,7 @@ public class Languages implements Iterable<Language> {
    * @param languages A number of languages.
    */
   public Languages(Language... languages) {
-    this(EnumSet.copyOf(Arrays.asList(languages)));
+    this(setOf(languages));
   }
 
   /**
@@ -66,7 +65,14 @@ public class Languages implements Iterable<Language> {
     return elements.size();
   }
 
-  public boolean contains(Languages languages) {
+  /**
+   * Checks if the collection contains one of the other languages.
+   *
+   * @param languages The other languages.
+   * @return True if at least one of the other languages is present in the collection,
+   *         false otherwise.
+   */
+  public boolean containsAnyOf(Languages languages) {
     for (Language language : languages) {
       if (this.elements.contains(language)) {
         return true;
@@ -81,7 +87,7 @@ public class Languages implements Iterable<Language> {
    */
   @JsonGetter("elements")
   public Set<Language> get() {
-    return EnumSet.copyOf(elements);
+    return new HashSet<>(elements);
   }
 
   @Override

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/PackageManagers.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/PackageManagers.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -14,12 +15,19 @@ import java.util.stream.Collectors;
 /**
  * A set of package managers.
  */
-public class PackageManagers {
+public class PackageManagers implements Iterable<PackageManager> {
 
   /**
    * A set of package managers.
    */
   private final Set<PackageManager> packageManagers;
+
+  /**
+   * Returns an empty set of package managers.
+   */
+  public static PackageManagers empty() {
+    return new PackageManagers();
+  }
 
   /**
    * Initializes a set of package managers.
@@ -137,5 +145,10 @@ public class PackageManagers {
   @Override
   public String toString() {
     return packageManagers.stream().map(Enum::toString).collect(Collectors.joining(", "));
+  }
+
+  @Override
+  public Iterator<PackageManager> iterator() {
+    return packageManagers.iterator();
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValue.java
@@ -145,6 +145,11 @@ public class ScoreValue implements Value<Double>, Confidence {
     return value;
   }
 
+  @Override
+  public Double orElse(Double other) {
+    return isUnknown() || isNotApplicable ? other : get();
+  }
+
   /**
    * Returns a list of values which were used to calculate the score value.
    */

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/UnknownValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/UnknownValue.java
@@ -59,6 +59,11 @@ public final class UnknownValue<T> implements Value<T> {
   }
 
   @Override
+  public T orElse(T other) {
+    return other;
+  }
+
+  @Override
   public Value<T> processIfKnown(Processor<T> processor) {
     return this;
   }

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
@@ -1,8 +1,52 @@
 ---
-defaults: []
+
+# default values for test vectors
+defaults:
+- type: "BooleanValue"
+  feature:
+    type: "BooleanFeature"
+    name: "If a project uses Dependabot"
+  flag: false
+- type: "BooleanValue"
+  feature:
+    type: "BooleanFeature"
+    name: "If a project uses GitHub as the main development platform"
+  flag: false
+- type: "PackageManagersValue"
+  feature:
+    type: "PackageManagersFeature"
+    name: "A set of package managers"
+  packageManagers:
+    packageManagers:
+      - "MAVEN"
+- type: "LanguagesValue"
+  feature:
+    type: "LanguagesFeature"
+    name: "A set of programming languages"
+  languages:
+    elements:
+    - "JAVA"
+
+# test vectors
 elements:
 - type: "StandardTestVector"
   values:
+  - type: "UnknownValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project uses Dependabot"
+  - type: "UnknownValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project uses GitHub as the main development platform"
+  - type: "UnknownValue"
+    feature:
+      type: "PackageManagersFeature"
+      name: "A set of package managers"
+  - type: "UnknownValue"
+    feature:
+      type: "LanguagesFeature"
+      name: "A set of programming languages"
   - type: "UnknownValue"
     feature:
       type: "BooleanFeature"

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScoreTestVectors.yml
@@ -1,8 +1,30 @@
 ---
+
+# default values for test vectors
 defaults: []
+
+# test vectors
 elements:
+
+# all unknown
 - type: "StandardTestVector"
   values:
+  - type: "UnknownValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project uses Dependabot"
+  - type: "UnknownValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project uses GitHub as the main development platform"
+  - type: "UnknownValue"
+    feature:
+      type: "PackageManagersFeature"
+      name: "A set of package managers"
+  - type: "UnknownValue"
+    feature:
+      type: "LanguagesFeature"
+      name: "A set of programming languages"
   - type: "UnknownValue"
     feature:
       type: "BooleanFeature"
@@ -16,7 +38,9 @@ elements:
     openRight: false
     positiveInfinity: false
   expectedLabel: null
-  alias: "test_vector_0"
+  alias: "all_unknown"
+
+# very bad project
 - type: "StandardTestVector"
   values:
   - type: "BooleanValue"
@@ -24,6 +48,30 @@ elements:
       type: "BooleanFeature"
       name: "If an open-source project is regularly scanned for vulnerable dependencies"
     flag: false
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project uses Dependabot"
+    flag: false
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project uses GitHub as the main development platform"
+    flag: false
+  - type: "PackageManagersValue"
+    feature:
+      type: "PackageManagersFeature"
+      name: "A set of package managers"
+    packageManagers:
+      packageManagers:
+      - "OTHER"
+  - type: "LanguagesValue"
+    feature:
+      type: "LanguagesFeature"
+      name: "A set of programming languages"
+    languages:
+      elements:
+      - "OTHER"
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -33,7 +81,52 @@ elements:
     openRight: false
     positiveInfinity: false
   expectedLabel: null
-  alias: "test_vector_1"
+  alias: "very_bad"
+
+  # okay project
+- type: "StandardTestVector"
+  values:
+    - type: "BooleanValue"
+      feature:
+        type: "BooleanFeature"
+        name: "If an open-source project is regularly scanned for vulnerable dependencies"
+      flag: false
+    - type: "BooleanValue"
+      feature:
+        type: "BooleanFeature"
+        name: "If a project uses Dependabot"
+      flag: false
+    - type: "BooleanValue"
+      feature:
+        type: "BooleanFeature"
+        name: "If a project uses GitHub as the main development platform"
+      flag: true
+    - type: "PackageManagersValue"
+      feature:
+        type: "PackageManagersFeature"
+        name: "A set of package managers"
+      packageManagers:
+        packageManagers:
+        - "MAVEN"
+    - type: "LanguagesValue"
+      feature:
+        type: "LanguagesFeature"
+        name: "A set of programming languages"
+      languages:
+        elements:
+        - "JAVA"
+  expectedScore:
+    type: "DoubleInterval"
+    from: 6.0
+    openLeft: false
+    negativeInfinity: false
+    to: 9.0
+    openRight: false
+    positiveInfinity: false
+  expectedLabel: null
+  alias: "okay"
+
+# very good project
 - type: "StandardTestVector"
   values:
   - type: "BooleanValue"
@@ -41,6 +134,30 @@ elements:
       type: "BooleanFeature"
       name: "If an open-source project is regularly scanned for vulnerable dependencies"
     flag: true
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project uses Dependabot"
+    flag: true
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project uses GitHub as the main development platform"
+    flag: true
+  - type: "PackageManagersValue"
+    feature:
+      type: "PackageManagersFeature"
+      name: "A set of package managers"
+    packageManagers:
+      packageManagers:
+      - "MAVEN"
+  - type: "LanguagesValue"
+    feature:
+      type: "LanguagesFeature"
+      name: "A set of programming languages"
+    languages:
+      elements:
+      - "JAVA"
   expectedScore:
     type: "DoubleInterval"
     from: 9.0
@@ -50,4 +167,4 @@ elements:
     openRight: false
     positiveInfinity: false
   expectedLabel: null
-  alias: "test_vector_2"
+  alias: "very_good"

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/DependencyScanScoreTest.java
@@ -1,10 +1,18 @@
 package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
 import static com.sap.sgs.phosphor.fosstars.TestUtils.assertScore;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_GITHUB_FOR_DEVELOPMENT;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVA;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.MAVEN;
 
 import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.value.Languages;
+import com.sap.sgs.phosphor.fosstars.model.value.PackageManagers;
 import org.junit.Test;
 
 public class DependencyScanScoreTest {
@@ -14,11 +22,17 @@ public class DependencyScanScoreTest {
     assertScore(
         Score.INTERVAL,
         new DependencyScanScore(),
-        setOf(SCANS_FOR_VULNERABLE_DEPENDENCIES.value(true)));
+        setOf(
+            SCANS_FOR_VULNERABLE_DEPENDENCIES.value(true),
+            USES_GITHUB_FOR_DEVELOPMENT.value(true),
+            USES_DEPENDABOT.value(true),
+            LANGUAGES.value(Languages.of(JAVA)),
+            PACKAGE_MANAGERS.value(PackageManagers.from(MAVEN))
+        ));
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void noInfoAboutScans() {
+  public void testWithNoInfo() {
     new DependencyScanScore().calculate();
   }
 

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
@@ -4,6 +4,7 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SE
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_TEAM;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.IS_APACHE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.IS_ECLIPSE;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_COMMITS_LAST_THREE_MONTHS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
@@ -12,12 +13,15 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAG
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_GITHUB_FOR_DEVELOPMENT;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_VERIFIED_SIGNED_COMMITS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_LGTM_GRADE;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVA;
 import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.MAVEN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -29,6 +33,7 @@ import com.sap.sgs.phosphor.fosstars.model.Confidence;
 import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.other.Utils;
+import com.sap.sgs.phosphor.fosstars.model.value.Languages;
 import com.sap.sgs.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.sgs.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
@@ -82,6 +87,9 @@ public class OssSecurityScoreTest {
         USES_LGTM.value(true),
         WORST_LGTM_GRADE.value(LgtmGrade.B),
         USES_NOHTTP.value(true),
+        USES_DEPENDABOT.value(true),
+        USES_GITHUB_FOR_DEVELOPMENT.value(true),
+        LANGUAGES.value(Languages.of(JAVA)),
         PACKAGE_MANAGERS.value(PackageManagers.from(MAVEN)));
     ScoreValue scoreValue = score.calculate(values);
     assertTrue(Score.INTERVAL.contains(scoreValue.get()));

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTuningWithCMAESTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTuningWithCMAESTest.java
@@ -4,6 +4,7 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SE
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_TEAM;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.IS_APACHE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.IS_ECLIPSE;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_COMMITS_LAST_THREE_MONTHS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
@@ -12,12 +13,16 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAG
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_GITHUB_FOR_DEVELOPMENT;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_VERIFIED_SIGNED_COMMITS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_LGTM_GRADE;
 import static com.sap.sgs.phosphor.fosstars.model.qa.TestVectorBuilder.newTestVector;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVA;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.OTHER;
 import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.MAVEN;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -25,6 +30,7 @@ import static org.junit.Assert.assertNotNull;
 import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.math.DoubleInterval;
 import com.sap.sgs.phosphor.fosstars.model.qa.TestVectors;
+import com.sap.sgs.phosphor.fosstars.model.value.Languages;
 import com.sap.sgs.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.sgs.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.sgs.phosphor.fosstars.model.value.UnknownValue;
@@ -60,6 +66,9 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(UnknownValue.of(USES_LGTM))
           .set(UnknownValue.of(WORST_LGTM_GRADE))
           .set(UnknownValue.of(USES_NOHTTP))
+          .set(UnknownValue.of(USES_DEPENDABOT))
+          .set(UnknownValue.of(USES_GITHUB_FOR_DEVELOPMENT))
+          .set(UnknownValue.of(LANGUAGES))
           .set(UnknownValue.of(PACKAGE_MANAGERS))
           .expectedScore(DoubleInterval.closed(Score.MIN, 0.1))
           .alias("one")
@@ -83,6 +92,9 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(USES_LGTM.value(false))
           .set(WORST_LGTM_GRADE.unknown())
           .set(USES_NOHTTP.value(false))
+          .set(USES_DEPENDABOT.value(false))
+          .set(USES_GITHUB_FOR_DEVELOPMENT.value(false))
+          .set(LANGUAGES.value(Languages.of(OTHER)))
           .set(PACKAGE_MANAGERS.unknown())
           .expectedScore(DoubleInterval.closed(1.0, 4.0))
           .alias("two")
@@ -106,6 +118,9 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(USES_LGTM.value(true))
           .set(WORST_LGTM_GRADE.value(LgtmGrade.A_PLUS))
           .set(USES_NOHTTP.value(true))
+          .set(USES_DEPENDABOT.value(true))
+          .set(USES_GITHUB_FOR_DEVELOPMENT.value(true))
+          .set(LANGUAGES.value(Languages.of(JAVA)))
           .set(PACKAGE_MANAGERS.value(new PackageManagers(MAVEN)))
           .expectedScore(DoubleInterval.init().from(9.0).to(Score.MAX).make())
           .alias("three")

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/AbstractValueTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/AbstractValueTest.java
@@ -46,7 +46,7 @@ public class AbstractValueTest {
   }
 
   @Test
-  public void processIfKnown() {
+  public void testProcessIfKnown() {
     ValueImpl value = new ValueImpl(new FeatureImpl("feature"), "test");
     assertFalse(value.isUnknown());
 
@@ -67,5 +67,12 @@ public class AbstractValueTest {
     assertEquals(2, processedValues.size());
     assertEquals("test", processedValues.get(0));
     assertEquals("unknown", processedValues.get(1));
+  }
+
+  @Test
+  public void testOrElse() {
+    FeatureImpl feature = new FeatureImpl("feature");
+    assertEquals("value", new ValueImpl(feature, "value").orElse("another"));
+    assertEquals("another", feature.unknown().orElse("another"));
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValueTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValueTest.java
@@ -24,7 +24,7 @@ public class ScoreValueTest {
   private static final double ACCURACY = 0.01;
 
   @Test
-  public void increase() {
+  public void testIncrease() {
     ScoreValue value = new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE);
     Assert.assertEquals(Score.MIN, value.get(), ACCURACY);
     value.increase(2.1);
@@ -36,12 +36,12 @@ public class ScoreValueTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void increaseNegative() {
+  public void testIncreaseNegative() {
     new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE).increase(-1.0);
   }
 
   @Test
-  public void decrease() {
+  public void testDecrease() {
     ScoreValue value = new ScoreValue(
         PROJECT_ACTIVITY_SCORE_EXAMPLE, 5.0, 1.0, 10.0, Collections.emptyList());
     assertEquals(5.0, value.get(), ACCURACY);
@@ -54,12 +54,12 @@ public class ScoreValueTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void decreaseNegative() {
+  public void testDecreaseNegative() {
     new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE).decrease(-1.0);
   }
 
   @Test
-  public void confidence() {
+  public void testConfidence() {
     ScoreValue value = new ScoreValue(
         PROJECT_ACTIVITY_SCORE_EXAMPLE, 5.0, 1.0, 10.0, Collections.emptyList());
     assertEquals(10.0, value.confidence(), ACCURACY);
@@ -68,7 +68,7 @@ public class ScoreValueTest {
   }
 
   @Test
-  public void usedValues() {
+  public void testUsedValues() {
     List<Value> usedValues = Arrays.asList(
         NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
         NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(3));
@@ -87,7 +87,7 @@ public class ScoreValueTest {
   }
 
   @Test
-  public void weight() {
+  public void testWeight() {
     ScoreValue value = new ScoreValue(
         PROJECT_ACTIVITY_SCORE_EXAMPLE, 5.0, 0.7, 10.0, Collections.emptyList());
     assertEquals(0.7, value.weight(), 0.01);
@@ -96,28 +96,28 @@ public class ScoreValueTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void negativeWeight() {
+  public void testNegativeWeight() {
     new ScoreValue(
         PROJECT_ACTIVITY_SCORE_EXAMPLE, 5.0, 0.7, 10.0, Collections.emptyList())
         .weight(-1);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void zeroWeight() {
+  public void testZeroWeight() {
     new ScoreValue(
         PROJECT_ACTIVITY_SCORE_EXAMPLE, 5.0, 0.7, 10.0, Collections.emptyList())
         .weight(0.0);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void tooBigWeight() {
+  public void testTooBigWeight() {
     new ScoreValue(
         PROJECT_ACTIVITY_SCORE_EXAMPLE, 5.0, 0.7, 10.0, Collections.emptyList())
         .weight(1.1);
   }
 
   @Test
-  public void explanation() {
+  public void testExplanation() {
     List<String> notes = new ArrayList<>();
     notes.add("first note");
     notes.add("second note");
@@ -138,7 +138,7 @@ public class ScoreValueTest {
   }
 
   @Test
-  public void equalsAndHashCode() {
+  public void testEqualsAndHashCode() {
     List<Value> usedValues = Arrays.asList(
         NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
         NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(3));
@@ -168,7 +168,7 @@ public class ScoreValueTest {
   }
 
   @Test
-  public void serializeAndDeserialize() throws IOException {
+  public void testSerializeAndDeserialize() throws IOException {
     List<Value> usedValues = Arrays.asList(
         NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
         NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(3));
@@ -184,6 +184,18 @@ public class ScoreValueTest {
     assertNotNull(clone);
     assertEquals(value, clone);
     assertEquals(value.hashCode(), clone.hashCode());
+  }
+
+  @Test
+  public void testOrElse() {
+    ScoreValue value = new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE).set(5.1);
+    assertEquals(5.1, value.orElse(1.2), ACCURACY);
+
+    Value<Double> unknown = UnknownValue.of(PROJECT_ACTIVITY_SCORE_EXAMPLE);
+    assertEquals(3.0, unknown.orElse(3.0), ACCURACY);
+
+    Value<Double> notApplicable = NotApplicableValue.of(PROJECT_ACTIVITY_SCORE_EXAMPLE);
+    assertEquals(3.0, notApplicable.orElse(3.0), ACCURACY);
   }
 
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/UnknownValueTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/UnknownValueTest.java
@@ -12,28 +12,33 @@ import org.junit.Test;
 public class UnknownValueTest {
 
   @Test
-  public void getFeature() {
+  public void testGetFeature() {
     Value value = new UnknownValue(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
     assertEquals(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, value.feature());
   }
 
   @Test
-  public void isUnknown() {
+  public void testIsUnknown() {
     assertTrue(new UnknownValue<>(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).isUnknown());
   }
 
   @Test(expected = UnsupportedOperationException.class)
-  public void get() {
+  public void testGet() {
     new UnknownValue<>(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).get();
   }
 
   @Test
-  public void serializationAndDeserialization() throws IOException {
+  public void testSerializationAndDeserialization() throws IOException {
     ObjectMapper mapper = new ObjectMapper();
     UnknownValue value = UnknownValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
     UnknownValue clone = mapper.readValue(
         mapper.writeValueAsBytes(value), UnknownValue.class);
     assertEquals(value, clone);
     assertEquals(value.hashCode(), clone.hashCode());
+  }
+
+  @Test
+  public void testOrElse() {
+    assertEquals(42, new UnknownValue(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).orElse(42));
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinterTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinterTest.java
@@ -5,6 +5,7 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SE
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_TEAM;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.IS_APACHE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.IS_ECLIPSE;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_COMMITS_LAST_THREE_MONTHS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
@@ -13,6 +14,7 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAG
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_GITHUB_FOR_DEVELOPMENT;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
@@ -20,6 +22,7 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_V
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_LGTM_GRADE;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVA;
 import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.GRADLE;
 import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.MAVEN;
 import static org.junit.Assert.assertEquals;
@@ -31,6 +34,7 @@ import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.RatingRepository;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.rating.oss.OssSecurityRating;
+import com.sap.sgs.phosphor.fosstars.model.value.Languages;
 import com.sap.sgs.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.sgs.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
@@ -63,6 +67,8 @@ public class PrettyPrinterTest {
         WORST_LGTM_GRADE.value(LgtmGrade.A),
         USES_GITHUB_FOR_DEVELOPMENT.value(false),
         USES_NOHTTP.value(false),
+        USES_DEPENDABOT.value(false),
+        LANGUAGES.value(Languages.of(JAVA)),
         PACKAGE_MANAGERS.value(new PackageManagers(MAVEN)));
     
     RatingValue ratingValue = rating.calculate(values);
@@ -109,6 +115,8 @@ public class PrettyPrinterTest {
         WORST_LGTM_GRADE.value(LgtmGrade.A),
         USES_GITHUB_FOR_DEVELOPMENT.value(false),
         USES_NOHTTP.value(true),
+        USES_DEPENDABOT.value(true),
+        LANGUAGES.value(Languages.of(JAVA)),
         PACKAGE_MANAGERS.value(new PackageManagers(GRADLE)));
     RatingValue ratingValue = rating.calculate(values);
 


### PR DESCRIPTION
Here is a list of main updates:

- Updated the score to use the `USES_GITHUB_FOR_DEVELOPMENT`, `LANGUAGES` and  `PACKAGE_MANAGERS` features. This closes #93.
- Updated the score to use the `USES_DEPENDABOT` feature. This closes #95.
- Introduced `Value.orElse()` method This closes #152.
- Made `Languages` and `PackageManagers` iterable. This closes #153.
- Updated test and test vectors.