### PR TITLE
Update UsesOwaspDependencyCheck to support Gradle

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesOwaspDependencyCheck.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesOwaspDependencyCheck.java
@@ -4,8 +4,10 @@ import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.feature.BooleanFeature;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.ReportPlugin;
@@ -25,7 +27,7 @@ public class UsesOwaspDependencyCheck extends CachedSingleFeatureGitHubDataProvi
   /**
    * A feature which is filled out by the provider.
    */
-  public static final Feature<Boolean> USES_OWASP_DEPENDENCY_CHECK
+  static final Feature<Boolean> USES_OWASP_DEPENDENCY_CHECK
       = new BooleanFeature("If a project uses OWASP Dependency Check");
 
   /**
@@ -95,8 +97,27 @@ public class UsesOwaspDependencyCheck extends CachedSingleFeatureGitHubDataProvi
    * @param repository The project's repository.
    * @return True if the project uses the plugin, false otherwise.
    */
-  private boolean checkGradle(GHRepository repository) {
-    // TODO: implement
+  private boolean checkGradle(GHRepository repository) throws IOException {
+    GHContent content;
+    try {
+      content = repository.getFileContent("build.gradle");
+    } catch (GHFileNotFoundException e) {
+      return false;
+    }
+
+    if (content == null || !content.isFile()) {
+      return false;
+    }
+
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(content.read()))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.trim().contains("org.owasp:dependency-check-gradle")) {
+          return true;
+        }
+      }
+    }
+
     return false;
   }
 

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesOwaspDependencyCheckTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesOwaspDependencyCheckTest.java
@@ -1,90 +1,105 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
-import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
+import static com.sap.sgs.phosphor.fosstars.data.github.UsesOwaspDependencyCheck.USES_OWASP_DEPENDENCY_CHECK;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import com.sap.sgs.phosphor.fosstars.data.Terminal;
 import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
+import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProjectValueCache;
 import java.io.IOException;
-import java.util.Optional;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
+import java.io.InputStream;
 import org.junit.Test;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 
