### PR TITLE
Added StaticAnalysisScore

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/Score.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/Score.java
@@ -20,6 +20,7 @@ import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.StaticAnalysisScore;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityLifetimeScore;
 import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
@@ -55,6 +56,7 @@ import java.util.Set;
     @JsonSubTypes.Type(value = MemorySafetyTestingScore.class),
     @JsonSubTypes.Type(value = FindSecBugsScore.class),
     @JsonSubTypes.Type(value = FuzzingScore.class),
+    @JsonSubTypes.Type(value = StaticAnalysisScore.class)
 })
 public interface Score extends Feature<Double> {
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AbstractScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AbstractScore.java
@@ -26,6 +26,9 @@ import org.apache.logging.log4j.Logger;
  */
 public abstract class AbstractScore implements Score {
 
+  /**
+   * No description.
+   */
   static final String EMPTY_DESCRIPTION = "";
 
   /**
@@ -50,7 +53,7 @@ public abstract class AbstractScore implements Score {
    *
    * @param name A name of the score.
    */
-  AbstractScore(String name) {
+  public AbstractScore(String name) {
     this(name, EMPTY_DESCRIPTION);
   }
 
@@ -60,7 +63,7 @@ public abstract class AbstractScore implements Score {
    * @param name A name of the score.
    * @param description A description of the score (may be empty).
    */
-  AbstractScore(String name, String description) {
+  public AbstractScore(String name, String description) {
     Objects.requireNonNull(name, "Hey! Score name can't be null!");
     Objects.requireNonNull(description, "Hey! Score description can't be null!");
     if (name.isEmpty()) {
@@ -213,17 +216,26 @@ public abstract class AbstractScore implements Score {
   }
 
   /**
-   * The method tries to get a value for a specified score. First, the method checks
-   * if the set of values already contains a value for the specified score. If yes, the method
-   * just returns the existing value. Otherwise, the method tries to calculate a value
-   * of the specified score.
+   * The method calculates a value for a specified score if the value is not available.
+   *
+   * @see #calculateIfNecessary(Score, ValueSet)
+   */
+  protected static ScoreValue calculateIfNecessary(Score score, Value... values) {
+    return calculateIfNecessary(score, ValueHashSet.from(values));
+  }
+
+  /**
+   * The method calculates a value for a specified score if the value is not available.
+   * First, the method checks if the set of values already contains a value for the specified score.
+   * If yes, the method just returns the existing value.
+   * Otherwise, the method tries to calculate a value of the specified score.
    *
    * @param score The score.
    * @param values The set of values.
    * @return A value of the specified score.
    * @throws IllegalArgumentException If a value for the score is not a {@link ScoreValue}.
    */
-  static ScoreValue calculateIfNecessary(Score score, ValueHashSet values) {
+  protected static ScoreValue calculateIfNecessary(Score score, ValueSet values) {
     Optional<Value> something = values.of(score);
 
     // if the set of values doesn't contain a value for the specified score, then calculate it
@@ -239,5 +251,51 @@ public abstract class AbstractScore implements Score {
 
     throw new IllegalArgumentException(String.format(
         "Hey! I expected a ScoreValue for a score but got %s!", value.getClass()));
+  }
+
+  /**
+   * Checks if all values are unknown.
+   *
+   * @param values The values to be checked.
+   * @return True if all values are unknown, false otherwise.
+   * @throws IllegalArgumentException If values are empty.
+   */
+  protected static boolean allUnknown(Value... values) {
+    Objects.requireNonNull(values, "Oh no! Values is null!");
+
+    if (values.length == 0) {
+      throw new IllegalStateException("Oh no! Values is empty!");
+    }
+
+    for (Value value : values) {
+      if (!value.isUnknown()) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Checks if all values are N/A.
+   *
+   * @param values The values to be checked.
+   * @return True if all values are N/A, false otherwise.
+   * @throws IllegalArgumentException If values are empty.
+   */
+  protected static boolean allNotApplicable(Value... values) {
+    Objects.requireNonNull(values, "Oh no! Values is null!");
+
+    if (values.length == 0) {
+      throw new IllegalStateException("Oh no! Values is empty!");
+    }
+
+    for (Value value : values) {
+      if (!value.isNotApplicable()) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AverageCompositeScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AverageCompositeScore.java
@@ -55,7 +55,7 @@ public class AverageCompositeScore extends AbstractScore {
   }
 
   /**
-   * The score doesn't use any feature directory
+   * The score doesn't use any feature directly
    * so that this method returns an empty set.
    *
    * @return An empty set of features.

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/FindSecBugsScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/FindSecBugsScore.java
@@ -40,6 +40,10 @@ public class FindSecBugsScore extends FeatureBasedScore {
 
     ScoreValue scoreValue = scoreValue(MIN, languages, usesFindSecBugs);
 
+    if (allUnknown(languages, usesFindSecBugs)) {
+      return scoreValue.makeUnknown();
+    }
+
     boolean applicable = languages.isUnknown() || languages.get().containsAnyOf(JAVA);
     if (!applicable) {
       return scoreValue.makeNotApplicable();

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScore.java
@@ -61,6 +61,10 @@ public class LgtmScore extends FeatureBasedScore {
 
     ScoreValue scoreValue = scoreValue(MIN, usesLgtmChecks, worstLgtmGrade);
 
+    if (allUnknown(usesLgtmChecks, worstLgtmGrade)) {
+      return scoreValue.makeUnknown();
+    }
+
     usesLgtmChecks.processIfKnown(uses -> {
       if (uses) {
         scoreValue.increase(LGTM_CHECKS_POINTS);

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScore.java
@@ -5,8 +5,12 @@ import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
 import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.qa.ScoreVerification;
+import com.sap.sgs.phosphor.fosstars.model.qa.TestVectors;
 import com.sap.sgs.phosphor.fosstars.model.score.AbstractScore;
 import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
@@ -79,5 +83,43 @@ public class StaticAnalysisScore extends AbstractScore {
     scoreValue.increase(findSecBugsScoreValue.orElse(MIN));
 
     return scoreValue;
+  }
+
+  /**
+   * This class implements a verification procedure for {@link StaticAnalysisScore}.
+   * The class loads test vectors,
+   * and provides methods to verify a {@link StaticAnalysisScore}
+   * against those test vectors.
+   */
+  public static class Verification extends ScoreVerification {
+
+    /**
+     * A name of a resource which contains the test vectors.
+     */
+    private static final String TEST_VECTORS_YAML = "StaticAnalysisScoreTestVectors.yml";
+
+    /**
+     * Initializes a {@link Verification}
+     * for a {@link StaticAnalysisScore}.
+     *
+     * @param score A score to be verified.
+     * @param vectors A list of test vectors.
+     */
+    public Verification(StaticAnalysisScore score, TestVectors vectors) {
+      super(score, vectors);
+    }
+
+    /**
+     * Creates an instance of {@link Verification} for a specified score. The method loads test
+     * vectors from a default resource.
+     *
+     * @param score The score to be verified.
+     * @return An instance of {@link StaticAnalysisScore}.
+     */
+    static Verification createFor(StaticAnalysisScore score) throws IOException {
+      try (InputStream is = Verification.class.getResourceAsStream(TEST_VECTORS_YAML)) {
+        return new Verification(score, TestVectors.loadFromYaml(is));
+      }
+    }
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScore.java
@@ -1,0 +1,83 @@
+package com.sap.sgs.phosphor.fosstars.model.score.oss;
+
+import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.score.AbstractScore;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * The score shows how an open-source project uses static analysis for security testing.
+ * It's based on the following sub-scores:
+ * <ul>
+ *   <li>{@link LgtmScore}</li>
+ *   <li>{@link FindSecBugsScore}</li>
+ * </ul>
+ * The above sub-scores may not apply to all projects. The score considers only the sub-scores
+ * that is applicable to a particular project.
+ */
+public class StaticAnalysisScore extends AbstractScore {
+
+  /**
+   * A score that shows how a project uses LGTM.
+   */
+  private final LgtmScore lgtmScore;
+
+  /**
+   * A score that shows how a project uses FindSecBugs.
+   */
+  private final FindSecBugsScore findSecBugsScore;
+
+  /**
+   * Initializes a new score.
+   */
+  public StaticAnalysisScore() {
+    super("How a project uses static analysis for security testing");
+    this.lgtmScore = new LgtmScore();
+    this.findSecBugsScore = new FindSecBugsScore();
+  }
+
+  /**
+   * The score doesn't use any feature directly
+   * so that this method returns an empty set.
+   *
+   * @return An empty set of features.
+   */
+  @Override
+  public Set<Feature> features() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Set<Score> subScores() {
+    return setOf(lgtmScore, findSecBugsScore);
+  }
+
+  @Override
+  public ScoreValue calculate(Value... values) {
+    Objects.requireNonNull(values, "Oh no! Values is null!");
+
+    ScoreValue lgtmScoreValue = calculateIfNecessary(lgtmScore, values);
+    ScoreValue findSecBugsScoreValue = calculateIfNecessary(findSecBugsScore, values);
+
+    ScoreValue scoreValue = scoreValue(MIN, lgtmScoreValue, findSecBugsScoreValue);
+
+    if (allUnknown(lgtmScoreValue, findSecBugsScoreValue)) {
+      return scoreValue.makeUnknown();
+    }
+
+    if (allNotApplicable(lgtmScoreValue, findSecBugsScoreValue)) {
+      return scoreValue.makeNotApplicable();
+    }
+
+    scoreValue.increase(lgtmScoreValue.orElse(MIN));
+    scoreValue.increase(findSecBugsScoreValue.orElse(MIN));
+
+    return scoreValue;
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValue.java
@@ -72,14 +72,11 @@ public class ScoreValue implements Value<Double>, Confidence {
    *
    * @param score The score.
    * @param value The score value.
+   * @param weight The weight.
    * @param confidence The confidence.
    * @param usedValues A list of values which were used to produce the score value.
    */
-  public ScoreValue(
-      Score score,
-      double value,
-      double weight,
-      double confidence,
+  public ScoreValue(Score score, double value, double weight, double confidence,
       List<Value> usedValues) {
 
     this(score, value, weight, confidence, usedValues, Collections.emptyList(), false, false);
@@ -90,9 +87,12 @@ public class ScoreValue implements Value<Double>, Confidence {
    *
    * @param score The score.
    * @param value The score value.
+   * @param weight The weight.
    * @param confidence The confidence.
    * @param usedValues A list of values which were used to produce the score value.
    * @param explanation A list of explanation which explain how the score value was calculated.
+   * @param isUnknown A flag that indicates that the value is unknown.
+   * @param isNotApplicable A flag that indicates that the value is N/A.
    */
   @JsonCreator
   public ScoreValue(
@@ -310,6 +310,16 @@ public class ScoreValue implements Value<Double>, Confidence {
    */
   public ScoreValue makeNotApplicable() {
     isNotApplicable = true;
+    return this;
+  }
+
+  /**
+   * Mark the value as unknown.
+   *
+   * @return The same score value.
+   */
+  public ScoreValue makeUnknown() {
+    isUnknown = true;
     return this;
   }
 

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScoreTestVectors.yml
@@ -1,0 +1,177 @@
+---
+defaults: []
+elements:
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.LgtmScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.FindSecBugsScore: 0.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 0.0
+      openLeft: false
+      negativeInfinity: false
+      to: 0.5
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_all_min"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.LgtmScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.FindSecBugsScore: 10.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 10.0
+      openLeft: false
+      negativeInfinity: false
+      to: 10.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_all_max"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.LgtmScore: 8.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.FindSecBugsScore: 2.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 10.0
+      openLeft: false
+      negativeInfinity: false
+      to: 10.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_1"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.LgtmScore: 1.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.FindSecBugsScore: 3.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 4.0
+      openLeft: false
+      negativeInfinity: false
+      to: 4.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_2"
+    expectedNotApplicableScore: false
+  - type: "StandardTestVector"
+    values:
+      - type: "ScoreValue"
+        score:
+          type: "LgtmScore"
+          name: "How a project addresses issues reported by LGTM"
+        value: 0.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+        isNotApplicable: true
+      - type: "ScoreValue"
+        score:
+          type: "FindSecBugsScore"
+          name: "How a project uses FindSecBugs"
+        value: 0.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+        isNotApplicable: true
+    expectedScore:
+      type: "DoubleInterval"
+      from: 0.0
+      openLeft: false
+      negativeInfinity: false
+      to: 0.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    expectedNotApplicableScore: true
+    alias: "all_not_applicable"
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.LgtmScore: 1.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.FindSecBugsScore: 3.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 4.0
+      openLeft: false
+      negativeInfinity: false
+      to: 4.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_2"
+    expectedNotApplicableScore: false
+  - type: "StandardTestVector"
+    values:
+      - type: "ScoreValue"
+        score:
+          type: "LgtmScore"
+          name: "How a project addresses issues reported by LGTM"
+        value: 5.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+        isNotApplicable: false
+      - type: "ScoreValue"
+        score:
+          type: "FindSecBugsScore"
+          name: "How a project uses FindSecBugs"
+        value: 0.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+        isNotApplicable: true
+    expectedScore:
+      type: "DoubleInterval"
+      from: 5.0
+      openLeft: false
+      negativeInfinity: false
+      to: 5.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    expectedNotApplicableScore: false
+    alias: "find_sec_bugs_not_applicable"
+  - type: "StandardTestVector"
+    values:
+      - type: "ScoreValue"
+        score:
+          type: "LgtmScore"
+          name: "How a project addresses issues reported by LGTM"
+        value: 0.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+        isNotApplicable: true
+      - type: "ScoreValue"
+        score:
+          type: "FindSecBugsScore"
+          name: "How a project uses FindSecBugs"
+        value: 3.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+        isNotApplicable: false
+    expectedScore:
+      type: "DoubleInterval"
+      from: 3.0
+      openLeft: false
+      negativeInfinity: false
+      to: 3.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    expectedNotApplicableScore: false
+    alias: "lgtm_not_applicable"

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/FindSecBugsScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/FindSecBugsScoreTest.java
@@ -1,15 +1,15 @@
 package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
-import static com.sap.sgs.phosphor.fosstars.TestUtils.assertScore;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_FIND_SEC_BUGS;
-import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
 import static com.sap.sgs.phosphor.fosstars.model.qa.TestVectorBuilder.newTestVector;
+import static org.junit.Assert.assertTrue;
 
 import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.qa.TestVectors;
 import com.sap.sgs.phosphor.fosstars.model.qa.VerificationFailedException;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.FindSecBugsScore.Verification;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,10 +29,9 @@ public class FindSecBugsScoreTest {
 
   @Test
   public void testWithAllUnknown() {
-    assertScore(
-        Score.INTERVAL,
-        new FindSecBugsScore(),
-        setOf(USES_FIND_SEC_BUGS.unknown(), LANGUAGES.unknown()));
+    FindSecBugsScore score = new FindSecBugsScore();
+    ScoreValue scoreValue = score.calculate(USES_FIND_SEC_BUGS.unknown(), LANGUAGES.unknown());
+    assertTrue(scoreValue.isUnknown());
   }
 
   @Test

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScoreTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.value.LgtmGrade;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import org.junit.Test;
 
 public class LgtmScoreTest {
@@ -25,22 +26,21 @@ public class LgtmScoreTest {
   }
 
   @Test
-  public void calculate() {
+  public void testCalculate() {
     LgtmScore score = new LgtmScore();
-    assertScore(
-        Score.INTERVAL, score,
-        setOf(USES_LGTM_CHECKS.unknown(), WORST_LGTM_GRADE.unknown()));
+    ScoreValue scoreValue = score.calculate(USES_LGTM_CHECKS.unknown(), WORST_LGTM_GRADE.unknown());
+    assertTrue(scoreValue.isUnknown());
     assertScore(Score.INTERVAL, score,
         setOf(USES_LGTM_CHECKS.value(true), WORST_LGTM_GRADE.value(LgtmGrade.A_PLUS)));
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void calculateWithoutUsesLgtmValue() {
+  public void testCalculateWithoutUsesLgtmValue() {
     new LgtmScore().calculate(WORST_LGTM_GRADE.unknown());
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void calculateWithoutUsesWorseLgtmGradeValue() {
+  public void testCalculateWithoutUsesWorseLgtmGradeValue() {
     new LgtmScore().calculate(USES_LGTM_CHECKS.unknown());
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScoreTest.java
@@ -1,0 +1,135 @@
+package com.sap.sgs.phosphor.fosstars.model.score.oss;
+
+import static com.sap.sgs.phosphor.fosstars.model.Score.MIN;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_FIND_SEC_BUGS;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM_CHECKS;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_LGTM_GRADE;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVA;
+import static com.sap.sgs.phosphor.fosstars.model.value.LgtmGrade.D;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.sgs.phosphor.fosstars.model.Confidence;
+import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.value.Languages;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
+import java.io.IOException;
+import org.junit.Test;
+
+public class StaticAnalysisScoreTest {
+
+  private static final double DELTA = 0.01;
+  
+  @Test
+  public void testCalculateWithFeatureValues() {
+    StaticAnalysisScore score = new StaticAnalysisScore();
+
+    ScoreValue scoreValue = score.calculate(
+        WORST_LGTM_GRADE.value(D),
+        USES_LGTM_CHECKS.value(true),
+        LANGUAGES.value(Languages.of(JAVA)),
+        USES_FIND_SEC_BUGS.value(false));
+
+    assertFalse(scoreValue.isUnknown());
+    assertFalse(scoreValue.isNotApplicable());
+    assertTrue(Score.INTERVAL.contains(scoreValue.get()));
+    assertEquals(Confidence.MAX, scoreValue.confidence(), DELTA);
+    assertSame(score, scoreValue.score());
+    assertEquals(2, scoreValue.usedValues().size());
+  }
+
+  @Test
+  public void testCalculateWithAllUnknown() {
+    StaticAnalysisScore score = new StaticAnalysisScore();
+
+    ScoreValue scoreValue = score.calculate(
+        WORST_LGTM_GRADE.unknown(),
+        USES_LGTM_CHECKS.unknown(),
+        LANGUAGES.unknown(),
+        USES_FIND_SEC_BUGS.unknown());
+
+    assertTrue(scoreValue.isUnknown());
+    assertFalse(scoreValue.isNotApplicable());
+    assertEquals(MIN, scoreValue.get(), DELTA);
+    assertEquals(Confidence.MIN, scoreValue.confidence(), DELTA);
+    assertSame(score, scoreValue.score());
+    assertEquals(2, scoreValue.usedValues().size());
+  }
+
+  @Test
+  public void testCalculateWithAllNotApplicable() {
+    StaticAnalysisScore score = new StaticAnalysisScore();
+
+    ScoreValue lgtmScoreValue = new ScoreValue(new LgtmScore()).makeNotApplicable();
+    ScoreValue findSecBugsScoreValue = new ScoreValue(new FindSecBugsScore()).makeNotApplicable();
+
+    ScoreValue scoreValue = score.calculate(lgtmScoreValue, findSecBugsScoreValue);
+    assertFalse(scoreValue.isUnknown());
+    assertTrue(scoreValue.isNotApplicable());
+    assertEquals(Confidence.MAX, scoreValue.confidence(), DELTA);
+    assertSame(score, scoreValue.score());
+    assertEquals(2, scoreValue.usedValues().size());
+    assertTrue(scoreValue.usedValues().contains(lgtmScoreValue));
+    assertTrue(scoreValue.usedValues().contains(findSecBugsScoreValue));
+  }
+
+  @Test
+  public void testCalculateWithSubScoreValues() {
+    StaticAnalysisScore score = new StaticAnalysisScore();
+
+    ScoreValue lgtmScoreValue = new ScoreValue(new LgtmScore()).set(MIN);
+    ScoreValue findSecBugsScoreValue = new ScoreValue(new FindSecBugsScore()).set(MIN);
+
+    ScoreValue scoreValue = score.calculate(lgtmScoreValue, findSecBugsScoreValue);
+    assertFalse(scoreValue.isUnknown());
+    assertFalse(scoreValue.isNotApplicable());
+    assertEquals(MIN, scoreValue.get(), DELTA);
+    assertEquals(Confidence.MAX, scoreValue.confidence(), DELTA);
+    assertSame(score, scoreValue.score());
+    assertEquals(2, scoreValue.usedValues().size());
+    assertTrue(scoreValue.usedValues().contains(lgtmScoreValue));
+    assertTrue(scoreValue.usedValues().contains(findSecBugsScoreValue));
+  }
+
+  @Test
+  public void testCalculateWithFindSecBugsNotApplicable() {
+    StaticAnalysisScore score = new StaticAnalysisScore();
+
+    final double value = 5.5;
+
+    ScoreValue lgtmScoreValue = new ScoreValue(new LgtmScore()).set(value);
+    ScoreValue findSecBugsScoreValue = new ScoreValue(new FindSecBugsScore()).makeNotApplicable();
+
+    ScoreValue scoreValue = score.calculate(lgtmScoreValue, findSecBugsScoreValue);
+    assertFalse(scoreValue.isUnknown());
+    assertFalse(scoreValue.isNotApplicable());
+    assertEquals(value, scoreValue.get(), DELTA);
+    assertEquals(Confidence.MAX, scoreValue.confidence(), DELTA);
+    assertSame(score, scoreValue.score());
+    assertEquals(2, scoreValue.usedValues().size());
+    assertTrue(scoreValue.usedValues().contains(lgtmScoreValue));
+    assertTrue(scoreValue.usedValues().contains(findSecBugsScoreValue));
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    StaticAnalysisScore one = new StaticAnalysisScore();
+    StaticAnalysisScore two = new StaticAnalysisScore();
+    assertTrue(one.equals(two) && two.equals(one));
+    assertEquals(one.hashCode(), two.hashCode());
+  }
+
+  @Test
+  public void testSerialization() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    StaticAnalysisScore score = new StaticAnalysisScore();
+    StaticAnalysisScore clone = mapper.readValue(
+        mapper.writeValueAsBytes(score), StaticAnalysisScore.class);
+    assertEquals(score, clone);
+  }
+
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScoreVerification.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScoreVerification.java
@@ -1,0 +1,14 @@
+package com.sap.sgs.phosphor.fosstars.model.score.oss;
+
+import com.sap.sgs.phosphor.fosstars.model.qa.VerificationFailedException;
+import java.io.IOException;
+import org.junit.Test;
+
+public class StaticAnalysisScoreVerification {
+
+  @Test
+  public void verify() throws IOException, VerificationFailedException {
+    StaticAnalysisScore.Verification.createFor(new StaticAnalysisScore()).run();
+  }
+
+}


### PR DESCRIPTION
This is a part of #192
 
- Added a new `StaticAnalysisScore` that is based on `LgtmScore` and `FindSecBugsScore`.
- Added a couple of helper methods in `AbstractScore`.
- Updated `LgtmScore` and `FindSecBugsScore` to return unknown and N/A values if necessary.
- Added `StaticAnalysisScore.Verification`.
- Added test vectors for `StaticAnalysisScore`.
- Added `StaticAnalysisScoreVerification` test and updated other tests.

Next, I'm planning to add the new score to the open-source security score.