### PR TITLE
VulnerabilityLifetimeScore should not break when dates are incorrect

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AbstractScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AbstractScore.java
@@ -18,6 +18,8 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A base class for scores.
@@ -36,6 +38,12 @@ public abstract class AbstractScore implements Score {
    */
   @JsonIgnore
   private final String description;
+
+  /**
+   * A logger.
+   */
+  @JsonIgnore
+  protected final Logger logger = LogManager.getLogger(getClass());
 
   /**
    * Initializes a new score.

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScore.java
@@ -99,8 +99,10 @@ public class VulnerabilityLifetimeScore extends FeatureBasedScore {
       Instant fixed = entry.fixed().orElse(now).toInstant();
 
       if (fixed.isBefore(introduced)) {
-        throw new IllegalArgumentException("Looks like the vulnerability had been fixed "
-            + "even before it was introduced! How is that possible?");
+        logger.warn("Looks like the vulnerability {} had been fixed ({}) "
+                + "even before it was introduced ({})! How is that possible? Let's skip it.",
+            entry.id(), fixed, introduced);
+        continue;
       }
 
       CVSS cvss = entry.cvss();


### PR DESCRIPTION
This is a quick fix for #178 that updates the `VulnerabilityLifetimeScore` to ignore vulnerabilities with incorrect fixed and introduced dates. Most likely the score will be soon disabled since it's not reliable enough.

This closes #178