### PR TITLE
Better vulnerability scores

### DIFF
--- a/docs/oss_security_rating.md
+++ b/docs/oss_security_rating.md
@@ -31,7 +31,6 @@ Implementations of the features can be found in
 1.  Number of contributors in the last three months.
 1.  Number of commits in the last three months.
 1.  Number of watchers for a GitHub repository.
-1.  When a project started.
 1.  Programming languages that are used in a project.
 1.  Package managers that are used in a project.
 
@@ -69,9 +68,6 @@ Implementations for all the scores can be found in the [com.sap.sgs.phosphor.fos
         1.  If an open-source project uses UndefinedBehaviorSanitizer.
 1.  **Unpatched vulnerabilities score** based on the following features:
     1.  Info about vulnerabilities in open-source project.
-1.  **Vulnerability lifetime score** based on the following features:
-    1.  Info about vulnerabilities in open-source project.
-    1.  When a project started.
 1.  **Security awareness score** based on the following features:
     1.  If an open-source project has a security team.
     1.  If an open-source project has a security policy.

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore.java
@@ -29,8 +29,7 @@ public class OssSecurityScore extends WeightedCompositeScore {
         new CommunityCommitmentScore(),
         new ProjectSecurityAwarenessScore(),
         new ProjectSecurityTestingScore(),
-        new UnpatchedVulnerabilitiesScore(),
-        new VulnerabilityLifetimeScore());
+        new UnpatchedVulnerabilitiesScore());
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScore.java
@@ -1,6 +1,5 @@
 package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
-import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.findValue;
 
@@ -17,26 +16,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZonedDateTime;
-import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
  * The score shows how fast vulnerabilities are patched in an open-source project.
