### PR TITLE
Update security ratings for well-known projects (0.9.0)

### DIFF
--- a/bin/report.sh
+++ b/bin/report.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [ "${TOKEN}" = "" ]; then
+  echo "Achtung! No GitHub token! Set TOKEN environment variable!"
+  exit 1
+fi
+
+set -e
+
+if [ "${BUILD}" = "yes" ]; then
+  mvn clean package -DskipTests
+fi
+
+if [ "${CLEAN}" = "yes" ]; then
+  rm -rf .fosstars/github_project_value_cache.json
+  rm -rf .fosstars/project_rating_cache.json
+  echo "[]" > docs/oss/security/github_projects.json
+
+  for file in $(find docs/oss/security -name "*.md" | grep -v README)
+  do
+    rm $file
+  done
+fi
+
+configs="other.yml jackson.yml spring.yml apache.yml eclipse.yml"
+
+echo "" > report.log
+for config in ${configs}
+do
+  java -jar target/fosstars-github-rating-calc.jar \
+      --no-questions --token ${TOKEN} --config docs/oss/security/${config} 2>&1 | tee report.log
+done
+
+if grep -i exception report.log > /dev/null 2>&1; then
+  echo "Achtung! Looks like there were some errors, check out report.log"
+fi
+

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/FuzzedInOssFuzz.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/FuzzedInOssFuzz.java
@@ -40,6 +40,8 @@ public class FuzzedInOssFuzz extends CachedSingleFeatureGitHubDataProvider {
 
   @Override
   protected Value<Boolean> fetchValueFor(GitHubProject project) throws IOException {
+    logger.info("Figuring out if the project is fuzzed in OSS-Fuzz ...");
+
     LocalRepository ossFuzzRepository = fetcher.localRepositoryFor(OSS_FUZZ_PROJECT);
 
     List<Path> dockerFiles = Files.walk(ossFuzzRepository.info().path())

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/HasSecurityTeam.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/HasSecurityTeam.java
@@ -39,9 +39,6 @@ public class HasSecurityTeam extends CachedSingleFeatureGitHubDataProvider {
   @Override
   protected Value fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project has a security team ...");
-    if (securityTeam.existsFor(project.url())) {
-      return HAS_SECURITY_TEAM.value(true);
-    }
-    return HAS_SECURITY_TEAM.unknown();
+    return HAS_SECURITY_TEAM.value(securityTeam.existsFor(project.url()));
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/InfoAboutVulnerabilities.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/InfoAboutVulnerabilities.java
@@ -53,6 +53,8 @@ public class InfoAboutVulnerabilities extends CachedSingleFeatureGitHubDataProvi
 
   @Override
   protected Value fetchValueFor(GitHubProject project) throws IOException {
+    logger.info("Looking for vulnerabilities in the project ...");
+
     Vulnerabilities allVulnerabilities = new Vulnerabilities();
     for (DataProvider<GitHubProject> provider : providers) {
       ValueSet subset = new ValueHashSet();

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/LgtmDataProvider.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/LgtmDataProvider.java
@@ -15,7 +15,6 @@ import com.sap.sgs.phosphor.fosstars.model.value.UnknownValue;
 import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Set;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -37,9 +36,9 @@ import org.kohsuke.github.GHCommit;
 public class LgtmDataProvider extends GitHubCachingDataProvider {
 
   /**
-   * Three months.
+   * The number of latest commits to be checked.
    */
-  private static final Duration THREE_MONTHS = Duration.ofDays(90);
+  private static final int COMMITS_TO_BE_CHECKED = 20;
 
   /**
    * For parsing JSON.
@@ -62,6 +61,7 @@ public class LgtmDataProvider extends GitHubCachingDataProvider {
 
   @Override
   protected ValueSet fetchValuesFor(GitHubProject project) throws IOException {
+    logger.info("Figuring out how the project uses LGTM ...");
     return ValueHashSet.from(usesLgtmChecks(project), worstLgtmGrade(project));
   }
 
@@ -95,7 +95,7 @@ public class LgtmDataProvider extends GitHubCachingDataProvider {
    * @return A value of the {@link OssFeatures#USES_LGTM_CHECKS} feature.
    */
   private Value<Boolean> usesLgtmChecks(GitHubProject project) throws IOException {
-    for (GHCommit commit : fetcher.githubCommitsFor(project, THREE_MONTHS)) {
+    for (GHCommit commit : fetcher.githubCommitsFor(project, COMMITS_TO_BE_CHECKED)) {
       if (hasLgtmChecks(commit)) {
         return USES_LGTM_CHECKS.value(true);
       }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/ScansForVulnerableDependencies.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/ScansForVulnerableDependencies.java
@@ -44,6 +44,8 @@ public class ScansForVulnerableDependencies extends CachedSingleFeatureGitHubDat
 
   @Override
   protected Value fetchValueFor(GitHubProject project) throws IOException {
+    logger.info("Figuring out if the project scans its dependencies for vulnerabilities ...");
+
     for (CachedSingleFeatureGitHubDataProvider provider : providers) {
       Value<Boolean> value = provider.fetchValueFor(project);
       if (value.orElse(FALSE)) {

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesGithubForDevelopment.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesGithubForDevelopment.java
@@ -68,7 +68,7 @@ public class UsesGithubForDevelopment extends CachedSingleFeatureGitHubDataProvi
 
   @Override
   protected Value fetchValueFor(GitHubProject project) {
-    logger.info("Figuring out if the project uses GitHub as the main development platform ...");
+    logger.info("Figuring out if the project uses GitHub for development ...");
     return usesGithubForDevelopment(project);
   }
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesNoHttpTool.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesNoHttpTool.java
@@ -41,7 +41,7 @@ public class UsesNoHttpTool extends CachedSingleFeatureGitHubDataProvider {
 
   @Override
   protected Value fetchValueFor(GitHubProject project) throws IOException {
-    logger.info("Figuring out if the project uses NoHTTP ...");
+    logger.info("Figuring out if the project uses nohttp ...");
 
     GHRepository repository = fetcher.repositoryFor(project);
     return USES_NOHTTP.value(checkMaven(repository) || checkGradle(repository));

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Languages.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Languages.java
@@ -5,10 +5,10 @@ import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -46,7 +46,7 @@ public class Languages implements Iterable<Language> {
   @JsonCreator
   public Languages(@JsonProperty("elements") Set<Language> languages) {
     Objects.requireNonNull(languages, "Languages can't be null!");
-    this.elements = new HashSet<>(languages);
+    this.elements = new TreeSet<>(languages);
   }
 
   /**
@@ -98,7 +98,7 @@ public class Languages implements Iterable<Language> {
    */
   @JsonGetter("elements")
   public Set<Language> get() {
-    return new HashSet<>(elements);
+    return new TreeSet<>(elements);
   }
 
   @Override

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/PackageManagers.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/PackageManagers.java
@@ -1,15 +1,16 @@
 package com.sap.sgs.phosphor.fosstars.model.value;
 
+import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -48,7 +49,7 @@ public class PackageManagers implements Iterable<PackageManager> {
       @JsonProperty("packageManagers") Set<PackageManager> packageManagers) {
 
     Objects.requireNonNull(packageManagers, "Package managers can't be null!");
-    this.packageManagers = packageManagers;
+    this.packageManagers = new TreeSet<>(packageManagers);
   }
 
   /**
@@ -57,8 +58,7 @@ public class PackageManagers implements Iterable<PackageManager> {
    * @param packageManagers A number of package managers.
    */
   public PackageManagers(PackageManager... packageManagers) {
-    this(EnumSet.noneOf(PackageManager.class));
-    this.packageManagers.addAll(Arrays.asList(packageManagers));
+    this(setOf(packageManagers));
   }
 
   /**
@@ -80,7 +80,7 @@ public class PackageManagers implements Iterable<PackageManager> {
    */
   @JsonGetter("packageManagers")
   private Set<PackageManager> packageManagers() {
-    return packageManagers;
+    return new TreeSet<>(packageManagers);
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinter.java
@@ -46,42 +46,18 @@ public class PrettyPrinter implements Formatter {
   private static final Map<Class, String> FEATURE_CLASS_TO_NAME = new HashMap<>();
 
   static {
-    FEATURE_CLASS_TO_NAME.put(
-        OssSecurityScore.class,
-        "Security of project");
-    FEATURE_CLASS_TO_NAME.put(
-        CommunityCommitmentScore.class,
-        "Community commitment");
-    FEATURE_CLASS_TO_NAME.put(
-        ProjectActivityScore.class,
-        "Project activity");
-    FEATURE_CLASS_TO_NAME.put(
-        ProjectPopularityScore.class,
-        "Project popularity");
-    FEATURE_CLASS_TO_NAME.put(
-        ProjectSecurityAwarenessScore.class,
-        "Security awareness");
-    FEATURE_CLASS_TO_NAME.put(
-        ProjectSecurityTestingScore.class,
-        "Security testing");
-    FEATURE_CLASS_TO_NAME.put(
-        UnpatchedVulnerabilitiesScore.class,
-        "Unpatched vulnerabilities");
-    FEATURE_CLASS_TO_NAME.put(
-        VulnerabilityLifetimeScore.class,
-        "Vulnerability lifetime");
-    FEATURE_CLASS_TO_NAME.put(
-        MemorySafetyTestingScore.class,
-        "Memory-safety testing");
-    FEATURE_CLASS_TO_NAME.put(
-        UsesFindSecBugs.class,
-        "Uses FindSecBugs");
-    FEATURE_CLASS_TO_NAME.put(
-        UsesNoHttpTool.class,
-        "Uses nohttp");
-    FEATURE_CLASS_TO_NAME.put(
-        DependencyScanScore.class,
-        "Dependency testing");
+    FEATURE_CLASS_TO_NAME.put(OssSecurityScore.class, "Security of project");
+    FEATURE_CLASS_TO_NAME.put(CommunityCommitmentScore.class, "Community commitment");
+    FEATURE_CLASS_TO_NAME.put(ProjectActivityScore.class, "Project activity");
+    FEATURE_CLASS_TO_NAME.put(ProjectPopularityScore.class, "Project popularity");
+    FEATURE_CLASS_TO_NAME.put(ProjectSecurityAwarenessScore.class, "Security awareness");
+    FEATURE_CLASS_TO_NAME.put(ProjectSecurityTestingScore.class, "Security testing");
+    FEATURE_CLASS_TO_NAME.put(UnpatchedVulnerabilitiesScore.class, "Unpatched vulnerabilities");
+    FEATURE_CLASS_TO_NAME.put(VulnerabilityLifetimeScore.class, "Vulnerability lifetime");
+    FEATURE_CLASS_TO_NAME.put(MemorySafetyTestingScore.class, "Memory-safety testing");
+    FEATURE_CLASS_TO_NAME.put(UsesFindSecBugs.class, "Uses FindSecBugs");
+    FEATURE_CLASS_TO_NAME.put(UsesNoHttpTool.class, "Uses nohttp");
+    FEATURE_CLASS_TO_NAME.put(DependencyScanScore.class, "Dependency testing");
   }
 
   /**
@@ -90,57 +66,26 @@ public class PrettyPrinter implements Formatter {
   private static final Map<Feature, String> FEATURE_TO_NAME = new HashMap<>();
 
   static {
-    FEATURE_TO_NAME.put(
-        OssFeatures.HAS_SECURITY_TEAM,
-        "Does it have a security team?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.HAS_SECURITY_POLICY,
-        "Does it have a security policy?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.USES_SIGNED_COMMITS,
-        "Does it use verified signed commits?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.VULNERABILITIES,
-        "Info about vulnerabilities");
-    FEATURE_TO_NAME.put(
-        OssFeatures.IS_APACHE,
-        "Does it belong to Apache?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.IS_ECLIPSE,
-        "Does it belong to Eclipse?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.SUPPORTED_BY_COMPANY,
-        "Is it supported by a company?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES,
+    FEATURE_TO_NAME.put(OssFeatures.HAS_SECURITY_TEAM, "Does it have a security team?");
+    FEATURE_TO_NAME.put(OssFeatures.HAS_SECURITY_POLICY, "Does it have a security policy?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_SIGNED_COMMITS, "Does it use verified signed commits?");
+    FEATURE_TO_NAME.put(OssFeatures.VULNERABILITIES, "Info about vulnerabilities");
+    FEATURE_TO_NAME.put(OssFeatures.IS_APACHE, "Does it belong to Apache?");
+    FEATURE_TO_NAME.put(OssFeatures.IS_ECLIPSE, "Does it belong to Eclipse?");
+    FEATURE_TO_NAME.put(OssFeatures.SUPPORTED_BY_COMPANY, "Is it supported by a company?");
+    FEATURE_TO_NAME.put(OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES,
         "Does it scan for vulnerable dependencies?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.USES_GITHUB_FOR_DEVELOPMENT,
+    FEATURE_TO_NAME.put(OssFeatures.USES_GITHUB_FOR_DEVELOPMENT,
         "Does it use GitHub as the main development platform?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.USES_ADDRESS_SANITIZER,
-        "Does it use AddressSanitizer?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.USES_MEMORY_SANITIZER,
-        "Does it use MemorySanitizer?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.USES_UNDEFINED_BEHAVIOR_SANITIZER,
+    FEATURE_TO_NAME.put(OssFeatures.USES_ADDRESS_SANITIZER, "Does it use AddressSanitizer?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_MEMORY_SANITIZER, "Does it use MemorySanitizer?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_UNDEFINED_BEHAVIOR_SANITIZER,
         "Does it use UndefinedBehaviorSanitizer?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.USES_NOHTTP,
-        "Does it use nohttp?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.USES_FIND_SEC_BUGS,
-        "Does it use FindSecBugs?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.USES_DEPENDABOT,
-        "Does it use Dependabot?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.USES_LGTM_CHECKS,
-        "Does it use LGTM?");
-    FEATURE_TO_NAME.put(
-        OssFeatures.HAS_BUG_BOUNTY_PROGRAM,
-        "Does it have a bug bounty program?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_NOHTTP, "Does it use nohttp?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_FIND_SEC_BUGS, "Does it use FindSecBugs?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_DEPENDABOT, "Does it use Dependabot?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_LGTM_CHECKS, "Does it use LGTM?");
+    FEATURE_TO_NAME.put(OssFeatures.HAS_BUG_BOUNTY_PROGRAM, "Does it have a bug bounty program?");
   }
 
   @Override

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SingleSecurityRatingCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SingleSecurityRatingCalculator.java
@@ -3,6 +3,7 @@ package com.sap.sgs.phosphor.fosstars.tool.github;
 import com.sap.sgs.phosphor.fosstars.data.DataProvider;
 import com.sap.sgs.phosphor.fosstars.data.github.FuzzedInOssFuzz;
 import com.sap.sgs.phosphor.fosstars.data.github.GitHubDataFetcher;
+import com.sap.sgs.phosphor.fosstars.data.github.HasBugBountyProgram;
 import com.sap.sgs.phosphor.fosstars.data.github.HasCompanySupport;
 import com.sap.sgs.phosphor.fosstars.data.github.HasSecurityPolicy;
 import com.sap.sgs.phosphor.fosstars.data.github.HasSecurityTeam;
@@ -118,6 +119,7 @@ class SingleSecurityRatingCalculator extends AbstractRatingCalculator {
         new HasSecurityTeam(fetcher),
         new HasCompanySupport(fetcher),
         new HasSecurityPolicy(fetcher),
+        new HasBugBountyProgram(fetcher),
         new InfoAboutVulnerabilities(fetcher, nvd),
         new IsApache(fetcher),
         new IsEclipse(fetcher),

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/HasSecurityTeamTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/HasSecurityTeamTest.java
@@ -2,6 +2,7 @@ package com.sap.sgs.phosphor.fosstars.data.github;
 
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_TEAM;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -32,7 +33,7 @@ public class HasSecurityTeamTest extends TestGitHubDataFetcherHolder {
     provider.set(new GitHubProjectValueCache());
     Value<Boolean> value = check(provider, project);
     assertNotNull(value);
-    assertTrue(value.isUnknown());
+    assertFalse(value.get());
   }
 
   private static Value<Boolean> check(HasSecurityTeam provider, GitHubProject project) 

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/LgtmDataProviderTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/LgtmDataProviderTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -16,13 +17,13 @@ import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Test;
 import org.kohsuke.github.GHCheckRun;
 import org.kohsuke.github.GHCommit;
+import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.PagedIterable;
 import org.kohsuke.github.PagedIterator;
 
@@ -47,17 +48,27 @@ public class LgtmDataProviderTest extends TestGitHubDataFetcherHolder {
     GHCheckRun checkRun = mock(GHCheckRun.class);
     when(checkRun.getName()).thenReturn("LGTM analysis");
 
-    PagedIterator<GHCheckRun> iterator = mock(PagedIterator.class);
-    when(iterator.hasNext()).thenReturn(true, false);
-    when(iterator.next()).thenReturn(checkRun);
+    PagedIterator<GHCheckRun> checkRunPagedIterator = mock(PagedIterator.class);
+    when(checkRunPagedIterator.hasNext()).thenReturn(true, false);
+    when(checkRunPagedIterator.next()).thenReturn(checkRun);
 
-    PagedIterable<GHCheckRun> pagedIterable = mock(PagedIterable.class);
-    when(pagedIterable.iterator()).thenReturn(iterator);
+    PagedIterable<GHCheckRun> checkRunPagedIterable = mock(PagedIterable.class);
+    when(checkRunPagedIterable.iterator()).thenReturn(checkRunPagedIterator);
 
     GHCommit commit = mock(GHCommit.class);
-    when(commit.getCheckRuns()).thenReturn(pagedIterable);
+    when(commit.getCheckRuns()).thenReturn(checkRunPagedIterable);
 
-    fetcher.githubCommitsCache().put(project, Collections.singletonList(commit));
+    GHRepository repository = mock(GHRepository.class);
+    when(fetcher.github().getRepository(anyString())).thenReturn(repository);
+
+    PagedIterator<GHCommit> commitPagedIterator = mock(PagedIterator.class);
+    when(commitPagedIterator.hasNext()).thenReturn(true, false);
+    when(commitPagedIterator.next()).thenReturn(commit);
+
+    PagedIterable<GHCommit> commitPagedIterable = mock(PagedIterable.class);
+    when(commitPagedIterable.iterator()).thenReturn(commitPagedIterator);
+
+    when(repository.listCommits()).thenReturn(commitPagedIterable);
 
     try (InputStream content = getClass().getResourceAsStream("LgtmProjectInfoReply.json")) {
       when(entity.getContent()).thenReturn(content);
@@ -97,17 +108,26 @@ public class LgtmDataProviderTest extends TestGitHubDataFetcherHolder {
 
     GitHubProject project = new GitHubProject("org", "project");
 
-    PagedIterator<GHCheckRun> iterator = mock(PagedIterator.class);
-    when(iterator.hasNext()).thenReturn(false);
+    PagedIterator<GHCheckRun> checkRunPagedIterator = mock(PagedIterator.class);
+    when(checkRunPagedIterator.hasNext()).thenReturn(false);
 
-    PagedIterable<GHCheckRun> pagedIterable = mock(PagedIterable.class);
-    when(pagedIterable.iterator()).thenReturn(iterator);
+    PagedIterable<GHCheckRun> checkRunPagedIterable = mock(PagedIterable.class);
+    when(checkRunPagedIterable.iterator()).thenReturn(checkRunPagedIterator);
 
     GHCommit commit = mock(GHCommit.class);
-    when(commit.getCheckRuns()).thenReturn(pagedIterable);
+    when(commit.getCheckRuns()).thenReturn(checkRunPagedIterable);
 
-    fetcher.githubCommitsCache().put(project, Collections.singletonList(commit));
+    GHRepository repository = mock(GHRepository.class);
+    when(fetcher.github().getRepository(anyString())).thenReturn(repository);
 
+    PagedIterator<GHCommit> commitPagedIterator = mock(PagedIterator.class);
+    when(commitPagedIterator.hasNext()).thenReturn(true, false);
+    when(commitPagedIterator.next()).thenReturn(commit);
+
+    PagedIterable<GHCommit> commitPagedIterable = mock(PagedIterable.class);
+    when(commitPagedIterable.iterator()).thenReturn(commitPagedIterator);
+
+    when(repository.listCommits()).thenReturn(commitPagedIterable);
 
     try (InputStream content =
         getClass().getResourceAsStream("LgtmProjectDoesNotExistReply.json")) {

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/LanguagesTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/LanguagesTest.java
@@ -1,0 +1,67 @@
+package com.sap.sgs.phosphor.fosstars.model.value;
+
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.C;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVA;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.OTHER;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.PYTHON;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Iterator;
+import org.junit.Test;
+
+public class LanguagesTest {
+
+  @Test
+  public void testSorted() {
+    Languages languages = Languages.of(JAVA, OTHER, C);
+    Iterator<Language> iterator = languages.get().iterator();
+    assertEquals(C, iterator.next());
+    assertEquals(JAVA, iterator.next());
+    assertEquals(OTHER, iterator.next());
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  public void testContains() {
+    Languages languages = Languages.of(JAVA, C, OTHER);
+    assertEquals(3, languages.size());
+    assertTrue(languages.containsAnyOf(JAVA));
+    assertTrue(languages.containsAnyOf(C));
+    assertTrue(languages.containsAnyOf(OTHER));
+    assertTrue(languages.containsAnyOf(Languages.of(C, PYTHON)));
+  }
+
+  @Test
+  public void testToString() {
+    Languages languages = Languages.of(JAVA, C);
+    assertEquals("C, JAVA", languages.toString());
+  }
+
+  @Test
+  public void testSerialization() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    Languages languages = Languages.of(JAVA, C, OTHER);
+    Languages clone = mapper.readValue(mapper.writeValueAsBytes(languages), Languages.class);
+    assertEquals(languages, clone);
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    Languages one = Languages.of(C, PYTHON);
+    assertEquals(one, one);
+
+    Languages two = Languages.of(PYTHON, C);
+    assertTrue(one.equals(two) && two.equals(one));
+    assertEquals(one.hashCode(), two.hashCode());
+
+    Languages three = Languages.of(JAVA, C);
+    assertNotEquals(one, three);
+    assertNotEquals(two, three);
+  }
+
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/PackageManagersTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/PackageManagersTest.java
@@ -1,0 +1,69 @@
+package com.sap.sgs.phosphor.fosstars.model.value;
+
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.MAVEN;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.NPM;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.OTHER;
+import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.PIP;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Test;
+
+public class PackageManagersTest {
+
+  @Test
+  public void testSorted() {
+    PackageManagers packageManagers = PackageManagers.from(PIP, MAVEN, NPM);
+    List<PackageManager> list = packageManagers.list();
+    assertEquals(3, list.size());
+    assertEquals(MAVEN, list.get(0));
+    assertEquals(NPM, list.get(1));
+    assertEquals(PIP, list.get(2));
+  }
+
+  @Test
+  public void testContainsAndAdd() {
+    PackageManagers packageManagers = PackageManagers.from(PIP, MAVEN, NPM);
+    assertTrue(packageManagers.containsAny(PIP));
+    assertTrue(packageManagers.containsAny(MAVEN));
+    assertTrue(packageManagers.containsAny(NPM));
+    assertFalse(packageManagers.containsAny(OTHER));
+
+    packageManagers.add(OTHER);
+    assertTrue(packageManagers.containsAny(OTHER));
+  }
+
+  @Test
+  public void testToString() {
+    PackageManagers packageManagers = PackageManagers.from(PIP, MAVEN);
+    assertEquals("MAVEN, PIP", packageManagers.toString());
+  }
+
+  @Test
+  public void testSerialization() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    PackageManagers packageManagers = PackageManagers.from(PIP, MAVEN);
+    PackageManagers clone = mapper.readValue(
+        mapper.writeValueAsBytes(packageManagers), PackageManagers.class);
+    assertEquals(packageManagers, clone);
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    PackageManagers one = PackageManagers.from(PIP, MAVEN);
+    assertEquals(one, one);
+
+    PackageManagers two = PackageManagers.from(PIP, MAVEN);
+    assertTrue(one.equals(two) && two.equals(one));
+    assertEquals(one.hashCode(), two.hashCode());
+
+    PackageManagers three = PackageManagers.from(PIP, OTHER);
+    assertNotEquals(one, three);
+    assertNotEquals(two, three);
+  }
+}


### PR DESCRIPTION
Here is a list of main updates:

- Made `HasSecurityTeam` provider more confident. This closes #225.
- Updated `LgtmDataProvider` to check N latest commits. This closes #229.
- Updated `PrettyPrinter` to print sorted values. This closes #230.