-/**
- * TODO: This test fails when GitHub API rate limit exceeded or some networking issues occur.
- *       The test needs to be re-written to use mocks.
- *       Meanwhile, the test is ignored.
- */
-@Ignore
 public class UsesOwaspDependencyCheckTest {
 
-  private static GitHub github;
+  @Test
+  public void testMavenWithOwaspDependencyCheckInBuild() throws IOException {
+    try (InputStream is = getClass()
+        .getResourceAsStream("MavenWithOwaspDependencyCheckInBuild.xml")) {
 
-  @BeforeClass
-  public static void initGithubConnection() {
-    try {
-      github = GitHub.connectAnonymously();
-      github.checkApiUrlValidity();
-    } catch (Exception e) {
-      System.out.println("Couldn't connect to GitHub!");
-      e.printStackTrace();
-      github = null;
+      checkValue(createProvider(is, "pom.xml"), true);
     }
   }
 
   @Test
-  public void testApacheCxf() throws IOException {
-    assumeNotNull(github);
-    GitHubProject project = new GitHubProject("apache", "cxf");
-    UsesOwaspDependencyCheck provider = new UsesOwaspDependencyCheck(github);
-    ValueHashSet values = new ValueHashSet();
-    provider.set(new Terminal()).update(project, values);
-    assertTrue(values.has(SCANS_FOR_VULNERABLE_DEPENDENCIES));
-    Optional<Value> something = values.of(SCANS_FOR_VULNERABLE_DEPENDENCIES);
-    assertNotNull(something);
-    assertTrue(something.isPresent());
-    Value<Boolean> value = something.get();
-    assertNotNull(value);
-    assertEquals(Boolean.TRUE, value.get());
+  public void testMavenWithOwaspDependencyCheckInReporting() throws IOException {
+    try (InputStream is = getClass()
+        .getResourceAsStream("MavenWithOwaspDependencyCheckInReporting.xml")) {
+
+      checkValue(createProvider(is, "pom.xml"), true);
+    }
   }
 
   @Test
-  public void testApachePoi() throws IOException {
-    assumeNotNull(github);
-    GitHubProject project = new GitHubProject("apache", "poi");
-    UsesOwaspDependencyCheck provider = new UsesOwaspDependencyCheck(github);
-    ValueHashSet values = new ValueHashSet();
-    provider.set(new Terminal()).update(project, values);
-    assertTrue(values.has(SCANS_FOR_VULNERABLE_DEPENDENCIES));
-    Optional<Value> something = values.of(SCANS_FOR_VULNERABLE_DEPENDENCIES);
-    assertNotNull(something);
-    assertTrue(something.isPresent());
-    Value<Boolean> value = something.get();
-    assertNotNull(value);
-    assertEquals(Boolean.FALSE, value.get());
+  public void testMavenWithoutOwaspDependencyCheck() throws IOException {
+    try (InputStream is = getClass()
+        .getResourceAsStream("MavenWithoutOwaspDependencyCheck.xml")) {
+
+      checkValue(createProvider(is, "pom.xml"), false);
+    }
   }
 
   @Test
-  public void testSpringSecurityOAuth() throws IOException {
-    assumeNotNull(github);
-    GitHubProject project = new GitHubProject("spring-projects", "spring-security-oauth");
+  public void testGradleWithOwaspDependencyCheck() throws IOException {
+    try (InputStream is = getClass()
+        .getResourceAsStream("GradleWithOwaspDependencyCheck.gradle")) {
+
+      checkValue(createProvider(is, "build.gradle"), true);
+    }
+  }
+
+  @Test
+  public void testGradleWithoutOwaspDependencyCheck() throws IOException {
+    try (InputStream is = getClass()
+        .getResourceAsStream("GradleWithoutOwaspDependencyCheck.gradle")) {
+
+      checkValue(createProvider(is, "build.gradle"), false);
+    }
+  }
+
+  private static UsesOwaspDependencyCheck createProvider(InputStream is, String filename)
+      throws IOException {
+
+    GHContent content = mock(GHContent.class);
+    when(content.isFile()).thenReturn(true);
+    when(content.read()).thenReturn(is);
+
+    GHRepository repository = mock(GHRepository.class);
+    when(repository.getFileContent(filename)).thenReturn(content);
+
+    GitHub github = mock(GitHub.class);
+    when(github.getRepository(any())).thenReturn(repository);
+
     UsesOwaspDependencyCheck provider = new UsesOwaspDependencyCheck(github);
-    ValueHashSet values = new ValueHashSet();
-    provider.set(new Terminal()).update(project, values);
-    assertTrue(values.has(SCANS_FOR_VULNERABLE_DEPENDENCIES));
-    Optional<Value> something = values.of(SCANS_FOR_VULNERABLE_DEPENDENCIES);
-    assertNotNull(something);
-    assertTrue(something.isPresent());
-    Value<Boolean> value = something.get();
-    assertNotNull(value);
-    assertEquals(Boolean.FALSE, value.get());
+    provider.set(new GitHubProjectValueCache());
+    provider.gitHubDataFetcher().repositoryCache().clear();
+
+    return provider;
+  }
+
+  private static void checkValue(UsesOwaspDependencyCheck provider, boolean expectedValue)
+      throws IOException {
+
+    GitHubProject project = new GitHubProject("org", "test");
+
+    ValueSet values = new ValueHashSet();
+    provider.update(project, values);
+
+    assertEquals(1, values.size());
+    assertTrue(values.has(USES_OWASP_DEPENDENCY_CHECK));
+    assertTrue(values.of(USES_OWASP_DEPENDENCY_CHECK).isPresent());
+
+    Value<Boolean> value = values.of(USES_OWASP_DEPENDENCY_CHECK).get();
+    assertEquals(expectedValue, value.get());
   }
 
 }

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/GradleWithOwaspDependencyCheck.gradle
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/GradleWithOwaspDependencyCheck.gradle
@@ -1,0 +1,10 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.owasp:dependency-check-gradle:5.3.2'
+    }
+}
+
+apply plugin: 'org.owasp.dependencycheck'

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/GradleWithoutOwaspDependencyCheck.gradle
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/GradleWithoutOwaspDependencyCheck.gradle
@@ -1,0 +1,10 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.owasp:another-plugin:1.0.0'
+    }
+}
+
+apply plugin: 'org.owasp:another-plugin'

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/MavenWithOwaspDependencyCheckInBuild.xml
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/MavenWithOwaspDependencyCheckInBuild.xml
@@ -1,0 +1,18 @@
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>5.3.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/MavenWithOwaspDependencyCheckInReporting.xml
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/MavenWithOwaspDependencyCheckInReporting.xml
@@ -1,0 +1,18 @@
+<project>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>5.3.2</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>aggregate</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/MavenWithoutOwaspDependencyCheck.xml
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/MavenWithoutOwaspDependencyCheck.xml
@@ -1,0 +1,5 @@
+<project>
+  <build>
+    <plugins></plugins>
+  </build>
+</project>


### PR DESCRIPTION
Here is a list of main updates:

- Updated `UsesOwaspDependencyCheck` to read `build.gradle` file
  and check if OWASP Dependency Check plugin is used.
- Updated `UsesOwaspDependencyCheckTest`.

This closes #131
This closes #11