### PR TITLE
Update LgtmScore to consider LGTM checks

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/LgtmDataProvider.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/LgtmDataProvider.java
@@ -1,6 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
-import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM_CHECKS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_LGTM_GRADE;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
 
@@ -10,12 +10,12 @@ import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures;
-import com.sap.sgs.phosphor.fosstars.model.value.BooleanValue;
 import com.sap.sgs.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.sgs.phosphor.fosstars.model.value.UnknownValue;
 import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Set;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -23,16 +23,23 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.kohsuke.github.GHCheckRun;
+import org.kohsuke.github.GHCommit;
 
 /**
  * The data provider gathers info about how a project uses static analysis with LGTM.
  * In particular, it tires to fill out the following features:
  * <ul>
- *   <li>{@link com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#USES_LGTM}</li>
- *   <li>{@link com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#WORST_LGTM_GRADE}</li>
+ *   <li>{@link OssFeatures#USES_LGTM_CHECKS}</li>
+ *   <li>{@link OssFeatures#WORST_LGTM_GRADE}</li>
  * </ul>
  */
 public class LgtmDataProvider extends GitHubCachingDataProvider {
+
+  /**
+   * Three months.
+   */
+  private static final Duration THREE_MONTHS = Duration.ofDays(90);
 
   /**
    * For parsing JSON.
@@ -50,13 +57,12 @@ public class LgtmDataProvider extends GitHubCachingDataProvider {
 
   @Override
   protected Set<Feature> supportedFeatures() {
-    return setOf(USES_LGTM, WORST_LGTM_GRADE);
+    return setOf(USES_LGTM_CHECKS, WORST_LGTM_GRADE);
   }
 
   @Override
   protected ValueSet fetchValuesFor(GitHubProject project) throws IOException {
-    JsonNode json = lgtmProjectInfo(project);
-    return ValueHashSet.from(usesLgtm(json), worstLgtmGrade(json));
+    return ValueHashSet.from(usesLgtmChecks(project), worstLgtmGrade(project));
   }
 
   /**
@@ -86,21 +92,27 @@ public class LgtmDataProvider extends GitHubCachingDataProvider {
    * Parses a JSON response from the LGTM API
    * and tries to figure out if the project has been analysed.
    *
-   * @param json The JSON response from LGTM to be parsed.
-   * @return A value of the {@link OssFeatures#USES_LGTM} feature.
+   * @return A value of the {@link OssFeatures#USES_LGTM_CHECKS} feature.
    */
-  private static Value<Boolean> usesLgtm(JsonNode json) {
-    return new BooleanValue(USES_LGTM, json.has("id"));
+  private Value<Boolean> usesLgtmChecks(GitHubProject project) throws IOException {
+    for (GHCommit commit : fetcher.githubCommitsFor(project, THREE_MONTHS)) {
+      if (hasLgtmChecks(commit)) {
+        return USES_LGTM_CHECKS.value(true);
+      }
+    }
+
+    return USES_LGTM_CHECKS.value(false);
   }
 
   /**
    * Parses a JSON response from the LGTM API
-   * and tries to figure out the worst grade for the project.
+   * and tries to figure out the worst grade for a project.
    *
-   * @param json The JSON response from LGTM to be parsed.
+   * @param project The project.
    * @return A value of the {@link OssFeatures#WORST_LGTM_GRADE} feature.
    */
-  private static Value<LgtmGrade> worstLgtmGrade(JsonNode json) {
+  private Value<LgtmGrade> worstLgtmGrade(GitHubProject project) throws IOException {
+    JsonNode json = lgtmProjectInfo(project);
     LgtmGrade worstGrade = null;
     if (json.has("languages") && json.get("languages").isArray()) {
       for (JsonNode item : json.get("languages")) {
@@ -122,4 +134,20 @@ public class LgtmDataProvider extends GitHubCachingDataProvider {
     return UnknownValue.of(WORST_LGTM_GRADE);
   }
 
+  /**
+   * Checks if a commit has LGTM checks.
+   *
+   * @param commit The commit to be checked.
+   * @return True if the commit has LGTM checks, false otherwise.
+   * @throws IOException If something went wrong.
+   */
+  private static boolean hasLgtmChecks(GHCommit commit) throws IOException {
+    for (GHCheckRun checkRun : commit.getCheckRuns()) {
+      if (checkRun.getName().startsWith("LGTM analysis")) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/feature/oss/OssFeatures.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/feature/oss/OssFeatures.java
@@ -174,9 +174,10 @@ public class OssFeatures {
       = new DateFeature("When first commit was done");
 
   /**
-   * Shows if an open-source project uses <a href="https://lgtm.com">LGTM</a> for static analysis.
+   * Shows if an open-source project uses <a href="https://lgtm.com">LGTM</a> checks for commits.
    */
-  public static final Feature<Boolean> USES_LGTM = new BooleanFeature("If a project uses LGTM");
+  public static final Feature<Boolean> USES_LGTM_CHECKS
+      = new BooleanFeature("If a project uses LGTM checks for commits");
 
   /**
    * Holds the worst grade assigned by <a href="https://lgtm.com">LGTM</a>.

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinter.java
@@ -136,7 +136,7 @@ public class PrettyPrinter implements Formatter {
         OssFeatures.USES_DEPENDABOT,
         "Does it use Dependabot?");
     FEATURE_TO_NAME.put(
-        OssFeatures.USES_LGTM,
+        OssFeatures.USES_LGTM_CHECKS,
         "Does it use LGTM?");
   }
 

--- a/src/main/jupyter/oss/security/LgtmScoreTestVectors.ipynb
+++ b/src/main/jupyter/oss/security/LgtmScoreTestVectors.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# this is a list of features which are used in the LGTM score\n",
     "features = [\n",
-    "    'If a project uses LGTM',\n",
+    "    'If a project uses LGTM checks for commits',\n",
     "    'The worst LGTM grade of a project'\n",
     "]"
    ]
@@ -41,7 +41,7 @@
        "      <th></th>\n",
        "      <th>alias</th>\n",
        "      <th>The worst LGTM grade of a project</th>\n",
-       "      <th>If a project uses LGTM</th>\n",
+       "      <th>If a project uses LGTM checks for commits</th>\n",
        "      <th>score_from</th>\n",
        "      <th>score_to</th>\n",
        "    </tr>\n",
@@ -116,7 +116,7 @@
        "</div>"
       ],
       "text/plain": [
-       "           alias The worst LGTM grade of a project If a project uses LGTM  \\\n",
+       "           alias The worst LGTM grade of a project If a project uses LGTM checks for commits  \\\n",
        "0  test_vector_0                           unknown                unknown   \n",
        "1  test_vector_1                           unknown                  False   \n",
        "2  test_vector_2                                 E                   True   \n",

--- a/src/main/jupyter/oss/security/OssSecurityRatingTestVectors.ipynb
+++ b/src/main/jupyter/oss/security/OssSecurityRatingTestVectors.ipynb
@@ -22,7 +22,7 @@
     "    'If an open-source project belongs to Apache Foundation',\n",
     "    'If an open-source project is supported by a company',\n",
     "    'If a project uses signed commits',\n",
-    "    'If a project uses LGTM',\n",
+    "    'If a project uses LGTM checks for commits',\n",
     "    'The worst LGTM grade of a project'\n",
     "]"
    ]
@@ -58,7 +58,7 @@
        "      <th>If a project uses signed commits</th>\n",
        "      <th>If an open-source project is regularly scanned for vulnerable dependencies</th>\n",
        "      <th>If an open-source project has a security team</th>\n",
-       "      <th>If a project uses LGTM</th>\n",
+       "      <th>If a project uses LGTM checks for commits</th>\n",
        "      <th>Number of watchers for a GitHub repository</th>\n",
        "      <th>If an open-source project has a security policy</th>\n",
        "      <th>Info about vulnerabilities in open-source project</th>\n",
@@ -421,7 +421,7 @@
        "12                                              False                           \n",
        "13                                              False                           \n",
        "\n",
-       "   If an open-source project has a security team If a project uses LGTM  \\\n",
+       "   If an open-source project has a security team If a project uses LGTM checks for commits  \\\n",
        "0                                        unknown                unknown   \n",
        "1                                          False                  False   \n",
        "2                                           True                   True   \n",

--- a/src/main/jupyter/oss/security/SecurityRatingAnalysis.ipynb
+++ b/src/main/jupyter/oss/security/SecurityRatingAnalysis.ipynb
@@ -1450,7 +1450,7 @@
    "source": [
     "columns = [    \n",
     "    'If an open-source project uses FindSecBugs',\n",
-    "    'If a project uses LGTM',\n",
+    "    'If a project uses LGTM checks for commits',\n",
     "    'If a project uses nohttp tool',\n",
     "    'If an open-source project is regularly scanned for vulnerable dependencies',\n",
     "    'If a project uses Dependabot',\n",

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
@@ -91,7 +91,7 @@ elements:
   - type: "UnknownValue"
     feature:
       type: "BooleanFeature"
-      name: "If a project uses LGTM"
+      name: "If a project uses LGTM checks for commits"
   - type: "UnknownValue"
     feature:
       type: "PositiveIntegerFeature"
@@ -175,7 +175,7 @@ elements:
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
-      name: "If a project uses LGTM"
+      name: "If a project uses LGTM checks for commits"
     flag: false
   - type: "IntegerValue"
     feature:
@@ -279,7 +279,7 @@ elements:
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
-      name: "If a project uses LGTM"
+      name: "If a project uses LGTM checks for commits"
     flag: true
   - type: "BooleanValue"
     feature:
@@ -408,7 +408,7 @@ elements:
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
-      name: "If a project uses LGTM"
+      name: "If a project uses LGTM checks for commits"
     flag: true
   - type: "BooleanValue"
     feature:

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScoreTestVectors.yml
@@ -10,7 +10,7 @@ elements:
   - type: "UnknownValue"
     feature:
       type: "BooleanFeature"
-      name: "If a project uses LGTM"
+      name: "If a project uses LGTM checks for commits"
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -30,7 +30,7 @@ elements:
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
-      name: "If a project uses LGTM"
+      name: "If a project uses LGTM checks for commits"
     flag: false
   expectedScore:
     type: "DoubleInterval"
@@ -52,14 +52,14 @@ elements:
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
-      name: "If a project uses LGTM"
+      name: "If a project uses LGTM checks for commits"
     flag: true
   expectedScore:
     type: "DoubleInterval"
-    from: 1.0
+    from: 4.0
     openLeft: false
     negativeInfinity: false
-    to: 3.0
+    to: 6.0
     openRight: false
     positiveInfinity: false
   expectedLabel: null
@@ -74,14 +74,14 @@ elements:
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
-      name: "If a project uses LGTM"
+      name: "If a project uses LGTM checks for commits"
     flag: true
   expectedScore:
     type: "DoubleInterval"
-    from: 3.0
+    from: 5.0
     openLeft: false
     negativeInfinity: false
-    to: 5.0
+    to: 7.0
     openRight: false
     positiveInfinity: false
   expectedLabel: null
@@ -96,7 +96,7 @@ elements:
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
-      name: "If a project uses LGTM"
+      name: "If a project uses LGTM checks for commits"
     flag: true
   expectedScore:
     type: "DoubleInterval"
@@ -118,7 +118,7 @@ elements:
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
-      name: "If a project uses LGTM"
+      name: "If a project uses LGTM checks for commits"
     flag: true
   expectedScore:
     type: "DoubleInterval"
@@ -140,7 +140,7 @@ elements:
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
-      name: "If a project uses LGTM"
+      name: "If a project uses LGTM checks for commits"
     flag: true
   expectedScore:
     type: "DoubleInterval"
@@ -157,7 +157,7 @@ elements:
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
-      name: "If a project uses LGTM"
+      name: "If a project uses LGTM checks for commits"
     flag: true
   - type: "LgtmGradeValue"
     feature:

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/LgtmDataProviderTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/LgtmDataProviderTest.java
@@ -1,6 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
-import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM_CHECKS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_LGTM_GRADE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -16,10 +16,15 @@ import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Test;
+import org.kohsuke.github.GHCheckRun;
+import org.kohsuke.github.GHCommit;
+import org.kohsuke.github.PagedIterable;
+import org.kohsuke.github.PagedIterator;
 
 public class LgtmDataProviderTest extends TestGitHubDataFetcherHolder {
 
@@ -39,6 +44,21 @@ public class LgtmDataProviderTest extends TestGitHubDataFetcherHolder {
 
     GitHubProject project = new GitHubProject("org", "project");
 
+    GHCheckRun checkRun = mock(GHCheckRun.class);
+    when(checkRun.getName()).thenReturn("LGTM analysis");
+
+    PagedIterator<GHCheckRun> iterator = mock(PagedIterator.class);
+    when(iterator.hasNext()).thenReturn(true, false);
+    when(iterator.next()).thenReturn(checkRun);
+
+    PagedIterable<GHCheckRun> pagedIterable = mock(PagedIterable.class);
+    when(pagedIterable.iterator()).thenReturn(iterator);
+
+    GHCommit commit = mock(GHCommit.class);
+    when(commit.getCheckRuns()).thenReturn(pagedIterable);
+
+    fetcher.githubCommitsCache().put(project, Collections.singletonList(commit));
+
     try (InputStream content = getClass().getResourceAsStream("LgtmProjectInfoReply.json")) {
       when(entity.getContent()).thenReturn(content);
 
@@ -49,10 +69,10 @@ public class LgtmDataProviderTest extends TestGitHubDataFetcherHolder {
       provider.update(project, values);
 
       assertEquals(2, values.size());
-      assertTrue(values.has(USES_LGTM));
-      assertTrue(values.of(USES_LGTM).isPresent());
-      assertFalse(values.of(USES_LGTM).get().isUnknown());
-      assertEquals(USES_LGTM.value(true), values.of(USES_LGTM).get());
+      assertTrue(values.has(USES_LGTM_CHECKS));
+      assertTrue(values.of(USES_LGTM_CHECKS).isPresent());
+      assertFalse(values.of(USES_LGTM_CHECKS).get().isUnknown());
+      assertEquals(USES_LGTM_CHECKS.value(true), values.of(USES_LGTM_CHECKS).get());
 
       assertTrue(values.has(WORST_LGTM_GRADE));
       assertTrue(values.of(WORST_LGTM_GRADE).isPresent());
@@ -77,6 +97,18 @@ public class LgtmDataProviderTest extends TestGitHubDataFetcherHolder {
 
     GitHubProject project = new GitHubProject("org", "project");
 
+    PagedIterator<GHCheckRun> iterator = mock(PagedIterator.class);
+    when(iterator.hasNext()).thenReturn(false);
+
+    PagedIterable<GHCheckRun> pagedIterable = mock(PagedIterable.class);
+    when(pagedIterable.iterator()).thenReturn(iterator);
+
+    GHCommit commit = mock(GHCommit.class);
+    when(commit.getCheckRuns()).thenReturn(pagedIterable);
+
+    fetcher.githubCommitsCache().put(project, Collections.singletonList(commit));
+
+
     try (InputStream content =
         getClass().getResourceAsStream("LgtmProjectDoesNotExistReply.json")) {
 
@@ -89,10 +121,10 @@ public class LgtmDataProviderTest extends TestGitHubDataFetcherHolder {
       provider.update(project, values);
 
       assertEquals(2, values.size());
-      assertTrue(values.has(USES_LGTM));
-      assertTrue(values.of(USES_LGTM).isPresent());
-      assertFalse(values.of(USES_LGTM).get().isUnknown());
-      assertEquals(USES_LGTM.value(false), values.of(USES_LGTM).get());
+      assertTrue(values.has(USES_LGTM_CHECKS));
+      assertTrue(values.of(USES_LGTM_CHECKS).isPresent());
+      assertFalse(values.of(USES_LGTM_CHECKS).get().isUnknown());
+      assertEquals(USES_LGTM_CHECKS.value(false), values.of(USES_LGTM_CHECKS).get());
 
       assertTrue(values.has(WORST_LGTM_GRADE));
       assertTrue(values.of(WORST_LGTM_GRADE).isPresent());

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScoreTest.java
@@ -1,7 +1,7 @@
 package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
 import static com.sap.sgs.phosphor.fosstars.TestUtils.assertScore;
-import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM_CHECKS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_LGTM_GRADE;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
 import static org.junit.Assert.assertEquals;
@@ -19,7 +19,7 @@ public class LgtmScoreTest {
     LgtmScore score = new LgtmScore();
     assertFalse(score.name().isEmpty());
     assertEquals(2, score.features().size());
-    assertTrue(score.features().contains(USES_LGTM));
+    assertTrue(score.features().contains(USES_LGTM_CHECKS));
     assertTrue(score.features().contains(WORST_LGTM_GRADE));
     assertTrue(score.subScores().isEmpty());
   }
@@ -27,9 +27,11 @@ public class LgtmScoreTest {
   @Test
   public void calculate() {
     LgtmScore score = new LgtmScore();
-    assertScore(Score.INTERVAL, score, setOf(USES_LGTM.unknown(), WORST_LGTM_GRADE.unknown()));
+    assertScore(
+        Score.INTERVAL, score,
+        setOf(USES_LGTM_CHECKS.unknown(), WORST_LGTM_GRADE.unknown()));
     assertScore(Score.INTERVAL, score,
-        setOf(USES_LGTM.value(true), WORST_LGTM_GRADE.value(LgtmGrade.A_PLUS)));
+        setOf(USES_LGTM_CHECKS.value(true), WORST_LGTM_GRADE.value(LgtmGrade.A_PLUS)));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -39,18 +41,6 @@ public class LgtmScoreTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void calculateWithoutUsesWorseLgtmGradeValue() {
-    new LgtmScore().calculate(USES_LGTM.unknown());
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void doesNotUseLgtmButHasWorseGrade() {
-    new LgtmScore().calculate(
-        USES_LGTM.value(false), WORST_LGTM_GRADE.value(LgtmGrade.A_PLUS));
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void unknownUseLgtmButHasWorseGrade() {
-    new LgtmScore().calculate(
-        USES_LGTM.unknown(), WORST_LGTM_GRADE.value(LgtmGrade.A_PLUS));
+    new LgtmScore().calculate(USES_LGTM_CHECKS.unknown());
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
@@ -18,7 +18,7 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_A
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_FIND_SEC_BUGS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_GITHUB_FOR_DEVELOPMENT;
-import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM_CHECKS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_MEMORY_SANITIZER;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_SIGNED_COMMITS;
@@ -89,7 +89,7 @@ public class OssSecurityScoreTest {
         VULNERABILITIES.value(new Vulnerabilities()),
         PROJECT_START_DATE.value(new Date()),
         USES_SIGNED_COMMITS.value(false),
-        USES_LGTM.value(true),
+        USES_LGTM_CHECKS.value(true),
         WORST_LGTM_GRADE.value(LgtmGrade.B),
         USES_NOHTTP.value(true),
         USES_DEPENDABOT.value(true),

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTuningWithCMAESTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTuningWithCMAESTest.java
@@ -18,7 +18,7 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_A
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_FIND_SEC_BUGS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_GITHUB_FOR_DEVELOPMENT;
-import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM_CHECKS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_MEMORY_SANITIZER;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_SIGNED_COMMITS;
@@ -65,7 +65,7 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(UnknownValue.of(VULNERABILITIES))
           .set(UnknownValue.of(PROJECT_START_DATE))
           .set(UnknownValue.of(USES_SIGNED_COMMITS))
-          .set(UnknownValue.of(USES_LGTM))
+          .set(UnknownValue.of(USES_LGTM_CHECKS))
           .set(UnknownValue.of(WORST_LGTM_GRADE))
           .set(UnknownValue.of(USES_NOHTTP))
           .set(UnknownValue.of(USES_DEPENDABOT))
@@ -96,7 +96,7 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(VULNERABILITIES.value(NO_VULNERABILITIES))
           .set(PROJECT_START_DATE.value(FIVE_YEARS_AGO))
           .set(USES_SIGNED_COMMITS.value(false))
-          .set(USES_LGTM.value(false))
+          .set(USES_LGTM_CHECKS.value(false))
           .set(WORST_LGTM_GRADE.unknown())
           .set(USES_NOHTTP.value(false))
           .set(USES_DEPENDABOT.value(false))
@@ -127,7 +127,7 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(VULNERABILITIES.value(NO_VULNERABILITIES))
           .set(PROJECT_START_DATE.value(FIVE_YEARS_AGO))
           .set(USES_SIGNED_COMMITS.value(true))
-          .set(USES_LGTM.value(true))
+          .set(USES_LGTM_CHECKS.value(true))
           .set(WORST_LGTM_GRADE.value(LgtmGrade.A_PLUS))
           .set(USES_NOHTTP.value(true))
           .set(USES_DEPENDABOT.value(true))

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinterTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinterTest.java
@@ -19,7 +19,7 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_A
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_FIND_SEC_BUGS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_GITHUB_FOR_DEVELOPMENT;
-import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM_CHECKS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_MEMORY_SANITIZER;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_SIGNED_COMMITS;
@@ -69,7 +69,7 @@ public class PrettyPrinterTest {
         PROJECT_START_DATE.value(new Date()),
         FIRST_COMMIT_DATE.value(new Date()),
         USES_SIGNED_COMMITS.value(false),
-        USES_LGTM.value(true),
+        USES_LGTM_CHECKS.value(true),
         WORST_LGTM_GRADE.value(LgtmGrade.A),
         USES_GITHUB_FOR_DEVELOPMENT.value(false),
         USES_NOHTTP.value(false),
@@ -123,7 +123,7 @@ public class PrettyPrinterTest {
         PROJECT_START_DATE.value(new Date()),
         FIRST_COMMIT_DATE.value(new Date()),
         USES_SIGNED_COMMITS.value(false),
-        USES_LGTM.value(true),
+        USES_LGTM_CHECKS.value(true),
         WORST_LGTM_GRADE.value(LgtmGrade.A),
         USES_GITHUB_FOR_DEVELOPMENT.value(false),
         USES_NOHTTP.value(true),


### PR DESCRIPTION
Here is a list of main updates:

- Renamed `USES_LGTM` feature to `USES_LGTM_CHECKS`.
- Updated `LgtmScore` to use the new feature.
- Updated `GitHubDataFetcher` to fetch commits from the GitHub API again.
- Updated `LgtmDataProvider` to fill out the new feature.
- Updated tests and test vectors.

This fixes #214