### PR TITLE
Simplify test vectors for scores

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/AbstractTestVector.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/AbstractTestVector.java
@@ -1,0 +1,106 @@
+package com.sap.sgs.phosphor.fosstars.model.qa;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.sap.sgs.phosphor.fosstars.model.Interval;
+import com.sap.sgs.phosphor.fosstars.model.Label;
+import java.util.Objects;
+
+/**
+ * A base class for test vectors.
+ */
+public abstract class AbstractTestVector implements TestVector {
+
+  /**
+   * An interval for an expected score.
+   */
+  final Interval expectedScore;
+
+  /**
+   * If it's set to true, then a not-applicable score value is expected.
+   */
+  final boolean expectedNotApplicableScore;
+
+  /**
+   * An expected label.
+   */
+  final Label expectedLabel;
+
+  /**
+   * An alias of the test vector.
+   */
+  final String alias;
+
+  /**
+   * Initializes a new {@link StandardTestVector}.
+   *
+   * @param expectedScore An interval for an expected score.
+   * @param expectedLabel An expected label (can be null).
+   * @param alias A alias of the test vector.
+   * @param expectedNotApplicableScore
+   *        If it's set to true, then a not-applicable score value is expected.
+   */
+  AbstractTestVector(Interval expectedScore, Label expectedLabel, String alias,
+      boolean expectedNotApplicableScore) {
+
+    Objects.requireNonNull(alias, "Hey! alias can't be null!");
+
+    if (expectedScore == null && !expectedNotApplicableScore) {
+      throw new IllegalArgumentException(
+          "Hey! Expected score can't be null unless a not-applicable value is expected!");
+    }
+
+    this.expectedScore = expectedScore;
+    this.expectedLabel = expectedLabel;
+    this.alias = alias;
+    this.expectedNotApplicableScore = expectedNotApplicableScore;
+  }
+
+  @Override
+  @JsonGetter("expectedScore")
+  public final Interval expectedScore() {
+    return expectedScore;
+  }
+
+  @Override
+  @JsonGetter("expectedNotApplicableScore")
+  public boolean expectsNotApplicableScore() {
+    return expectedNotApplicableScore;
+  }
+
+  @Override
+  public boolean hasLabel() {
+    return expectedLabel != NO_LABEL;
+  }
+
+  @Override
+  @JsonGetter("expectedLabel")
+  public final Label expectedLabel() {
+    return expectedLabel;
+  }
+
+  @Override
+  @JsonGetter("alias")
+  public final String alias() {
+    return alias;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o instanceof AbstractTestVector == false) {
+      return false;
+    }
+    AbstractTestVector that = (AbstractTestVector) o;
+    return expectedNotApplicableScore == that.expectedNotApplicableScore
+        && Objects.equals(expectedScore, that.expectedScore)
+        && Objects.equals(expectedLabel, that.expectedLabel)
+        && Objects.equals(alias, that.alias);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(expectedScore, expectedNotApplicableScore, expectedLabel, alias);
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreTestVector.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreTestVector.java
@@ -1,0 +1,101 @@
+package com.sap.sgs.phosphor.fosstars.model.qa;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sap.sgs.phosphor.fosstars.model.Interval;
+import com.sap.sgs.phosphor.fosstars.model.Label;
+import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A test vector for a score.
+ */
+public class ScoreTestVector extends AbstractTestVector {
+
+  /**
+   * Maps score classes to its values.
+   */
+  private final Map<Class<? extends Score>, Double> values;
+
+  /**
+   * Initializes a new {@link ScoreTestVector}.
+   *
+   * @param values A map of score values.
+   * @param expectedScore An interval for an expected score.
+   * @param expectedLabel An expected label (can be null).
+   * @param alias A alias of the test vector.
+   * @param expectedNotApplicableScore
+   *        If it's set to true, then a not-applicable score value is expected.
+   */
+  @JsonCreator
+  public ScoreTestVector(
+      @JsonProperty("values") Map<Class<? extends Score>, Double> values,
+      @JsonProperty("expectedScore") Interval expectedScore,
+      @JsonProperty("expectedLabel") Label expectedLabel,
+      @JsonProperty("alias") String alias,
+      @JsonProperty(
+          value = "expectedNotApplicableScore",
+          defaultValue = "false") boolean expectedNotApplicableScore) {
+
+    super(expectedScore, expectedLabel, alias, expectedNotApplicableScore);
+
+    Objects.requireNonNull(values, "Hey! Values can't be null!");
+
+    if (values.isEmpty()) {
+      throw new IllegalArgumentException("Hey! Values can't be empty");
+    }
+
+    this.values = values;
+  }
+
+  @Override
+  public Set<Value> values() {
+    throw new UnsupportedOperationException("I need a score to create values!");
+  }
+
+  @Override
+  public Set<Value> valuesFor(Score score) {
+    Objects.requireNonNull(score, "Oh no! Score is null!");
+
+    Set<Value> result = new HashSet<>();
+    for (Map.Entry<Class<? extends Score>, Double> entry : values.entrySet()) {
+      Score subScore = subScore(score, entry.getKey());
+      Value value = subScore.value(entry.getValue());
+      result.add(value);
+    }
+
+    return result;
+  }
+
+  /*
+   * This getter is necessary for serialization.
+   */
+  @JsonGetter("values")
+  private Map<Class<? extends Score>, Double> rawValues() {
+    return values;
+  }
+
+  /**
+   * Looks for a sub-score in a score.
+   *
+   * @param score The score.
+   * @param scoreClass A class of the sub-score.
+   * @return The sub-score if it's found.
+   * @throws IllegalArgumentException If no sub-score found.
+   */
+  private static Score subScore(Score score, Class<? extends Score> scoreClass) {
+    for (Score subScore : score.subScores()) {
+      if (scoreClass.equals(subScore.getClass())) {
+        return subScore;
+      }
+    }
+
+    throw new IllegalArgumentException(
+        String.format("Could not fine sub-score %s!", scoreClass.getCanonicalName()));
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreVerifier.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreVerifier.java
@@ -34,7 +34,7 @@ public class ScoreVerifier extends AbstractVerifier {
 
     int index = 0;
     for (TestVector vector : vectors) {
-      ScoreValue scoreValue = score.calculate(vector.values());
+      ScoreValue scoreValue = score.calculate(vector.valuesFor(score));
       results.add(testResultFor(vector, scoreValue, index++));
     }
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/StandardTestVector.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/StandardTestVector.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sap.sgs.phosphor.fosstars.model.Interval;
 import com.sap.sgs.phosphor.fosstars.model.Label;
+import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import java.util.Collections;
 import java.util.Objects;
@@ -13,32 +14,12 @@ import java.util.Set;
 /**
  * A standard test vector for a rating or a score. The class is immutable.
  */
-public class StandardTestVector implements TestVector {
+public class StandardTestVector extends AbstractTestVector {
 
   /**
    * A set of feature values.
    */
   private final Set<Value> values;
-
-  /**
-   * An interval for an expected score.
-   */
-  private final Interval expectedScore;
-
-  /**
-   * If it's set to true, then a not-applicable score value is expected.
-   */
-  private final boolean expectedNotApplicableScore;
-
-  /**
-   * An expected label.
-   */
-  private final Label expectedLabel;
-
-  /**
-   * An alias of the test vector.
-   */
-  private final String alias;
 
   /**
    * Initializes a new {@link StandardTestVector}.
@@ -74,23 +55,15 @@ public class StandardTestVector implements TestVector {
           value = "expectedNotApplicableScore",
           defaultValue = "false") boolean expectedNotApplicableScore) {
 
+    super(expectedScore, expectedLabel, alias, expectedNotApplicableScore);
+
     Objects.requireNonNull(values, "Hey! Values can't be null!");
-    Objects.requireNonNull(alias, "Hey! alias can't be null!");
 
     if (values.isEmpty()) {
       throw new IllegalArgumentException("Hey! Values can't be empty");
     }
 
-    if (expectedScore == null && !expectedNotApplicableScore) {
-      throw new IllegalArgumentException(
-          "Hey! Expected score can't be null unless a not-applicable value is expected!");
-    }
-
     this.values = values;
-    this.expectedScore = expectedScore;
-    this.expectedLabel = expectedLabel;
-    this.alias = alias;
-    this.expectedNotApplicableScore = expectedNotApplicableScore;
   }
 
   @Override
@@ -100,32 +73,8 @@ public class StandardTestVector implements TestVector {
   }
 
   @Override
-  @JsonGetter("expectedScore")
-  public final Interval expectedScore() {
-    return expectedScore;
-  }
-
-  @Override
-  @JsonGetter("expectedNotApplicableScore")
-  public boolean expectsNotApplicableScore() {
-    return expectedNotApplicableScore;
-  }
-
-  @Override
-  public boolean hasLabel() {
-    return expectedLabel != NO_LABEL;
-  }
-
-  @Override
-  @JsonGetter("expectedLabel")
-  public final Label expectedLabel() {
-    return expectedLabel;
-  }
-
-  @Override
-  @JsonGetter("alias")
-  public final String alias() {
-    return alias;
+  public Set<Value> valuesFor(Score score) {
+    return values();
   }
 
   @Override
@@ -136,16 +85,15 @@ public class StandardTestVector implements TestVector {
     if (o instanceof StandardTestVector == false) {
       return false;
     }
-    StandardTestVector vector = (StandardTestVector) o;
-    return Objects.equals(values, vector.values)
-        && Objects.equals(expectedScore, vector.expectedScore)
-        && Objects.equals(expectedLabel, vector.expectedLabel)
-        && Objects.equals(alias, vector.alias);
+    if (!super.equals(o)) {
+      return false;
+    }
+    StandardTestVector that = (StandardTestVector) o;
+    return Objects.equals(values, that.values);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(values, expectedScore, expectedLabel, alias);
+    return Objects.hash(super.hashCode(), values);
   }
-
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVector.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVector.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sap.sgs.phosphor.fosstars.model.Interval;
 import com.sap.sgs.phosphor.fosstars.model.Label;
+import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import java.util.Set;
 
@@ -14,7 +15,8 @@ import java.util.Set;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = StandardTestVector.class)
+    @JsonSubTypes.Type(value = StandardTestVector.class),
+    @JsonSubTypes.Type(value = ScoreTestVector.class)
 })
 public interface TestVector {
 
@@ -24,9 +26,17 @@ public interface TestVector {
   Label NO_LABEL = null;
 
   /**
-   * Returns feature values.
+   * Returns the values.
    */
   Set<Value> values();
+
+  /**
+   * Returns the values resolved for a specified score.
+   *
+   * @param score The score.
+   * @return The values.
+   */
+  Set<Value> valuesFor(Score score);
 
   /**
    * Returns an expected score.

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorWithDefaults.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorWithDefaults.java
@@ -2,6 +2,7 @@ package com.sap.sgs.phosphor.fosstars.model.qa;
 
 import com.sap.sgs.phosphor.fosstars.model.Interval;
 import com.sap.sgs.phosphor.fosstars.model.Label;
+import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
 import java.util.Objects;
@@ -29,7 +30,7 @@ public class TestVectorWithDefaults implements TestVector {
    * @param vector A test vector to be wrapped.
    * @param defaults A set of default values.
    */
-  public TestVectorWithDefaults(TestVector vector, Set<Value> defaults) {
+  TestVectorWithDefaults(TestVector vector, Set<Value> defaults) {
     Objects.requireNonNull(vector, "Hey! Vector can't be null!");
     Objects.requireNonNull(defaults, "Hey! Defaults can't be null!");
     this.vector = vector;
@@ -52,6 +53,11 @@ public class TestVectorWithDefaults implements TestVector {
       }
     }
     return values.toSet();
+  }
+
+  @Override
+  public Set<Value> valuesFor(Score score) {
+    return vector.valuesFor(score);
   }
 
   @Override

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectors.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectors.java
@@ -74,7 +74,7 @@ public class TestVectors implements Iterable<TestVector> {
    */
   public TestVectors(
       @JsonProperty("elements") List<TestVector> vectors,
-      @JsonProperty(value = "defaults") Set<Value> defaults) {
+      @JsonProperty("defaults") Set<Value> defaults) {
 
     Objects.requireNonNull(vectors, "Hey! Vectors can't be null!");
     Objects.requireNonNull(defaults, "Hey! Defaults can't be null!");
@@ -123,6 +123,7 @@ public class TestVectors implements Iterable<TestVector> {
   /**
    * Returns a size of the collection.
    */
+  @JsonIgnore
   public int size() {
     return elements.size();
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore.java
@@ -67,5 +67,4 @@ public class OssSecurityScore extends WeightedCompositeScore {
       }
     }
   }
-
 }

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTestVectors.yml
@@ -1,811 +1,193 @@
 ---
 defaults: []
 elements:
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityTestingScore"
-      name: "How well security testing is done for an open-source project"
-      subScores:
-      - type: "DependencyScanScore"
-        name: "How a project scans its dependencies for vulnerabilities"
-      - type: "LgtmScore"
-        name: "How a project addresses issues reported by LGTM"
-      - type: "NoHttpToolScore"
-        name: "If a project uses nohttp tool"
-      - type: "MemorySafetyTestingScore"
-        name: "How a project tests for memory-safety issues"
-      - type: "FindSecBugsScore"
-        name: "How a project uses FindSecBugs"
-      - type: "FuzzingScore"
-        name: "How a project uses fuzzing"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectPopularityScore"
-      name: "Open-source project popularity score"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "CommunityCommitmentScore"
-      name: "How well open-source community commits to support an open-source project"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "UnpatchedVulnerabilitiesScore"
-      name: "How well vulnerabilities are patched"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityAwarenessScore"
-      name: "How well open-source community is aware about security"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectActivityScore"
-      name: "Open-source project activity score"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 0.0
-    openLeft: false
-    negativeInfinity: false
-    to: 0.5
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_0"
-
-#
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityTestingScore"
-      name: "How well security testing is done for an open-source project"
-      subScores:
-      - type: "DependencyScanScore"
-        name: "How a project scans its dependencies for vulnerabilities"
-      - type: "LgtmScore"
-        name: "How a project addresses issues reported by LGTM"
-      - type: "NoHttpToolScore"
-        name: "If a project uses nohttp tool"
-      - type: "MemorySafetyTestingScore"
-        name: "How a project tests for memory-safety issues"
-      - type: "FindSecBugsScore"
-        name: "How a project uses FindSecBugs"
-      - type: "FuzzingScore"
-        name: "How a project uses fuzzing"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "UnpatchedVulnerabilitiesScore"
-      name: "How well vulnerabilities are patched"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectActivityScore"
-      name: "Open-source project activity score"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "CommunityCommitmentScore"
-      name: "How well open-source community commits to support an open-source project"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityAwarenessScore"
-      name: "How well open-source community is aware about security"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectPopularityScore"
-      name: "Open-source project popularity score"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 1.0
-    openLeft: false
-    negativeInfinity: false
-    to: 2.2
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_1"
-
-#
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "UnpatchedVulnerabilitiesScore"
-      name: "How well vulnerabilities are patched"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityTestingScore"
-      name: "How well security testing is done for an open-source project"
-      subScores:
-      - type: "DependencyScanScore"
-        name: "How a project scans its dependencies for vulnerabilities"
-      - type: "LgtmScore"
-        name: "How a project addresses issues reported by LGTM"
-      - type: "NoHttpToolScore"
-        name: "If a project uses nohttp tool"
-      - type: "MemorySafetyTestingScore"
-        name: "How a project tests for memory-safety issues"
-      - type: "FindSecBugsScore"
-        name: "How a project uses FindSecBugs"
-      - type: "FuzzingScore"
-        name: "How a project uses fuzzing"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityAwarenessScore"
-      name: "How well open-source community is aware about security"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectActivityScore"
-      name: "Open-source project activity score"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "CommunityCommitmentScore"
-      name: "How well open-source community commits to support an open-source project"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectPopularityScore"
-      name: "Open-source project popularity score"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 3.0
-    openLeft: false
-    negativeInfinity: false
-    to: 5.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_2"
-
-#
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityTestingScore"
-      name: "How well security testing is done for an open-source project"
-      subScores:
-      - type: "DependencyScanScore"
-        name: "How a project scans its dependencies for vulnerabilities"
-      - type: "LgtmScore"
-        name: "How a project addresses issues reported by LGTM"
-      - type: "NoHttpToolScore"
-        name: "If a project uses nohttp tool"
-      - type: "MemorySafetyTestingScore"
-        name: "How a project tests for memory-safety issues"
-      - type: "FindSecBugsScore"
-        name: "How a project uses FindSecBugs"
-      - type: "FuzzingScore"
-        name: "How a project uses fuzzing"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "UnpatchedVulnerabilitiesScore"
-      name: "How well vulnerabilities are patched"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectActivityScore"
-      name: "Open-source project activity score"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "CommunityCommitmentScore"
-      name: "How well open-source community commits to support an open-source project"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityAwarenessScore"
-      name: "How well open-source community is aware about security"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectPopularityScore"
-      name: "Open-source project popularity score"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 3.0
-    openLeft: false
-    negativeInfinity: false
-    to: 4.5
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_3"
-
-#
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityTestingScore"
-      name: "How well security testing is done for an open-source project"
-      subScores:
-      - type: "DependencyScanScore"
-        name: "How a project scans its dependencies for vulnerabilities"
-      - type: "LgtmScore"
-        name: "How a project addresses issues reported by LGTM"
-      - type: "NoHttpToolScore"
-        name: "If a project uses nohttp tool"
-      - type: "MemorySafetyTestingScore"
-        name: "How a project tests for memory-safety issues"
-      - type: "FindSecBugsScore"
-        name: "How a project uses FindSecBugs"
-      - type: "FuzzingScore"
-        name: "How a project uses fuzzing"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "UnpatchedVulnerabilitiesScore"
-      name: "How well vulnerabilities are patched"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectActivityScore"
-      name: "Open-source project activity score"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "CommunityCommitmentScore"
-      name: "How well open-source community commits to support an open-source project"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityAwarenessScore"
-      name: "How well open-source community is aware about security"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectPopularityScore"
-      name: "Open-source project popularity score"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 4.0
-    openLeft: false
-    negativeInfinity: false
-    to: 5.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_4"
-
-#
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityTestingScore"
-      name: "How well security testing is done for an open-source project"
-      subScores:
-      - type: "DependencyScanScore"
-        name: "How a project scans its dependencies for vulnerabilities"
-      - type: "LgtmScore"
-        name: "How a project addresses issues reported by LGTM"
-      - type: "NoHttpToolScore"
-        name: "If a project uses nohttp tool"
-      - type: "MemorySafetyTestingScore"
-        name: "How a project tests for memory-safety issues"
-      - type: "FindSecBugsScore"
-        name: "How a project uses FindSecBugs"
-      - type: "FuzzingScore"
-        name: "How a project uses fuzzing"
-    value: 8.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "UnpatchedVulnerabilitiesScore"
-      name: "How well vulnerabilities are patched"
-    value: 8.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectActivityScore"
-      name: "Open-source project activity score"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "CommunityCommitmentScore"
-      name: "How well open-source community commits to support an open-source project"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityAwarenessScore"
-      name: "How well open-source community is aware about security"
-    value: 8.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectPopularityScore"
-      name: "Open-source project popularity score"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 6.0
-    openLeft: false
-    negativeInfinity: false
-    to: 8.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_5"
-
-#
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "UnpatchedVulnerabilitiesScore"
-      name: "How well vulnerabilities are patched"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityTestingScore"
-      name: "How well security testing is done for an open-source project"
-      subScores:
-      - type: "DependencyScanScore"
-        name: "How a project scans its dependencies for vulnerabilities"
-      - type: "LgtmScore"
-        name: "How a project addresses issues reported by LGTM"
-      - type: "NoHttpToolScore"
-        name: "If a project uses nohttp tool"
-      - type: "MemorySafetyTestingScore"
-        name: "How a project tests for memory-safety issues"
-      - type: "FindSecBugsScore"
-        name: "How a project uses FindSecBugs"
-      - type: "FuzzingScore"
-        name: "How a project uses fuzzing"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityAwarenessScore"
-      name: "How well open-source community is aware about security"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectActivityScore"
-      name: "Open-source project activity score"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "CommunityCommitmentScore"
-      name: "How well open-source community commits to support an open-source project"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectPopularityScore"
-      name: "Open-source project popularity score"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 7.0
-    openLeft: false
-    negativeInfinity: false
-    to: 8.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_6"
-
-#
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityTestingScore"
-      name: "How well security testing is done for an open-source project"
-      subScores:
-      - type: "DependencyScanScore"
-        name: "How a project scans its dependencies for vulnerabilities"
-      - type: "LgtmScore"
-        name: "How a project addresses issues reported by LGTM"
-      - type: "NoHttpToolScore"
-        name: "If a project uses nohttp tool"
-      - type: "MemorySafetyTestingScore"
-        name: "How a project tests for memory-safety issues"
-      - type: "FindSecBugsScore"
-        name: "How a project uses FindSecBugs"
-      - type: "FuzzingScore"
-        name: "How a project uses fuzzing"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "UnpatchedVulnerabilitiesScore"
-      name: "How well vulnerabilities are patched"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectPopularityScore"
-      name: "Open-source project popularity score"
-    value: 7.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityAwarenessScore"
-      name: "How well open-source community is aware about security"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectActivityScore"
-      name: "Open-source project activity score"
-    value: 7.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "CommunityCommitmentScore"
-      name: "How well open-source community commits to support an open-source project"
-    value: 7.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 5.0
-    openLeft: false
-    negativeInfinity: false
-    to: 6.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_7"
-
-#
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "UnpatchedVulnerabilitiesScore"
-      name: "How well vulnerabilities are patched"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityTestingScore"
-      name: "How well security testing is done for an open-source project"
-      subScores:
-      - type: "DependencyScanScore"
-        name: "How a project scans its dependencies for vulnerabilities"
-      - type: "LgtmScore"
-        name: "How a project addresses issues reported by LGTM"
-      - type: "NoHttpToolScore"
-        name: "If a project uses nohttp tool"
-      - type: "MemorySafetyTestingScore"
-        name: "How a project tests for memory-safety issues"
-      - type: "FindSecBugsScore"
-        name: "How a project uses FindSecBugs"
-      - type: "FuzzingScore"
-        name: "How a project uses fuzzing"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityAwarenessScore"
-      name: "How well open-source community is aware about security"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectPopularityScore"
-      name: "Open-source project popularity score"
-    value: 7.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectActivityScore"
-      name: "Open-source project activity score"
-    value: 7.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "CommunityCommitmentScore"
-      name: "How well open-source community commits to support an open-source project"
-    value: 7.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 8.0
-    openLeft: false
-    negativeInfinity: false
-    to: 9.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_8"
-
-#
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "UnpatchedVulnerabilitiesScore"
-      name: "How well vulnerabilities are patched"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityTestingScore"
-      name: "How well security testing is done for an open-source project"
-      subScores:
-      - type: "DependencyScanScore"
-        name: "How a project scans its dependencies for vulnerabilities"
-      - type: "LgtmScore"
-        name: "How a project addresses issues reported by LGTM"
-      - type: "NoHttpToolScore"
-        name: "If a project uses nohttp tool"
-      - type: "MemorySafetyTestingScore"
-        name: "How a project tests for memory-safety issues"
-      - type: "FindSecBugsScore"
-        name: "How a project uses FindSecBugs"
-      - type: "FuzzingScore"
-        name: "How a project uses fuzzing"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectSecurityAwarenessScore"
-      name: "How well open-source community is aware about security"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectActivityScore"
-      name: "Open-source project activity score"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "CommunityCommitmentScore"
-      name: "How well open-source community commits to support an open-source project"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "ProjectPopularityScore"
-      name: "Open-source project popularity score"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 9.9
-    openLeft: false
-    negativeInfinity: false
-    to: 10.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_9"
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 0.0
+      openLeft: false
+      negativeInfinity: false
+      to: 0.5
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_0"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 1.0
+      openLeft: false
+      negativeInfinity: false
+      to: 2.2
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_1"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 5.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 3.0
+      openLeft: false
+      negativeInfinity: false
+      to: 5.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_2"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 3.0
+      openLeft: false
+      negativeInfinity: false
+      to: 4.5
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_3"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 4.0
+      openLeft: false
+      negativeInfinity: false
+      to: 5.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_4"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore: 8.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore: 8.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 8.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 6.0
+      openLeft: false
+      negativeInfinity: false
+      to: 8.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_5"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 10.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 7.0
+      openLeft: false
+      negativeInfinity: false
+      to: 8.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_6"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore: 7.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 7.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 7.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 5.0
+      openLeft: false
+      negativeInfinity: false
+      to: 6.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_7"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore: 7.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 7.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 7.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 10.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 8.0
+      openLeft: false
+      negativeInfinity: false
+      to: 9.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_8"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 10.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 9.9
+      openLeft: false
+      negativeInfinity: false
+      to: 10.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_9"
+    expectedNotApplicableScore: false

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreTestVectorTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreTestVectorTest.java
@@ -1,0 +1,76 @@
+package com.sap.sgs.phosphor.fosstars.model.qa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.sap.sgs.phosphor.fosstars.model.Interval;
+import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.math.DoubleInterval;
+import com.sap.sgs.phosphor.fosstars.model.score.example.ExampleScores;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+public class ScoreTestVectorTest {
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testValues() {
+    Map<Class<? extends Score>, Double> values = new HashMap<>();
+    values.put(ExampleScores.PROJECT_ACTIVITY_SCORE_EXAMPLE.getClass(), 5.3);
+    values.put(ExampleScores.SECURITY_TESTING_SCORE_EXAMPLE.getClass(), 4.0);
+
+    Interval expectedScore = DoubleInterval.init().from(4.0).to(6.4).closed().make();
+    ScoreTestVector vector = new ScoreTestVector(
+        values, expectedScore, null, "test", false);
+
+    vector.values();
+  }
+
+  @Test
+  public void testValuesFor() {
+    Map<Class<? extends Score>, Double> values = new HashMap<>();
+    values.put(ExampleScores.PROJECT_ACTIVITY_SCORE_EXAMPLE.getClass(), 5.3);
+    values.put(ExampleScores.SECURITY_TESTING_SCORE_EXAMPLE.getClass(), 4.0);
+
+    Interval expectedScore = DoubleInterval.init().from(4.0).to(6.4).closed().make();
+    ScoreTestVector vector = new ScoreTestVector(
+        values, expectedScore, null, "test", false);
+
+    Set<Value> set = vector.valuesFor(ExampleScores.SECURITY_SCORE_EXAMPLE);
+    assertNotNull(set);
+    assertEquals(2, set.size());
+    assertTrue(set.contains(ExampleScores.PROJECT_ACTIVITY_SCORE_EXAMPLE.value(5.3)));
+    assertTrue(set.contains(ExampleScores.SECURITY_TESTING_SCORE_EXAMPLE.value(4.0)));
+  }
+
+  @Test
+  public void testYamlSerializeAndDeserialize() throws IOException {
+    Map<Class<? extends Score>, Double> values = new HashMap<>();
+    values.put(ExampleScores.PROJECT_ACTIVITY_SCORE_EXAMPLE.getClass(), 5.3);
+    values.put(ExampleScores.SECURITY_TESTING_SCORE_EXAMPLE.getClass(), 4.0);
+
+    Interval expectedScore = DoubleInterval.init().from(4.0).to(6.4).closed().make();
+    ScoreTestVector vector = new ScoreTestVector(
+        values, expectedScore, null, "test", false);
+
+    YAMLFactory factory = new YAMLFactory();
+    factory.disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID);
+    ObjectMapper mapper = new ObjectMapper(factory);
+
+    byte[] bytes = mapper.writeValueAsBytes(vector);
+    assertNotNull(bytes);
+    assertTrue(bytes.length > 0);
+
+    ScoreTestVector clone = mapper.readValue(bytes, ScoreTestVector.class);
+    assertEquals(vector, clone);
+    assertEquals(vector.hashCode(), clone.hashCode());
+  }
+
+}


### PR DESCRIPTION
Here is a list of main updates:

- Added a new `AbstractTestVector` class.
- Added a new `ScoreTestVector` class.
- Added a new `TestVector.valuesFor()` method.
- Updated `ScoreVerified` to use the new `valuesFor()` method.
- Simplified the test vectors for the `OssSecurityScore`.
- Added `ScoreTestVectorTest`.

This closes #211