### PR TITLE
ProjectSecurityTestingScore should use weigths

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScore.java
@@ -2,7 +2,7 @@ package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
 import com.sap.sgs.phosphor.fosstars.model.qa.ScoreVerification;
 import com.sap.sgs.phosphor.fosstars.model.qa.TestVectors;
-import com.sap.sgs.phosphor.fosstars.model.score.AverageCompositeScore;
+import com.sap.sgs.phosphor.fosstars.model.score.WeightedCompositeScore;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -19,7 +19,7 @@ import java.io.InputStream;
  * There is plenty room for improvements.
  * The score can take into account a lot of other information.
  */
-public class ProjectSecurityTestingScore extends AverageCompositeScore {
+public class ProjectSecurityTestingScore extends WeightedCompositeScore {
 
   /**
    * Initializes a new score.

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScoreWeights.json
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScoreWeights.json
@@ -1,0 +1,28 @@
+{
+  "values" : {
+    "com.sap.sgs.phosphor.fosstars.model.score.oss.MemorySafetyTestingScore" : {
+      "type" : "ImmutableWeight",
+      "value" : 1.0
+    },
+    "com.sap.sgs.phosphor.fosstars.model.score.oss.FindSecBugsScore" : {
+      "type" : "ImmutableWeight",
+      "value" : 1.0
+    },
+    "com.sap.sgs.phosphor.fosstars.model.score.oss.LgtmScore" : {
+      "type" : "ImmutableWeight",
+      "value" : 1.0
+    },
+    "com.sap.sgs.phosphor.fosstars.model.score.oss.DependencyScanScore" : {
+      "type" : "ImmutableWeight",
+      "value" : 1.0
+    },
+    "com.sap.sgs.phosphor.fosstars.model.score.oss.NoHttpToolScore" : {
+      "type" : "ImmutableWeight",
+      "value" : 0.5
+    },
+    "com.sap.sgs.phosphor.fosstars.model.score.oss.FuzzingScore" : {
+      "type" : "ImmutableWeight",
+      "value" : 1.0
+    }
+  }
+}


### PR DESCRIPTION
Here is a list of main updates:

- Updated `ProjectSecurityTestingScore` to extend `WeightedCompositeScore`.
- Updated `RatingRepository` to load weights for `ProjectSecurityTestingScore`.
- Reduced the weight of `NoHttpToolScore`.

This closes #196