### PR TITLE
GitHubProjectFinder should take into account number of stars

### DIFF
--- a/docs/oss/security/apache.yml
+++ b/docs/oss/security/apache.yml
@@ -9,6 +9,7 @@ reports:
 finder:
   organizations:
     - name: apache
+      stars: 100
       exclude:
         - incubator
         - website
@@ -23,3 +24,5 @@ finder:
         - wiki
         - infra
         - github.io
+        - demo
+        - sample

--- a/docs/oss/security/eclipse.yml
+++ b/docs/oss/security/eclipse.yml
@@ -9,6 +9,7 @@ reports:
 finder:
   organizations:
     - name: eclipse
+      stars: 100
       exclude:
         - incubator
         - website
@@ -23,3 +24,5 @@ finder:
         - wiki
         - Test
         - org.eclipse
+        - demo
+        - sample

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectFinderTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectFinderTest.java
@@ -38,13 +38,13 @@ public class GitHubProjectFinderTest {
       assertThat(
           config.organizationConfigs,
           hasItem(
-              new OrganizationConfig("apache", Arrays.asList("incubator", "incubating"))));
+              new OrganizationConfig("apache", Arrays.asList("incubator", "incubating"), 100)));
       assertThat(config.organizationConfigs,
           hasItem(
-              new OrganizationConfig("eclipse", Collections.singletonList("incubator"))));
+              new OrganizationConfig("eclipse", Collections.singletonList("incubator"), 0)));
       assertThat(config.organizationConfigs,
           hasItem(
-              new OrganizationConfig("spring-projects", EMPTY_EXCLUDE_LIST)));
+              new OrganizationConfig("spring-projects", EMPTY_EXCLUDE_LIST, 0)));
       assertNotNull(config.projectConfigs);
       assertEquals(2, config.projectConfigs.size());
       assertThat(

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculatorTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculatorTest.java
@@ -61,15 +61,15 @@ public class SecurityRatingCalculatorTest {
       assertThat(
           mainConfig.finderConfig.organizationConfigs,
           hasItem(
-              new OrganizationConfig("apache", Arrays.asList("incubator", "incubating"))));
+              new OrganizationConfig("apache", Arrays.asList("incubator", "incubating"), 0)));
       assertThat(
           mainConfig.finderConfig.organizationConfigs,
           hasItem(
-              new OrganizationConfig("eclipse", Collections.singletonList("incubator"))));
+              new OrganizationConfig("eclipse", Collections.singletonList("incubator"), 0)));
       assertThat(
           mainConfig.finderConfig.organizationConfigs,
           hasItem(
-              new OrganizationConfig("spring-projects", EMPTY_EXCLUDE_LIST)));
+              new OrganizationConfig("spring-projects", EMPTY_EXCLUDE_LIST, 0)));
       assertNotNull(mainConfig.finderConfig.projectConfigs);
       assertEquals(2, mainConfig.finderConfig.projectConfigs.size());
       assertThat(

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/tool/github/ValidProjectFinderConfig.yml
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/tool/github/ValidProjectFinderConfig.yml
@@ -1,6 +1,7 @@
 # this is a test configuration for the ConfigParser class
 organizations:
   - name: apache
+    stars: 100
     exclude:
       - incubator
       - incubating


### PR DESCRIPTION
This update introduce a new parameter for `GitHubProjectFinder` to make it filter out projects with a low number of stars. That would allow to exclude unpopular projects from the markdown report.

This closes #165 