### PR TITLE
Multiple bug fixes in the data providers

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/ScansForVulnerableDependencies.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/ScansForVulnerableDependencies.java
@@ -1,26 +1,28 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
+import static java.lang.Boolean.FALSE;
 
 import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
 /**
- * This data provider tries to fill out the
- * {@link
- * com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#SCANS_FOR_VULNERABLE_DEPENDENCIES}.
- * feature.
- * It is based on a number of data providers:
+ * This data provider tries to fill out the {@link OssFeatures#SCANS_FOR_VULNERABLE_DEPENDENCIES}.
+ * feature. It is based on the following data providers:
  * <ul>
  *   <li>{@link UsesOwaspDependencyCheck}</li>
  * </ul>
  */
 public class ScansForVulnerableDependencies extends CachedSingleFeatureGitHubDataProvider {
 
+  /**
+   * A list of underlying data providers.
+   */
   private final List<CachedSingleFeatureGitHubDataProvider> providers;
 
   /**
@@ -43,12 +45,12 @@ public class ScansForVulnerableDependencies extends CachedSingleFeatureGitHubDat
   @Override
   protected Value fetchValueFor(GitHubProject project) throws IOException {
     for (CachedSingleFeatureGitHubDataProvider provider : providers) {
-      Value value = provider.fetchValueFor(project);
-      if (!value.isUnknown() && Boolean.TRUE.equals(value.get())) {
+      Value<Boolean> value = provider.fetchValueFor(project);
+      if (value.orElse(FALSE)) {
         return SCANS_FOR_VULNERABLE_DEPENDENCIES.value(true);
       }
     }
 
-    return SCANS_FOR_VULNERABLE_DEPENDENCIES.unknown();
+    return SCANS_FOR_VULNERABLE_DEPENDENCIES.value(false);
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesGithubForDevelopment.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesGithubForDevelopment.java
@@ -24,7 +24,7 @@ public class UsesGithubForDevelopment extends CachedSingleFeatureGitHubDataProvi
    * This threshold shows how many checks have to be passed to say that a project uses GitHub
    * for development.
    */
-  static final double CONFIDENCE_THRESHOLD = 0.6;
+  private static final double CONFIDENCE_THRESHOLD = 0.6;
 
   /**
    * A list of checks to figure out if a project uses GitHub for development.
@@ -32,7 +32,10 @@ public class UsesGithubForDevelopment extends CachedSingleFeatureGitHubDataProvi
   private static final List<Predicate<GHRepository>> CHECKS = Arrays.asList(
 
       // check if the description mentions "mirror"
-      repository -> !repository.getDescription().toLowerCase().contains("mirror"),
+      repository -> {
+        String description = repository.getDescription();
+        return StringUtils.isEmpty(description) || !description.toLowerCase().contains("mirror");
+      },
 
       // if GitHub issues are enabled, then it's likely that the project uses GitHub
       GHRepository::hasIssues,


### PR DESCRIPTION
Here is a list of updates:

- Updated `ScansForVulnerableDependencies` data provider to return false if no scanner found. This closes #203.
- Improved `UsesSanitizers` data provider. This closes #195.
- Updated `UsesGithubForDevelopment` data provider to expect empty descriptions. This closes #204.