### PR TITLE
Fix GHFileNotFoundException in GitHubProject.parse()

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProject.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProject.java
@@ -194,7 +194,11 @@ public class GitHubProject implements Project {
       throw new IllegalArgumentException(
           String.format("The URL doesn't seem to be correct: %s", urlString));
     }
-    return new GitHubProject(new GitHubOrganization(parts[1]), parts[2]);
+    String name = parts[2];
+    if (name.endsWith(".git")) {
+      name = name.substring(0, name.length() - 4);
+    }
+    return new GitHubProject(new GitHubOrganization(parts[1]), name);
   }
 
   /**

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectTest.java
@@ -31,4 +31,20 @@ public class GitHubProjectTest {
     assertEquals(project, clone);
     assertEquals(project.hashCode(), clone.hashCode());
   }
+
+  @Test
+  public void parseFromUrl() throws IOException {
+    GitHubProject parsed = GitHubProject.parse("http://github.com/SAP/fosstars-rating-core");
+    assertEquals(parsed.name(), "fosstars-rating-core");
+    assertEquals(parsed.organization().name(), "SAP");
+    assertEquals(parsed.path(), "SAP/fosstars-rating-core");
+  }
+
+  @Test
+  public void parseFromUrlEndsWithDotGit() throws IOException {
+    GitHubProject parsed = GitHubProject.parse("http://github.com/SAP/fosstars-rating-core.git");
+    assertEquals(parsed.name(), "fosstars-rating-core");
+    assertEquals(parsed.organization().name(), "SAP");
+    assertEquals(parsed.path(), "SAP/fosstars-rating-core");
+  }
 }


### PR DESCRIPTION
Fixed parsing url for GitHubProject creation.

This closes #213 