- * The score is based on the following features:
- * <ul>
- *   <li>Information about vulnerabilities in the project.</li>
- *   <li>When the project started.</li>
- * </ul>
+ * The score is based on information about vulnerabilities in the project.
  */
 public class VulnerabilityLifetimeScore extends FeatureBasedScore {
-
-  /**
-   * If unknown, the score assumes that the project started 10 years ago.
-   */
-  private static final Date DEFAULT_PROJECT_START_DATE
-      = Date.from(ZonedDateTime.now().minusYears(10).toInstant());
 
   /**
    * Maximum lifetime factor.
@@ -75,28 +62,31 @@ public class VulnerabilityLifetimeScore extends FeatureBasedScore {
    * Initializes a new score.
    */
   VulnerabilityLifetimeScore() {
-    super("How fast vulnerabilities are patched", VULNERABILITIES, PROJECT_START_DATE);
+    super("How fast vulnerabilities are patched", VULNERABILITIES);
   }
 
   @Override
   public ScoreValue calculate(Value... values) {
     Value<Vulnerabilities> vulnerabilities = findValue(values, VULNERABILITIES,
         "Hey! Give me info about vulnerabilities!");
-    Value<Date> projectStartDate = findValue(values, PROJECT_START_DATE,
-        "Hey! Tell me when the project started!");
 
     if (vulnerabilities.isUnknown()) {
-      return scoreValue(Score.MIN, vulnerabilities, projectStartDate);
+      return scoreValue(Score.MIN, vulnerabilities);
     }
 
-    Date now = new Date(System.currentTimeMillis());
-    Date estimatedIntroducedDate = projectStartDate.isUnknown()
-        ? DEFAULT_PROJECT_START_DATE : projectStartDate.get();
+    if (vulnerabilities.get().isEmpty()) {
+      return scoreValue(Score.MAX, vulnerabilities).explain("No vulnerabilities found.");
+    }
 
     double penalty = 0.0;
+    boolean found = false;
     for (Vulnerability entry : vulnerabilities.get().entries()) {
-      Instant introduced = entry.introduced().orElse(estimatedIntroducedDate).toInstant();
-      Instant fixed = entry.fixed().orElse(now).toInstant();
+      if (!entry.introduced().isPresent() || !entry.fixed().isPresent()) {
+        continue;
+      }
+
+      Instant introduced = entry.introduced().get().toInstant();
+      Instant fixed = entry.fixed().get().toInstant();
 
       if (fixed.isBefore(introduced)) {
         logger.warn("Looks like the vulnerability {} had been fixed ({}) "
@@ -109,9 +99,17 @@ public class VulnerabilityLifetimeScore extends FeatureBasedScore {
       double cvssValue = cvss.isUnknown() ? CVSS.MAX : cvss.value();
 
       penalty += cvssValue * factorOf(Duration.between(introduced, fixed));
+      found = true;
     }
 
-    return scoreValue(Score.MAX - penalty, vulnerabilities, projectStartDate);
+    if (!found) {
+      return scoreValue(Score.MIN, vulnerabilities)
+          .makeNotApplicable()
+          .explain("The score could not be applied "
+              + "because no vulnerabilities with introduced/fixed dates were found.");
+    }
+
+    return scoreValue(Score.MAX - penalty, vulnerabilities);
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Vulnerabilities.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Vulnerabilities.java
@@ -4,16 +4,18 @@ import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
 
 /**
  * A collection of vulnerabilities.
  */
-public class Vulnerabilities {
+public class Vulnerabilities implements Iterable<Vulnerability> {
 
   /**
    * A set of vulnerabilities.
@@ -46,6 +48,14 @@ public class Vulnerabilities {
   @JsonGetter("entries")
   public Set<Vulnerability> entries() {
     return Collections.unmodifiableSet(entries);
+  }
+
+  /**
+   * Returns true if the collection is empty, false otherwise.
+   */
+  @JsonIgnore
+  public boolean isEmpty() {
+    return entries.isEmpty();
   }
 
   /**
@@ -87,5 +97,10 @@ public class Vulnerabilities {
   public String toString() {
     int n = entries.size();
     return String.format("%d %s", n, n == 1 ? "vulnerability" : "vulnerabilities");
+  }
+
+  @Override
+  public Iterator<Vulnerability> iterator() {
+    return entries.iterator();
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SingleSecurityRatingCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SingleSecurityRatingCalculator.java
@@ -16,7 +16,6 @@ import com.sap.sgs.phosphor.fosstars.data.github.NumberOfStars;
 import com.sap.sgs.phosphor.fosstars.data.github.NumberOfWatchers;
 import com.sap.sgs.phosphor.fosstars.data.github.PackageManagement;
 import com.sap.sgs.phosphor.fosstars.data.github.ProgrammingLanguages;
-import com.sap.sgs.phosphor.fosstars.data.github.ProjectStarted;
 import com.sap.sgs.phosphor.fosstars.data.github.ScansForVulnerableDependencies;
 import com.sap.sgs.phosphor.fosstars.data.github.UsesDependabot;
 import com.sap.sgs.phosphor.fosstars.data.github.UsesFindSecBugs;
@@ -116,7 +115,6 @@ class SingleSecurityRatingCalculator extends AbstractRatingCalculator {
         new NumberOfContributors(fetcher),
         new NumberOfStars(fetcher),
         new NumberOfWatchers(fetcher),
-        new ProjectStarted(fetcher),
         new HasSecurityTeam(fetcher),
         new HasCompanySupport(fetcher),
         new HasSecurityPolicy(fetcher),

--- a/src/main/jupyter/oss/security/commons.py
+++ b/src/main/jupyter/oss/security/commons.py
@@ -22,7 +22,7 @@ def load_test_vectors_from_yaml(file, features):
     rows = []
     with open(file, 'r') as f:
         raw_data = yaml.load(f)
-        for raw in raw_data:
+        for raw in raw_data['elements']:
             data = {}
             data['alias'] = raw['alias']
             for value in raw['values']:

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
@@ -114,10 +114,6 @@ elements:
       name: "Number of contributors in the last three months"
   - type: "UnknownValue"
     feature:
-      type: "DateFeature"
-      name: "When a project started"
-  - type: "UnknownValue"
-    feature:
       type: "LgtmGradeFeature"
       name: "The worst LGTM grade of a project"
   - type: "UnknownValue"
@@ -156,11 +152,6 @@ elements:
 #
 - type: "StandardTestVector"
   values:
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-21T23:00:00.000+0000"
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
@@ -270,11 +261,6 @@ elements:
       type: "BooleanFeature"
       name: "If an open-source project has a security policy"
     flag: true
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-21T23:00:00.000+0000"
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
@@ -409,11 +395,6 @@ elements:
       type: "BooleanFeature"
       name: "If an open-source project has a security policy"
     flag: false
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-21T23:00:00.000+0000"
   - type: "IntegerValue"
     feature:
       type: "PositiveIntegerFeature"

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTestVectors.yml
@@ -70,15 +70,6 @@ elements:
     confidence: 10.0
     usedValues: []
     explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "VulnerabilityLifetimeScore"
-      name: "How fast vulnerabilities are patched"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -153,15 +144,6 @@ elements:
     explanation: []
   - type: "ScoreValue"
     score:
-      type: "VulnerabilityLifetimeScore"
-      name: "How fast vulnerabilities are patched"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
       type: "ProjectPopularityScore"
       name: "Open-source project popularity score"
     value: 5.0
@@ -174,7 +156,7 @@ elements:
     from: 1.0
     openLeft: false
     negativeInfinity: false
-    to: 2.0
+    to: 2.2
     openRight: false
     positiveInfinity: false
   expectedLabel: null
@@ -227,15 +209,6 @@ elements:
     score:
       type: "ProjectActivityScore"
       name: "Open-source project activity score"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "VulnerabilityLifetimeScore"
-      name: "How fast vulnerabilities are patched"
     value: 5.0
     weight: 1.0
     confidence: 10.0
@@ -333,15 +306,6 @@ elements:
     explanation: []
   - type: "ScoreValue"
     score:
-      type: "VulnerabilityLifetimeScore"
-      name: "How fast vulnerabilities are patched"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
       type: "ProjectPopularityScore"
       name: "Open-source project popularity score"
     value: 10.0
@@ -351,10 +315,10 @@ elements:
     explanation: []
   expectedScore:
     type: "DoubleInterval"
-    from: 2.0
+    from: 3.0
     openLeft: false
     negativeInfinity: false
-    to: 4.0
+    to: 4.5
     openRight: false
     positiveInfinity: false
   expectedLabel: null
@@ -398,15 +362,6 @@ elements:
     score:
       type: "ProjectActivityScore"
       name: "Open-source project activity score"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "VulnerabilityLifetimeScore"
-      name: "How fast vulnerabilities are patched"
     value: 5.0
     weight: 1.0
     confidence: 10.0
@@ -513,15 +468,6 @@ elements:
     explanation: []
   - type: "ScoreValue"
     score:
-      type: "VulnerabilityLifetimeScore"
-      name: "How fast vulnerabilities are patched"
-    value: 8.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
       type: "ProjectPopularityScore"
       name: "Open-source project popularity score"
     value: 5.0
@@ -594,15 +540,6 @@ elements:
     explanation: []
   - type: "ScoreValue"
     score:
-      type: "VulnerabilityLifetimeScore"
-      name: "How fast vulnerabilities are patched"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
       type: "CommunityCommitmentScore"
       name: "How well open-source community commits to support an open-source project"
     value: 5.0
@@ -669,15 +606,6 @@ elements:
       type: "ProjectPopularityScore"
       name: "Open-source project popularity score"
     value: 7.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "VulnerabilityLifetimeScore"
-      name: "How fast vulnerabilities are patched"
-    value: 10.0
     weight: 1.0
     confidence: 10.0
     usedValues: []
@@ -774,15 +702,6 @@ elements:
     explanation: []
   - type: "ScoreValue"
     score:
-      type: "VulnerabilityLifetimeScore"
-      name: "How fast vulnerabilities are patched"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
       type: "ProjectActivityScore"
       name: "Open-source project activity score"
     value: 7.0
@@ -857,15 +776,6 @@ elements:
     score:
       type: "ProjectActivityScore"
       name: "Open-source project activity score"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "VulnerabilityLifetimeScore"
-      name: "How fast vulnerabilities are patched"
     value: 10.0
     weight: 1.0
     confidence: 10.0

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore_1_0.json
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore_1_0.json
@@ -14,9 +14,6 @@
     "type" : "ProjectSecurityAwarenessScore",
     "name" : "How well open-source community is aware about security"
   }, {
-    "type" : "VulnerabilityLifetimeScore",
-    "name" : "How fast vulnerabilities are patched"
-  }, {
     "type" : "ProjectSecurityTestingScore",
     "name" : "How well security testing is done for an open-source project",
     "subScores" : [ {
@@ -51,10 +48,6 @@
       "com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore" : {
         "type" : "MutableWeight",
         "value" : 0.8362090433439393
-      },
-      "com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityLifetimeScore" : {
-        "type" : "MutableWeight",
-        "value" : 0.22939855566110368
       },
       "com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore" : {
         "type" : "MutableWeight",

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScoreTestVectors.yml
@@ -7,10 +7,6 @@ elements:
     feature:
       type: "VulnerabilitiesInProject"
       name: "Info about vulnerabilities in open-source project"
-  - type: "UnknownValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -27,11 +23,6 @@ elements:
     feature:
       type: "VulnerabilitiesInProject"
       name: "Info about vulnerabilities in open-source project"
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-20T23:00:00.000+0000"
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -50,11 +41,6 @@ elements:
     feature:
       type: "VulnerabilitiesInProject"
       name: "Info about vulnerabilities in open-source project"
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-20T23:00:00.000+0000"
   expectedScore:
     type: "DoubleInterval"
     from: 9.0
@@ -153,11 +139,6 @@ elements:
     feature:
       type: "VulnerabilitiesInProject"
       name: "Info about vulnerabilities in open-source project"
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-20T23:00:00.000+0000"
   expectedScore:
     type: "DoubleInterval"
     from: 9.0
@@ -256,11 +237,6 @@ elements:
     feature:
       type: "VulnerabilitiesInProject"
       name: "Info about vulnerabilities in open-source project"
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-20T23:00:00.000+0000"
   expectedScore:
     type: "DoubleInterval"
     from: 7.0
@@ -359,11 +335,6 @@ elements:
     feature:
       type: "VulnerabilitiesInProject"
       name: "Info about vulnerabilities in open-source project"
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-20T23:00:00.000+0000"
   expectedScore:
     type: "DoubleInterval"
     from: 4.0
@@ -462,11 +433,6 @@ elements:
     feature:
       type: "VulnerabilitiesInProject"
       name: "Info about vulnerabilities in open-source project"
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-20T23:00:00.000+0000"
   expectedScore:
     type: "DoubleInterval"
     from: 1.0
@@ -479,11 +445,6 @@ elements:
   alias: "test_vector_6"
 - type: "StandardTestVector"
   values:
-  - type: "DateValue"
-    feature:
-      type: "DateFeature"
-      name: "When a project started"
-    date: "2015-03-20T23:00:00.000+0000"
   - type: "VulnerabilitiesValue"
     vulnerabilities:
       entries:

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScoreTest.java
@@ -1,7 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
 import static com.sap.sgs.phosphor.fosstars.TestUtils.assertScore;
-import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
 import static org.junit.Assert.assertEquals;
@@ -17,7 +16,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Locale;
 import java.util.Set;
 import org.junit.Test;
@@ -52,15 +50,7 @@ public class VulnerabilityLifetimeScoreTest {
                 Resolution.PATCHED,
                 DATE_FORMAT.parse("01/01/2020"),
                 DATE_FORMAT.parse("01/05/2020")
-        ))),
-        PROJECT_START_DATE.value(new Date()));
-    assertScore(Score.INTERVAL, VULNERABILITY_LIFETIME_SCORE, values);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void noInfoAboutVulnerabilities() {
-    Set<Value> values = setOf(
-        PROJECT_START_DATE.value(new Date()));
+        ))));
     assertScore(Score.INTERVAL, VULNERABILITY_LIFETIME_SCORE, values);
   }
 

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScoreVerification.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScoreVerification.java
@@ -1,23 +1,14 @@
 package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
-import static org.junit.Assert.assertTrue;
-
-import com.sap.sgs.phosphor.fosstars.model.RatingRepository;
 import com.sap.sgs.phosphor.fosstars.model.qa.VerificationFailedException;
-import com.sap.sgs.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 import java.io.IOException;
-import java.util.Optional;
 import org.junit.Test;
 
 public class VulnerabilityLifetimeScoreVerification {
 
   @Test
   public void verify() throws IOException, VerificationFailedException {
-    OssSecurityRating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
-    Optional<VulnerabilityLifetimeScore> something
-        = rating.score().subScore(VulnerabilityLifetimeScore.class);
-    assertTrue(something.isPresent());
-    VulnerabilityLifetimeScore.Verification.createFor(something.get()).run();
+    VulnerabilityLifetimeScore.Verification.createFor(new VulnerabilityLifetimeScore()).run();
   }
 
 }


### PR DESCRIPTION
Here is a list of updates:

- Disabled analyzing NVD in `UnpatchedVulnerabilities` data provider.
- Updated `VulnerabilityLifetimeScore` not to estimate dates.
- Removed `VulnerabilityLifetimeScore` from `OssSecurityScore`.
- Disabled `ProjectStarted` provider in the demo tool.
- Updated the existing tests and test vectors.
- Updated docs.

This closes #191