### PR TITLE
Turn on StaticAnalysisScore

### DIFF
--- a/docs/oss_security_rating.md
+++ b/docs/oss_security_rating.md
@@ -43,12 +43,13 @@ Here is a list of sub-scores that are currently used in the open-source security
 Implementations for all the scores can be found in the [com.sap.sgs.phosphor.fosstars.model.score.oss](https://github.com/SAP/fosstars-rating-core/blob/master/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss) package.
 
 1.  **Security testing score** based on the following sub-scores:
-    1.  How a project addresses issues reported by LGTM. It's based on the following features:
-        1.  If a project uses LGTM.
-        1.  The worst LGTM grade of a project.
-    1.  How a project uses FindSecBugs. It's based on the following features:
-        1.  Programming languages that are used in a project.
-        1.  If an open-source project uses FindSecBugs.
+    1.  How a project uses static analysis for security testing. It's based on the following sub-scores:
+        1.  How a project addresses issues reported by LGTM. It's based on the following features:
+            1.  If a project uses LGTM.
+            1.  The worst LGTM grade of a project.
+        1.  How a project uses FindSecBugs. It's based on the following features:
+            1.  Programming languages that are used in a project.
+            1.  If an open-source project uses FindSecBugs.
     1.  If a project uses nohttp tool. It's based on the following features:
         1.  Package managers that are used in a project.
         1.  If a project uses nohttp tool.

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScore.java
@@ -10,10 +10,9 @@ import java.io.InputStream;
  * The security testing score uses the following sub-scores:
  * <ul>
  *  <li>{@link DependencyScanScore}</li>
- *  <li>{@link LgtmScore}</li>
  *  <li>{@link NoHttpToolScore}</li>
  *  <li>{@link MemorySafetyTestingScore}</li>
- *  <li>{@link FindSecBugsScore}</li>
+ *  <li>{@link StaticAnalysisScore}</li>
  *  <li>{@link FuzzingScore}</li>
  * </ul>
  * There is plenty room for improvements.
@@ -27,10 +26,9 @@ public class ProjectSecurityTestingScore extends WeightedCompositeScore {
   ProjectSecurityTestingScore() {
     super("How well security testing is done for an open-source project",
         new DependencyScanScore(),
-        new LgtmScore(),
         new NoHttpToolScore(),
         new MemorySafetyTestingScore(),
-        new FindSecBugsScore(),
+        new StaticAnalysisScore(),
         new FuzzingScore());
   }
 
@@ -48,8 +46,7 @@ public class ProjectSecurityTestingScore extends WeightedCompositeScore {
     private static final String TEST_VECTORS_YAML = "ProjectSecurityTestingScoreTestVectors.yml";
 
     /**
-     * Initializes a {@link Verification}
-     * for a {@link ProjectSecurityTestingScore}.
+     * Initializes a {@link Verification} for a {@link ProjectSecurityTestingScore}.
      *
      * @param score A score to be verified.
      * @param vectors A list of test vectors.

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScoreTestVectors.yml
@@ -1,549 +1,301 @@
 ---
 defaults: []
 elements:
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "LgtmScore"
-      name: "How a project addresses issues reported by LGTM"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "DependencyScanScore"
-      name: "How a project scans its dependencies for vulnerabilities"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "NoHttpToolScore"
-      name: "If a project uses nohttp tool"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "MemorySafetyTestingScore"
-      name: "How a project tests for memory-safety issues"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "FuzzingScore"
-      name: "How a project uses fuzzing"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "FindSecBugsScore"
-      name: "How a project uses FindSecBugs"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 0.0
-    openLeft: false
-    negativeInfinity: false
-    to: 0.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "all_min"
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.FuzzingScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.NoHttpToolScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.DependencyScanScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.StaticAnalysisScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.MemorySafetyTestingScore: 0.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 0.0
+      openLeft: false
+      negativeInfinity: false
+      to: 0.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "all_min"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.FuzzingScore: 8.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.NoHttpToolScore: 9.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.DependencyScanScore: 3.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.StaticAnalysisScore: 7.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.MemorySafetyTestingScore: 5.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 6.0
+      openLeft: false
+      negativeInfinity: false
+      to: 7.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_1"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.FuzzingScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.NoHttpToolScore: 1.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.DependencyScanScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.StaticAnalysisScore: 4.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.MemorySafetyTestingScore: 2.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 3.0
+      openLeft: false
+      negativeInfinity: false
+      to: 4.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_2"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.FuzzingScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.NoHttpToolScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.DependencyScanScore: 7.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.StaticAnalysisScore: 3.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.MemorySafetyTestingScore: 5.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 4.0
+      openLeft: false
+      negativeInfinity: false
+      to: 5.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_3"
+    expectedNotApplicableScore: false
+  - type: "ScoreTestVector"
+    values:
+      com.sap.sgs.phosphor.fosstars.model.score.oss.FuzzingScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.NoHttpToolScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.DependencyScanScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.StaticAnalysisScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.MemorySafetyTestingScore: 10.0
+    expectedScore:
+      type: "DoubleInterval"
+      from: 10.0
+      openLeft: false
+      negativeInfinity: false
+      to: 10.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "test_vector_4"
+    expectedNotApplicableScore: false
 
-#
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "LgtmScore"
-      name: "How a project addresses issues reported by LGTM"
-    value: 7.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "DependencyScanScore"
-      name: "How a project scans its dependencies for vulnerabilities"
-    value: 3.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "NoHttpToolScore"
-      name: "If a project uses nohttp tool"
-    value: 9.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "MemorySafetyTestingScore"
-      name: "How a project tests for memory-safety issues"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "FuzzingScore"
-      name: "How a project uses fuzzing"
-    value: 8.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "FindSecBugsScore"
-      name: "How a project uses FindSecBugs"
-    value: 6.5
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 6.0
-    openLeft: false
-    negativeInfinity: false
-    to: 7.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_1"
+  # NoHttpToolScore is N/A
+  - type: "StandardTestVector"
+    values:
+      - type: "ScoreValue"
+        score:
+          type: "DependencyScanScore"
+          name: "How a project scans its dependencies for vulnerabilities"
+        value: 3.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+      - type: "ScoreValue"
+        score:
+          type: "LgtmScore"
+          name: "How a project addresses issues reported by LGTM"
+        value: 7.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+      - type: "ScoreValue"
+        score:
+          type: "NoHttpToolScore"
+          name: "If a project uses nohttp tool"
+        value: 0.0
+        weight: 1.0
+        confidence: 0.0
+        usedValues: []
+        explanation: []
+        isNotApplicable: true
+      - type: "ScoreValue"
+        score:
+          type: "MemorySafetyTestingScore"
+          name: "How a project tests for memory-safety issues"
+        value: 10.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+      - type: "ScoreValue"
+        score:
+          type: "FuzzingScore"
+          name: "How a project uses fuzzing"
+        value: 5.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+      - type: "ScoreValue"
+        score:
+          type: "FindSecBugsScore"
+          name: "How a project uses FindSecBugs"
+        value: 0.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+    expectedScore:
+      type: "DoubleInterval"
+      from: 5.0
+      openLeft: false
+      negativeInfinity: false
+      to: 10.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "nohttp_tool_not_applicable"
 
-#
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "DependencyScanScore"
-      name: "How a project scans its dependencies for vulnerabilities"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "LgtmScore"
-      name: "How a project addresses issues reported by LGTM"
-    value: 4.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "NoHttpToolScore"
-      name: "If a project uses nohttp tool"
-    value: 1.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "MemorySafetyTestingScore"
-      name: "How a project tests for memory-safety issues"
-    value: 2.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "FuzzingScore"
-      name: "How a project uses fuzzing"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "FindSecBugsScore"
-      name: "How a project uses FindSecBugs"
-    value: 3.7
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 3.0
-    openLeft: false
-    negativeInfinity: false
-    to: 4.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_2"
+  # MemorySafetyTestingScore and FussingScore are N/A
+  - type: "StandardTestVector"
+    values:
+      - type: "ScoreValue"
+        score:
+          type: "DependencyScanScore"
+          name: "How a project scans its dependencies for vulnerabilities"
+        value: 3.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+      - type: "ScoreValue"
+        score:
+          type: "LgtmScore"
+          name: "How a project addresses issues reported by LGTM"
+        value: 7.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+      - type: "ScoreValue"
+        score:
+          type: "NoHttpToolScore"
+          name: "If a project uses nohttp tool"
+        value: 6.0
+        weight: 1.0
+        confidence: 0.0
+        usedValues: []
+        explanation: []
+      - type: "ScoreValue"
+        score:
+          type: "MemorySafetyTestingScore"
+          name: "How a project tests for memory-safety issues"
+        value: 0.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+        isNotApplicable: true
+      - type: "ScoreValue"
+        score:
+          type: "FuzzingScore"
+          name: "How a project uses fuzzing"
+        value: 0.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+        isNotApplicable: true
+      - type: "ScoreValue"
+        score:
+          type: "FindSecBugsScore"
+          name: "How a project uses FindSecBugs"
+        value: 10.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+    expectedScore:
+      type: "DoubleInterval"
+      from: 5.0
+      openLeft: false
+      negativeInfinity: false
+      to: 10.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "memory_safety_and_fuzzing_not_applicable"
 
-#
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "DependencyScanScore"
-      name: "How a project scans its dependencies for vulnerabilities"
-    value: 7.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "LgtmScore"
-      name: "How a project addresses issues reported by LGTM"
-    value: 3.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "NoHttpToolScore"
-      name: "If a project uses nohttp tool"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "MemorySafetyTestingScore"
-      name: "How a project tests for memory-safety issues"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "FuzzingScore"
-      name: "How a project uses fuzzing"
-    value: 5.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "FindSecBugsScore"
-      name: "How a project uses FindSecBugs"
-    value: 0.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 3.0
-    openLeft: false
-    negativeInfinity: false
-    to: 4.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_3"
-
-# all max values
-- type: "StandardTestVector"
-  values:
-  - type: "ScoreValue"
-    score:
-      type: "DependencyScanScore"
-      name: "How a project scans its dependencies for vulnerabilities"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "LgtmScore"
-      name: "How a project addresses issues reported by LGTM"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "NoHttpToolScore"
-      name: "If a project uses nohttp tool"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "MemorySafetyTestingScore"
-      name: "How a project tests for memory-safety issues"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "FuzzingScore"
-      name: "How a project uses fuzzing"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  - type: "ScoreValue"
-    score:
-      type: "FindSecBugsScore"
-      name: "How a project uses FindSecBugs"
-    value: 10.0
-    weight: 1.0
-    confidence: 10.0
-    usedValues: []
-    explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 10.0
-    openLeft: false
-    negativeInfinity: false
-    to: 10.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "test_vector_4"
-
-# NoHttpToolScore is N/A
-- type: "StandardTestVector"
-  values:
-    - type: "ScoreValue"
-      score:
-        type: "DependencyScanScore"
-        name: "How a project scans its dependencies for vulnerabilities"
-      value: 3.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-    - type: "ScoreValue"
-      score:
-        type: "LgtmScore"
-        name: "How a project addresses issues reported by LGTM"
-      value: 7.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-    - type: "ScoreValue"
-      score:
-        type: "NoHttpToolScore"
-        name: "If a project uses nohttp tool"
-      value: 0.0
-      weight: 1.0
-      confidence: 0.0
-      usedValues: []
-      explanation: []
-      isNotApplicable: true
-    - type: "ScoreValue"
-      score:
-        type: "MemorySafetyTestingScore"
-        name: "How a project tests for memory-safety issues"
-      value: 10.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-    - type: "ScoreValue"
-      score:
-        type: "FuzzingScore"
-        name: "How a project uses fuzzing"
-      value: 5.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-    - type: "ScoreValue"
-      score:
-        type: "FindSecBugsScore"
-        name: "How a project uses FindSecBugs"
-      value: 0.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 5.0
-    openLeft: false
-    negativeInfinity: false
-    to: 10.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "nohttp_tool_not_applicable"
-
-# MemorySafetyTestingScore and FussingScore are N/A
-- type: "StandardTestVector"
-  values:
-    - type: "ScoreValue"
-      score:
-        type: "DependencyScanScore"
-        name: "How a project scans its dependencies for vulnerabilities"
-      value: 3.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-    - type: "ScoreValue"
-      score:
-        type: "LgtmScore"
-        name: "How a project addresses issues reported by LGTM"
-      value: 7.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-    - type: "ScoreValue"
-      score:
-        type: "NoHttpToolScore"
-        name: "If a project uses nohttp tool"
-      value: 6.0
-      weight: 1.0
-      confidence: 0.0
-      usedValues: []
-      explanation: []
-    - type: "ScoreValue"
-      score:
-        type: "MemorySafetyTestingScore"
-        name: "How a project tests for memory-safety issues"
-      value: 0.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-      isNotApplicable: true
-    - type: "ScoreValue"
-      score:
-        type: "FuzzingScore"
-        name: "How a project uses fuzzing"
-      value: 0.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-      isNotApplicable: true
-    - type: "ScoreValue"
-      score:
-        type: "FindSecBugsScore"
-        name: "How a project uses FindSecBugs"
-      value: 10.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-  expectedScore:
-    type: "DoubleInterval"
-    from: 5.0
-    openLeft: false
-    negativeInfinity: false
-    to: 10.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "memory_safety_and_fuzzing_not_applicable"
-
-# FindSecBugsScore is N/A
-- type: "StandardTestVector"
-  values:
-    - type: "ScoreValue"
-      score:
-        type: "LgtmScore"
-        name: "How a project addresses issues reported by LGTM"
-      value: 7.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-    - type: "ScoreValue"
-      score:
-        type: "DependencyScanScore"
-        name: "How a project scans its dependencies for vulnerabilities"
-      value: 3.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-    - type: "ScoreValue"
-      score:
-        type: "NoHttpToolScore"
-        name: "If a project uses nohttp tool"
-      value: 9.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-    - type: "ScoreValue"
-      score:
-        type: "MemorySafetyTestingScore"
-        name: "How a project tests for memory-safety issues"
-      value: 5.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-    - type: "ScoreValue"
-      score:
-        type: "FuzzingScore"
-        name: "How a project uses fuzzing"
-      value: 8.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-    - type: "ScoreValue"
-      score:
-        type: "FindSecBugsScore"
-        name: "How a project uses FindSecBugs"
-      value: 0.0
-      weight: 1.0
-      confidence: 10.0
-      usedValues: []
-      explanation: []
-      isNotApplicable: true
-  expectedScore:
-    type: "DoubleInterval"
-    from: 6.0
-    openLeft: false
-    negativeInfinity: false
-    to: 7.0
-    openRight: false
-    positiveInfinity: false
-  expectedLabel: null
-  alias: "find_sec_bugs_not_applicable"
+  # FindSecBugsScore is N/A
+  - type: "StandardTestVector"
+    values:
+      - type: "ScoreValue"
+        score:
+          type: "LgtmScore"
+          name: "How a project addresses issues reported by LGTM"
+        value: 7.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+      - type: "ScoreValue"
+        score:
+          type: "DependencyScanScore"
+          name: "How a project scans its dependencies for vulnerabilities"
+        value: 3.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+      - type: "ScoreValue"
+        score:
+          type: "NoHttpToolScore"
+          name: "If a project uses nohttp tool"
+        value: 9.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+      - type: "ScoreValue"
+        score:
+          type: "MemorySafetyTestingScore"
+          name: "How a project tests for memory-safety issues"
+        value: 5.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+      - type: "ScoreValue"
+        score:
+          type: "FuzzingScore"
+          name: "How a project uses fuzzing"
+        value: 8.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+      - type: "ScoreValue"
+        score:
+          type: "FindSecBugsScore"
+          name: "How a project uses FindSecBugs"
+        value: 0.0
+        weight: 1.0
+        confidence: 10.0
+        usedValues: []
+        explanation: []
+        isNotApplicable: true
+    expectedScore:
+      type: "DoubleInterval"
+      from: 6.0
+      openLeft: false
+      negativeInfinity: false
+      to: 7.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "find_sec_bugs_not_applicable"

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScoreWeights.json
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScoreWeights.json
@@ -4,11 +4,7 @@
       "type" : "ImmutableWeight",
       "value" : 1.0
     },
-    "com.sap.sgs.phosphor.fosstars.model.score.oss.FindSecBugsScore" : {
-      "type" : "ImmutableWeight",
-      "value" : 1.0
-    },
-    "com.sap.sgs.phosphor.fosstars.model.score.oss.LgtmScore" : {
+    "com.sap.sgs.phosphor.fosstars.model.score.oss.StaticAnalysisScore" : {
       "type" : "ImmutableWeight",
       "value" : 1.0
     },

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityTestingScoreTest.java
@@ -25,33 +25,30 @@ public class ProjectSecurityTestingScoreTest {
         Score.INTERVAL,
         PROJECT_SECURITY_TESTING,
         setOf(
-            PROJECT_SECURITY_TESTING.score(LgtmScore.class).value(Score.MIN),
+            PROJECT_SECURITY_TESTING.score(StaticAnalysisScore.class).value(Score.MIN),
             PROJECT_SECURITY_TESTING.score(DependencyScanScore.class).value(Score.MIN),
             PROJECT_SECURITY_TESTING.score(NoHttpToolScore.class).value(Score.MIN),
             PROJECT_SECURITY_TESTING.score(MemorySafetyTestingScore.class).value(Score.MIN),
-            PROJECT_SECURITY_TESTING.score(FindSecBugsScore.class).value(Score.MIN),
             PROJECT_SECURITY_TESTING.score(FuzzingScore.class).value(Score.MIN)));
 
     assertScore(
         Score.INTERVAL,
         PROJECT_SECURITY_TESTING,
         setOf(
-            PROJECT_SECURITY_TESTING.score(LgtmScore.class).value(Score.MAX),
+            PROJECT_SECURITY_TESTING.score(StaticAnalysisScore.class).value(Score.MAX),
             PROJECT_SECURITY_TESTING.score(DependencyScanScore.class).value(Score.MAX),
             PROJECT_SECURITY_TESTING.score(NoHttpToolScore.class).value(Score.MAX),
             PROJECT_SECURITY_TESTING.score(MemorySafetyTestingScore.class).value(Score.MAX),
-            PROJECT_SECURITY_TESTING.score(FindSecBugsScore.class).value(Score.MAX),
             PROJECT_SECURITY_TESTING.score(FuzzingScore.class).value(Score.MAX)));
   }
 
   @Test
   public void explanation() {
     ScoreValue value = PROJECT_SECURITY_TESTING.calculate(
-        PROJECT_SECURITY_TESTING.score(LgtmScore.class).value(Score.MAX / 3),
+        PROJECT_SECURITY_TESTING.score(StaticAnalysisScore.class).value(Score.MAX / 3),
         PROJECT_SECURITY_TESTING.score(DependencyScanScore.class).value(Score.MAX / 5),
         PROJECT_SECURITY_TESTING.score(NoHttpToolScore.class).value(Score.MAX / 2),
         PROJECT_SECURITY_TESTING.score(MemorySafetyTestingScore.class).value(Score.MAX / 4),
-        PROJECT_SECURITY_TESTING.score(FindSecBugsScore.class).value(Score.MAX / 7),
         PROJECT_SECURITY_TESTING.score(FuzzingScore.class).value(Score.MIN / 2));
 
     assertTrue(value.score().description().isEmpty());


### PR DESCRIPTION
Here is a list of main updates:

- Added `StaticAnalysisScore` to the open-source security score.
- Updated tests vectors and tests.

This closes #192