### PR TITLE
Make GitHubDataFetcher thread safe

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubDataFetcher.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubDataFetcher.java
@@ -385,8 +385,8 @@ public class GitHubDataFetcher {
         throw new IOException(String.format("Hey! %s is not a file!", path));
       }
 
-      LOCAL_REPOSITORIES_INFO
-          .putAll(MAPPER.readValue(Files.newInputStream(path), LOCAL_REPOSITORIES_TYPE_REF));
+      LOCAL_REPOSITORIES_INFO.putAll(
+          MAPPER.readValue(Files.newInputStream(path), LOCAL_REPOSITORIES_TYPE_REF));
     }
   }
 
@@ -395,7 +395,7 @@ public class GitHubDataFetcher {
    *
    * @throws IOException If something went wrong.
    */
-  protected static void storeLocalRepositoriesInfo() throws IOException {
+  private static void storeLocalRepositoriesInfo() throws IOException {
     synchronized (LOCAL_REPOSITORIES_INFO) {
       Files.write(
           DEFAULT_PATH_LOCAL_REPOSITORIES_INFO_FILE,

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/FuzzedInOssFuzzTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/FuzzedInOssFuzzTest.java
@@ -1,6 +1,7 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
 import static com.sap.sgs.phosphor.fosstars.data.github.FuzzedInOssFuzz.OSS_FUZZ_PROJECT;
+import static com.sap.sgs.phosphor.fosstars.data.github.TestGitHubDataFetcherHolder.TestGitHubDataFetcher.addForTesting;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.FUZZED_IN_OSS_FUZZ;
 import static org.junit.Assert.assertEquals;
 
@@ -45,7 +46,7 @@ public class FuzzedInOssFuzzTest extends TestGitHubDataFetcherHolder {
           new LocalRepositoryInfo(directory, new Date(), OSS_FUZZ_PROJECT.url()),
           repository
       );
-      fetcher.addForTesting(OSS_FUZZ_PROJECT, localRepository);
+      addForTesting(OSS_FUZZ_PROJECT, localRepository);
 
       FuzzedInOssFuzz provider = new FuzzedInOssFuzz(fetcher);
       provider.set(new GitHubProjectValueCache());

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubDataFetcherTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubDataFetcherTest.java
@@ -3,23 +3,35 @@ package com.sap.sgs.phosphor.fosstars.data.github;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.junit.Test;
 import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
 
 public class GitHubDataFetcherTest extends TestGitHubDataFetcherHolder  {
 
@@ -78,5 +90,304 @@ public class GitHubDataFetcherTest extends TestGitHubDataFetcherHolder  {
             path, now, new URL("https://scm/org/test")),
         repository);
     assertFalse(fetcher.shouldUpdate(freshRepository));
+  }
+
+  @Test
+  public void testUpdateGithubInstance() throws IOException {
+    GitHub github = mock(GitHub.class);
+    fetcher = spy(new TestGitHubDataFetcher(github, path));
+    assertEquals(fetcher.github(), github);
+
+    // Create the second GitHub mock bean
+    GitHub github2 = mock(GitHub.class);
+    fetcher = spy(new TestGitHubDataFetcher(github2, path));
+    assertEquals(fetcher.github(), github2);
+  }
+
+  @Test
+  public void testLoadAndCleanRepository() throws IOException, InterruptedException {
+    GitHubProject project = new GitHubProject("test", "project");
+    Path projectDir = path.resolve(project.name());
+    try (
+        Repository repository = FileRepositoryBuilder.create(projectDir.resolve(".git").toFile())) {
+      repository.create();
+
+      createRepoTestFile(repository, project, "testfile");
+
+      fetcher.addRepositoryInfoForTesting(project, projectDir);
+
+      localRepositoryFor(project, 1);
+
+      cleanup(project, 0);
+    }
+  }
+
+  @Test
+  public void testCleanAndLoadRepository() throws IOException, InterruptedException {
+    GitHubProject project = new GitHubProject("test", "project");
+    Path projectDir = path.resolve(project.name());
+    try (
+        Repository repository = FileRepositoryBuilder.create(projectDir.resolve(".git").toFile())) {
+      repository.create();
+
+      createRepoTestFile(repository, project, "testFile");
+
+      cleanup(project, 0);
+
+      fetcher.addRepositoryInfoForTesting(project, projectDir);
+
+      localRepositoryFor(project, 1);
+    }
+  }
+
+  @Test
+  public void testMultiGithubInstanceAndAccessRepo() throws IOException {
+    // Create the first project with first GitHub mock instance.
+    GitHubProject firstProject = new GitHubProject("test", "project1");
+    Path project1Dir = path.resolve(firstProject.name());
+    GitHub github = mock(GitHub.class);
+    try (Repository repository =
+        FileRepositoryBuilder.create(project1Dir.resolve(".git").toFile())) {
+      repository.create();
+
+      createRepoTestFile(repository, firstProject, "testFile1");
+
+
+      fetcher = spy(new TestGitHubDataFetcher(github, path));
+
+      fetcher.addRepositoryInfoForTesting(firstProject, project1Dir);
+
+      localRepositoryFor(firstProject, 1);
+      assertEquals(fetcher.github(), github);
+    }
+
+    // Create the second project with second GitHub mock instance.
+    GitHubProject secondProject = new GitHubProject("test", "project2");
+    Path project2Dir = path.resolve(secondProject.name());
+    GitHub github2 = mock(GitHub.class);
+    try (Repository repository =
+        FileRepositoryBuilder.create(project2Dir.resolve(".git").toFile())) {
+      repository.create();
+
+      createRepoTestFile(repository, secondProject, "testFile2");
+
+      fetcher = spy(new TestGitHubDataFetcher(github2, path));
+
+      fetcher.addRepositoryInfoForTesting(secondProject, project2Dir);
+
+      localRepositoryFor(secondProject, 2);
+      assertEquals(fetcher.github(), github2);
+    }
+
+    // Create the third project with second GitHub mock instance.
+    GitHubProject thirdProject = new GitHubProject("test", "project3");
+
+    Path project3Dir = path.resolve(thirdProject.name());
+    try (Repository repository =
+        FileRepositoryBuilder.create(project3Dir.resolve(".git").toFile())) {
+      repository.create();
+      createRepoTestFile(repository, thirdProject, "testFile3");
+
+      fetcher.addRepositoryInfoForTesting(thirdProject, project3Dir);
+
+      localRepositoryFor(thirdProject, 3);
+      assertEquals(fetcher.github(), github2);
+    }
+  }
+
+  @Test
+  public void testMultiThreadReadAndUpdate() throws IOException, InterruptedException {
+    ScheduledExecutorService executorService = Executors.newScheduledThreadPool(2);
+
+    GitHubProject firstProject = new GitHubProject("test", "project");
+    Path project1Dir = path.resolve(firstProject.name());
+    try (Repository repository =
+        FileRepositoryBuilder.create(project1Dir.resolve(".git").toFile())) {
+      repository.create();
+
+      createRepoTestFile(repository, firstProject, "testFile");
+
+      fetcher.addRepositoryInfoForTesting(firstProject, project1Dir);
+
+      CountDownLatch latch = new CountDownLatch(1);
+
+      Runnable cleanTask = () -> {
+        try {
+          fetcher.cleanup((url, repo, total) -> {
+            latch.countDown();
+            return true;
+          });
+          checkCleanUp(firstProject, 0);
+        } catch (IOException e) {
+          throw new IllegalStateException("Clean up exception");
+        }
+      };
+
+      GitHubProject secondProject = new GitHubProject("test", "project2");
+
+      Runnable loadRepoTask = () -> {
+        try {
+          assertTrue(latch.await(10, TimeUnit.SECONDS));
+          fetcher.localRepositoryFor(secondProject);
+          checkLocalRepository(secondProject, 1);
+        } catch (InterruptedException | IOException e) {
+          throw new IllegalStateException("Load repository exception");
+        }
+      };
+
+      executorService.execute(cleanTask);
+      executorService.execute(loadRepoTask);
+    } finally {
+      executorService.shutdown();
+    }
+  }
+
+  @Test
+  public void testMultiThreadLocalRepoInfoTest() throws IOException, InterruptedException {
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+    GitHubProject project = new GitHubProject("test", "project");
+    Path projectDir = path.resolve(project.name());
+    try (
+        Repository repository = FileRepositoryBuilder.create(projectDir.resolve(".git").toFile())) {
+      repository.create();
+
+      createRepoTestFile(repository, project, "testFile");
+
+      fetcher.addRepositoryInfoForTesting(project, projectDir);
+
+      int numberOfThreads = 25;
+      CountDownLatch latch = new CountDownLatch(numberOfThreads);
+      for (int i = 0; i < numberOfThreads; i++) {
+        executorService.submit(() -> {
+          try {
+            localRepositoryFor(project);
+          } catch (IOException e) {
+            throw new IllegalStateException("Load repository exception");
+          }
+          latch.countDown();
+        });
+      }
+      latch.await();
+
+      checkLocalRepository(project, 1);
+    } finally {
+      executorService.shutdown();
+    }
+  }
+
+  @Test
+  public void testMultiThreadCleanUpTest() throws IOException, InterruptedException {
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+    GitHubProject project = new GitHubProject("test", "project");
+    Path projectDir = path.resolve(project.name());
+    try (
+        Repository repository = FileRepositoryBuilder.create(projectDir.resolve(".git").toFile())) {
+      repository.create();
+
+      createRepoTestFile(repository, project, "testFile");
+
+      fetcher.addRepositoryInfoForTesting(project, projectDir);
+
+      localRepositoryFor(project, 1);
+
+      int numberOfThreads = 25;
+      CountDownLatch latch = new CountDownLatch(numberOfThreads);
+      for (int i = 0; i < numberOfThreads; i++) {
+        executorService.submit(() -> {
+          try {
+            cleanup(project);
+          } catch (IOException e) {
+            throw new IllegalStateException("Clean up exception");
+          }
+          latch.countDown();
+        });
+      }
+      latch.await();
+
+      checkCleanUp(project, 0);
+    } finally {
+      executorService.shutdown();
+    }
+  }
+
+  @Test
+  public void testLocalRepositoriesInfoJson() throws IOException {
+    // Create the first project with first GitHub mock instance.
+    GitHubProject firstProject = new GitHubProject("test", "project1");
+    Path project1Dir = path.resolve(firstProject.name());
+    GitHub github = mock(GitHub.class);
+    try (Repository repository =
+        FileRepositoryBuilder.create(project1Dir.resolve(".git").toFile())) {
+      repository.create();
+
+      createRepoTestFile(repository, firstProject, "testFile1");
+
+      fetcher = spy(new TestGitHubDataFetcher(github, path));
+
+      fetcher.addRepositoryInfoForTesting(firstProject, project1Dir);
+
+      localRepositoryFor(firstProject, 1);
+    }
+
+    // Create the second project with second GitHub mock instance.
+    GitHubProject secondProject = new GitHubProject("test", "project2");
+    Path project2Dir = path.resolve(secondProject.name());
+    try (Repository repository =
+        FileRepositoryBuilder.create(project2Dir.resolve(".git").toFile())) {
+      repository.create();
+
+      createRepoTestFile(repository, secondProject, "testFile2");
+
+      fetcher.addRepositoryInfoForTesting(secondProject, project2Dir);
+
+      localRepositoryFor(secondProject, 2);
+    }
+
+    cleanup(firstProject, 1);
+    cleanup(secondProject, 0);
+  }
+
+  private void localRepositoryFor(GitHubProject project, int expectedSize) throws IOException {
+    localRepositoryFor(project);
+    checkLocalRepository(project, expectedSize);
+  }
+
+  private void localRepositoryFor(GitHubProject project) throws IOException {
+    fetcher.localRepositoryFor(project);
+  }
+
+  private void checkLocalRepository(GitHubProject project, int expectedSize) throws IOException {
+    Map<URL, LocalRepositoryInfo> repositories = fetcher.getLocalRespositoriesInfoForTesting();
+    assertTrue(repositories.size() == expectedSize);
+    LocalRepositoryInfo localRepositoryInfo = repositories.get(project.url());
+    assertNotNull(localRepositoryInfo);
+    assertEquals(project.url(), localRepositoryInfo.url());
+  }
+
+  private void cleanup(GitHubProject project, int expectedSize) throws IOException {
+    cleanup(project);
+    checkCleanUp(project, expectedSize);
+  }
+
+  private void cleanup(GitHubProject project) throws IOException {
+    fetcher.cleanup((url, repo, total) -> {
+      return url.equals(project.url());
+    });
+  }
+
+  private void checkCleanUp(GitHubProject project, int expectedSize) throws IOException {
+    Map<URL, LocalRepositoryInfo> localRepositories = fetcher.getLocalRespositoriesInfoForTesting();
+    assertTrue(localRepositories.size() == expectedSize);
+    LocalRepositoryInfo cleanRepositoryInfo = localRepositories.get(project.url());
+    assertNull(cleanRepositoryInfo);
+  }
+
+  private void createRepoTestFile(Repository repository, GitHubProject project, String fileName)
+      throws IOException {
+    Path testFilePath = new File(repository.getDirectory().getParent(), fileName).toPath();
+    String content = String.format("git clone %s", project.url());
+    Files.write(testFilePath, content.getBytes());
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubDataFetcherTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/GitHubDataFetcherTest.java
@@ -185,7 +185,7 @@ public class GitHubDataFetcherTest extends TestGitHubDataFetcherHolder  {
   }
 
   @Test
-  public void testMultiThreadLocalRepoInfoTest() throws IOException, InterruptedException {
+  public void testMultiThreadAccessToLocalRepoInfo() throws IOException, InterruptedException {
     ExecutorService executorService = Executors.newFixedThreadPool(10);
 
     GitHubProject project = new GitHubProject("test", "project");

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/HasSecurityPolicyTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/HasSecurityPolicyTest.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
+import static com.sap.sgs.phosphor.fosstars.data.github.TestGitHubDataFetcherHolder.TestGitHubDataFetcher.addForTesting;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_POLICY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -26,7 +27,7 @@ public class HasSecurityPolicyTest extends TestGitHubDataFetcherHolder {
 
     GitHubProject project = new GitHubProject("org", "test");
 
-    fetcher.addForTesting(project, repository);
+    addForTesting(project, repository);
 
     HasSecurityPolicy provider = new HasSecurityPolicy(fetcher);
     provider.set(new GitHubProjectValueCache());
@@ -40,7 +41,7 @@ public class HasSecurityPolicyTest extends TestGitHubDataFetcherHolder {
     when(repository.file("SECURITY.md")).thenReturn(Optional.empty());
 
     GitHubProject project = new GitHubProject("org", "test");
-    fetcher.addForTesting(project, repository);
+    addForTesting(project, repository);
 
     HasSecurityPolicy provider = new HasSecurityPolicy(fetcher);
     provider.set(new GitHubProjectValueCache());

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/NumberOfContributorsTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/NumberOfContributorsTest.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
+import static com.sap.sgs.phosphor.fosstars.data.github.TestGitHubDataFetcherHolder.TestGitHubDataFetcher.addForTesting;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -41,7 +42,7 @@ public class NumberOfContributorsTest extends TestGitHubDataFetcherHolder {
 
     GitHubProject project = new GitHubProject("org", "test");
 
-    fetcher.addForTesting(project, repository);
+    addForTesting(project, repository);
 
     NumberOfContributors provider = new NumberOfContributors(fetcher);
 

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/TestGitHubDataFetcherHolder.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/TestGitHubDataFetcherHolder.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
+import static com.sap.sgs.phosphor.fosstars.data.github.GitHubDataFetcher.DEFAULT_DIRECTORY;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -25,11 +26,6 @@ import org.kohsuke.github.GitHub;
 public class TestGitHubDataFetcherHolder {
 
   /**
-   * A base directory for {@link GitHubDataFetcher}.
-   */
-  protected Path path;
-
-  /**
    * An instance of {@link GitHubDataFetcher} for tests.
    */
   protected TestGitHubDataFetcher fetcher;
@@ -42,8 +38,7 @@ public class TestGitHubDataFetcherHolder {
   @Before
   public void init() throws IOException {
     GitHub github = mock(GitHub.class);
-    path = Files.createTempDirectory(getClass().getName());
-    fetcher = spy(new TestGitHubDataFetcher(github, path));
+    fetcher = spy(new TestGitHubDataFetcher(github));
   }
 
   /**
@@ -63,7 +58,7 @@ public class TestGitHubDataFetcherHolder {
       assertFalse(Files.exists(deletedPath));
     }
 
-    FileUtils.forceDeleteOnExit(path.toFile());
+    FileUtils.forceDeleteOnExit(DEFAULT_DIRECTORY.toFile());
   }
 
   public static class TestGitHubDataFetcher extends GitHubDataFetcher {
@@ -71,8 +66,8 @@ public class TestGitHubDataFetcherHolder {
     /**
      * Test class constructor.
      */
-    public TestGitHubDataFetcher(GitHub github, Path base) throws IOException {
-      super(github, base);
+    public TestGitHubDataFetcher(GitHub github) throws IOException {
+      super(github);
     }
 
     /**
@@ -91,6 +86,7 @@ public class TestGitHubDataFetcherHolder {
      * @throws IOException if something goes wrong.
      */
     public Map<URL, LocalRepositoryInfo> getLocalRespositoriesInfoForTesting() throws IOException {
+      loadLocalRepositoriesInfo();
       return LOCAL_REPOSITORIES_INFO;
     }
     
@@ -98,7 +94,7 @@ public class TestGitHubDataFetcherHolder {
      * Add new project to be considered while loading repository.
      *  
      * @param project The {@link GitHubProject}.
-     * @param projectDir The local {@link Path} of for the {@link GitHubProject}.
+     * @param projectDir The local {@link Path} for the {@link GitHubProject}.
      */
     public void addRepositoryInfoForTesting(GitHubProject project, Path projectDir) {
       LOCAL_REPOSITORIES.remove(project);
@@ -109,6 +105,16 @@ public class TestGitHubDataFetcherHolder {
     @Override
     protected void clone(GitHubProject project, Path base) {
       // do nothing
+    }
+
+    /**
+     * Returns a resolved valid directory path of the project.
+     *  
+     * @param project of type {@link GitHubProject}.
+     * @return path of type {@link Path}. 
+     */
+    static Path directoryFor(GitHubProject project) {
+      return DEFAULT_DIRECTORY.resolve(project.name());
     }
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/TestGitHubDataFetcherHolder.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/TestGitHubDataFetcherHolder.java
@@ -1,6 +1,7 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
-import static com.sap.sgs.phosphor.fosstars.data.github.GitHubDataFetcher.DEFAULT_DIRECTORY;
+import static com.sap.sgs.phosphor.fosstars.data.github.GitHubDataFetcher.REPOSITORIES_BASE_PATH;
+import static com.sap.sgs.phosphor.fosstars.data.github.GitHubDataFetcher.REPOSITORIES_BASE_PATH_PROPERTY;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -23,6 +24,10 @@ import org.kohsuke.github.GitHub;
  */
 public class TestGitHubDataFetcherHolder {
 
+  static {
+    System.setProperty(REPOSITORIES_BASE_PATH_PROPERTY, ".fosstars/test_repositories");
+  }
+
   /**
    * An instance of {@link GitHubDataFetcher} for tests.
    */
@@ -35,8 +40,7 @@ public class TestGitHubDataFetcherHolder {
    */
   @Before
   public void init() throws IOException {
-    GitHub github = mock(GitHub.class);
-    fetcher = spy(new TestGitHubDataFetcher(github));
+    fetcher = spy(new TestGitHubDataFetcher(mock(GitHub.class)));
   }
 
   /**
@@ -56,7 +60,7 @@ public class TestGitHubDataFetcherHolder {
       assertFalse(Files.exists(deletedPath));
     }
 
-    FileUtils.forceDeleteOnExit(DEFAULT_DIRECTORY.toFile());
+    FileUtils.forceDeleteOnExit(REPOSITORIES_BASE_PATH.toFile());
   }
 
   public static class TestGitHubDataFetcher extends GitHubDataFetcher {
@@ -70,6 +74,7 @@ public class TestGitHubDataFetcherHolder {
 
     /**
      * Adds {@link GitHubProject} and its associated {@link LocalRepository} details to cache.
+     *
      * @param project The {@link GitHubProject}.
      * @param repository The {@link LocalRepository}.
      */
@@ -78,7 +83,7 @@ public class TestGitHubDataFetcherHolder {
     }
     
     /**
-     * Add new project to be considered while loading repository.
+     * Add a new project to be considered while loading repository.
      *  
      * @param project The {@link GitHubProject}.
      * @param projectDir The local {@link Path} for the {@link GitHubProject}.
@@ -89,11 +94,6 @@ public class TestGitHubDataFetcherHolder {
           new LocalRepositoryInfo(projectDir, Date.from(Instant.now()), project.url()));
     }
 
-    @Override
-    protected void clone(GitHubProject project, Path base) {
-      // do nothing
-    }
-
     /**
      * Returns a resolved valid directory path of the project.
      *  
@@ -101,7 +101,7 @@ public class TestGitHubDataFetcherHolder {
      * @return path of type {@link Path}. 
      */
     static Path directoryFor(GitHubProject project) {
-      return DEFAULT_DIRECTORY.resolve(project.name());
+      return REPOSITORIES_BASE_PATH.resolve(project.name());
     }
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/TestGitHubDataFetcherHolder.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/TestGitHubDataFetcherHolder.java
@@ -7,14 +7,12 @@ import static org.mockito.Mockito.spy;
 
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -75,19 +73,8 @@ public class TestGitHubDataFetcherHolder {
      * @param project The {@link GitHubProject}.
      * @param repository The {@link LocalRepository}.
      */
-    public void addForTesting(GitHubProject project, LocalRepository repository) {
+    static void addForTesting(GitHubProject project, LocalRepository repository) {
       LOCAL_REPOSITORIES.put(project, repository);
-    }
-
-    /**
-     * Returns the current list of local repositories stored in the base folder.
-     *
-     * @return Map of local repositories available.
-     * @throws IOException if something goes wrong.
-     */
-    public Map<URL, LocalRepositoryInfo> getLocalRespositoriesInfoForTesting() throws IOException {
-      loadLocalRepositoriesInfo();
-      return LOCAL_REPOSITORIES_INFO;
     }
     
     /**
@@ -96,7 +83,7 @@ public class TestGitHubDataFetcherHolder {
      * @param project The {@link GitHubProject}.
      * @param projectDir The local {@link Path} for the {@link GitHubProject}.
      */
-    public void addRepositoryInfoForTesting(GitHubProject project, Path projectDir) {
+    static void addRepositoryInfoForTesting(GitHubProject project, Path projectDir) {
       LOCAL_REPOSITORIES.remove(project);
       LOCAL_REPOSITORIES_INFO.put(project.url(),
           new LocalRepositoryInfo(projectDir, Date.from(Instant.now()), project.url()));

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesDependabotTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesDependabotTest.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
+import static com.sap.sgs.phosphor.fosstars.data.github.TestGitHubDataFetcherHolder.TestGitHubDataFetcher.addForTesting;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -45,7 +46,7 @@ public class UsesDependabotTest extends TestGitHubDataFetcherHolder {
     when(repository.commitsAfter(any())).thenReturn(commits);
 
     GitHubProject project = new GitHubProject("org", "test");
-    fetcher.addForTesting(project, repository);
+    addForTesting(project, repository);
 
     testProvider(true, project, provider);
   }
@@ -60,7 +61,7 @@ public class UsesDependabotTest extends TestGitHubDataFetcherHolder {
         .thenReturn(Optional.of(StringUtils.repeat("x", 1000)));
 
     GitHubProject project = new GitHubProject("org", "test");
-    fetcher.addForTesting(project, repository);
+    addForTesting(project, repository);
 
     testProvider(true, project, provider);
   }
@@ -89,7 +90,7 @@ public class UsesDependabotTest extends TestGitHubDataFetcherHolder {
     when(repository.commitsAfter(any())).thenReturn(commits);
 
     GitHubProject project = new GitHubProject("org", "test");
-    fetcher.addForTesting(project, repository);
+    addForTesting(project, repository);
 
     testProvider(false, project, provider);
   }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesFindSecBugsTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesFindSecBugsTest.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
+import static com.sap.sgs.phosphor.fosstars.data.github.TestGitHubDataFetcherHolder.TestGitHubDataFetcher.addForTesting;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_FIND_SEC_BUGS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -46,7 +47,7 @@ public class UsesFindSecBugsTest extends TestGitHubDataFetcherHolder {
     when(repository.read(filename)).thenReturn(Optional.of(is));
 
     GitHubProject project = new GitHubProject("org", "test");
-    fetcher.addForTesting(project, repository);
+    addForTesting(project, repository);
 
     UsesFindSecBugs provider = new UsesFindSecBugs(fetcher);
     provider.set(new GitHubProjectValueCache());

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesNoHttpToolTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesNoHttpToolTest.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
+import static com.sap.sgs.phosphor.fosstars.data.github.TestGitHubDataFetcherHolder.TestGitHubDataFetcher.addForTesting;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -60,7 +61,7 @@ public class UsesNoHttpToolTest extends TestGitHubDataFetcherHolder {
     when(repository.read(filename)).thenReturn(Optional.of(is));
 
     GitHubProject project = new GitHubProject("org", "test");
-    fetcher.addForTesting(project, repository);
+    addForTesting(project, repository);
 
     UsesNoHttpTool provider = new UsesNoHttpTool(fetcher);
     provider.set(new GitHubProjectValueCache());

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesOwaspDependencyCheckTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesOwaspDependencyCheckTest.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
+import static com.sap.sgs.phosphor.fosstars.data.github.TestGitHubDataFetcherHolder.TestGitHubDataFetcher.addForTesting;
 import static com.sap.sgs.phosphor.fosstars.data.github.UsesOwaspDependencyCheck.USES_OWASP_DEPENDENCY_CHECK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -97,7 +98,7 @@ public class UsesOwaspDependencyCheckTest extends TestGitHubDataFetcherHolder {
     when(repository.read(filename)).thenReturn(Optional.of(is));
 
     GitHubProject project = new GitHubProject("org", "test");
-    fetcher.addForTesting(project, repository);
+    addForTesting(project, repository);
 
     UsesOwaspDependencyCheck provider = new UsesOwaspDependencyCheck(fetcher);
     provider.set(new GitHubProjectValueCache());

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesSanitizersTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesSanitizersTest.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
+import static com.sap.sgs.phosphor.fosstars.data.github.TestGitHubDataFetcherHolder.TestGitHubDataFetcher.addForTesting;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_ADDRESS_SANITIZER;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_MEMORY_SANITIZER;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_UNDEFINED_BEHAVIOR_SANITIZER;
@@ -118,7 +119,7 @@ public class UsesSanitizersTest extends TestGitHubDataFetcherHolder {
     when(repository.file(any(Path.class))).thenReturn(Optional.of(content));
 
     GitHubProject project = new GitHubProject("org", "test");
-    fetcher.addForTesting(project, repository);
+    addForTesting(project, repository);
 
     ValueSet values = provider.fetchValuesFor(project);
     assertEquals(3, values.size());

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesSignedCommitTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/UsesSignedCommitTest.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.data.github;
 
+import static com.sap.sgs.phosphor.fosstars.data.github.TestGitHubDataFetcherHolder.TestGitHubDataFetcher.addForTesting;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_SIGNED_COMMITS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -44,7 +45,7 @@ public class UsesSignedCommitTest extends TestGitHubDataFetcherHolder {
     when(repository.commitsWithin(any())).thenReturn(commits);
 
     GitHubProject project = new GitHubProject("org", "test");
-    fetcher.addForTesting(project, repository);
+    addForTesting(project, repository);
 
     ValueHashSet values = new ValueHashSet();
     assertEquals(0, values.size());
@@ -67,7 +68,7 @@ public class UsesSignedCommitTest extends TestGitHubDataFetcherHolder {
     when(repository.commitsWithin(any())).thenThrow(new IOException());
 
     GitHubProject project = new GitHubProject("org", "test");
-    fetcher.addForTesting(project, repository);
+    addForTesting(project, repository);
 
     ValueHashSet values = new ValueHashSet();
     assertEquals(0, values.size());


### PR DESCRIPTION
- `localRepositoriesInfo` has to be set to `static`.
  - Also, with new `GitHubDataFetcher` instance, this Map is loaded with the current list of local repositories. As expected.
- `storeLocalRepositoriesInfo()` is required at the end of `cleanup()`
- Add multiple test case scenarios
  - Update GitHub instance and confirm if fetcher is using the new GitHub instance
  - Load a repository and clean up the repository
  - Clean up the repository without loading the repository
  - Test multi-thread access to synchronized methods
  - Test multi-thread parallel access to a single synchronized method
  - Check if localRepositoriesInfo.json file is being updated on each load and clean up tasks

This fixes #210 
This fixes #221