### PR TITLE
New feature for signing artifacts

### DIFF
--- a/docs/oss_security_rating.md
+++ b/docs/oss_security_rating.md
@@ -13,6 +13,7 @@ Implementations of the features can be found in
 1.  If an open-source project has a security team.
 1.  If an open-source project has a security policy.
 1.  If an open-source project has a bug bounty program.
+1.  If an open-source project signs its artifacts.
 1.  If an open-source project is regularly scanned for vulnerable dependencies.
 1.  If a project uses Dependabot.
 1.  If an open-source project uses FindSecBugs.
@@ -75,6 +76,7 @@ Implementations for all the scores can be found in the [com.sap.sgs.phosphor.fos
     1.  If an open-source project has a security policy.
     1.  If a project uses signed commits.
     1.  If an open-source project has a bug bounty program.
+    1.  If an open-source project signs its artifacts.
 1.  **Project activity score** based on the following features:
     1.  Number of commits last three months.
     1.  Number of contributors last three months.

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/SignsJarArtifacts.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/SignsJarArtifacts.java
@@ -1,0 +1,79 @@
+package com.sap.sgs.phosphor.fosstars.data.github;
+
+import static com.sap.sgs.phosphor.fosstars.maven.MavenUtils.readModel;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
+
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures;
+import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+
+/**
+ * <p>This data provider checks if an open-source project signs its JAR artifacts. In particular,
+ * the data provider checks if a project uses
+ * <a href="http://maven.apache.org/plugins/maven-gpg-plugin/">Maven GPG plugin</a>.</p>
+ * <p>The provider fills out the {@link OssFeatures#SIGNS_ARTIFACTS} feature.</p>
+ */
+public class SignsJarArtifacts extends CachedSingleFeatureGitHubDataProvider {
+
+  /**
+   * Initializes a data provider.
+   *
+   * @param fetcher An interface to GitHub.
+   */
+  public SignsJarArtifacts(GitHubDataFetcher fetcher) {
+    super(fetcher);
+  }
+
+  @Override
+  protected Feature supportedFeature() {
+    return SIGNS_ARTIFACTS;
+  }
+
+  @Override
+  protected Value fetchValueFor(GitHubProject project) throws IOException {
+    logger.info("Figuring out if the project signs jar files ...");
+    LocalRepository repository = fetcher.localRepositoryFor(project);
+    boolean answer = checkMaven(repository);
+    return SIGNS_ARTIFACTS.value(answer);
+  }
+
+  /**
+   * Checks if a project uses Maven GPG plugin.
+   *
+   * @param repository The project's repository.
+   * @return True if the project uses Maven GPG plugin, false otherwise.
+   * @throws IOException If something went wrong.
+   */
+  private boolean checkMaven(LocalRepository repository) throws IOException {
+    Optional<InputStream> content = repository.read("pom.xml");
+
+    if (!content.isPresent()) {
+      return false;
+    }
+
+    Model model = readModel(content.get());
+    Build build = model.getBuild();
+
+    return build != null && build.getPlugins().stream().anyMatch(SignsJarArtifacts::isMavenGpg);
+  }
+
+  /**
+   * Checks a plugin is the Maven GPG plugin.
+   *
+   * @param plugin The plugin to be checked.
+   * @return True if the plugin is the Maven GPG plugin, false otherwise.
+   */
+  private static boolean isMavenGpg(Plugin plugin) {
+    return plugin != null
+        && "org.apache.maven.plugins".equals(plugin.getGroupId())
+        && "maven-gpg-plugin".equals(plugin.getArtifactId());
+  }
+
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesFindSecBugs.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesFindSecBugs.java
@@ -173,7 +173,7 @@ public class UsesFindSecBugs extends CachedSingleFeatureGitHubDataProvider {
   private static class Visitor implements ModelVisitor {
 
     /**
-     * A visitor for searching OWASP Dependency Check in a POM file.
+     * A visitor for searching FindSecBugs in a POM file.
      */
     private boolean result = false;
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/feature/oss/OssFeatures.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/feature/oss/OssFeatures.java
@@ -210,4 +210,10 @@ public class OssFeatures {
    */
   public static final Feature<Boolean> HAS_BUG_BOUNTY_PROGRAM
       = new BooleanFeature("If a project has a bug bounty program");
+
+  /**
+   * Shows if an open-source project signs its artifacts (for example, jar files).
+   */
+  public static final Feature<Boolean> SIGNS_ARTIFACTS
+      = new BooleanFeature("If a project signs artifacts");
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityAwarenessScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityAwarenessScore.java
@@ -3,6 +3,7 @@ package com.sap.sgs.phosphor.fosstars.model.score.oss;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_BUG_BOUNTY_PROGRAM;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_POLICY;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_TEAM;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_SIGNED_COMMITS;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.findValue;
 
@@ -42,6 +43,11 @@ public class ProjectSecurityAwarenessScore extends FeatureBasedScore {
   private static final double SIGNED_COMMITS_POINTS = 2.0;
 
   /**
+   * A number of points which are added to a score value if a project signs its artifacts.
+   */
+  private static final double SIGNED_ARTIFICTS_POINTS = 2.0;
+
+  /**
    * A number of points which are added to a score value if a project has a bug bounty program.
    */
   private static final double BUG_BOUNTY_PROGRAM_POINTS = 4.0;
@@ -50,20 +56,22 @@ public class ProjectSecurityAwarenessScore extends FeatureBasedScore {
    * A description of the score.
    */
   private static final String DESCRIPTION = String.format(
-      "The score checks if a project has a security policy and a security team.\n"
+      "The score shows how a project is aware of security.\n"
           + "If the project has a security policy, then the score adds %2.2f.\n"
           + "If the project has a security team, then the score adds %2.2f.\n"
           + "If the project uses verified signed commits, then the score adds %2.2f.\n"
-          + "If the project has a bug bounty program, then the score adds %2.2f.",
+          + "If the project has a bug bounty program, then the score adds %2.2f\n"
+          + "If the project signs its artifacts, then the score adds %2.2f.",
       SECURITY_POLICY_POINTS, SECURITY_TEAM_POINTS, SIGNED_COMMITS_POINTS,
-      BUG_BOUNTY_PROGRAM_POINTS);
+      BUG_BOUNTY_PROGRAM_POINTS, SIGNED_ARTIFICTS_POINTS);
 
   /**
    * Initializes a new {@link ProjectSecurityAwarenessScore}.
    */
   ProjectSecurityAwarenessScore() {
     super("How well open-source community is aware about security", DESCRIPTION,
-        HAS_SECURITY_POLICY, HAS_SECURITY_TEAM, USES_SIGNED_COMMITS, HAS_BUG_BOUNTY_PROGRAM);
+        HAS_SECURITY_POLICY, HAS_SECURITY_TEAM, USES_SIGNED_COMMITS, HAS_BUG_BOUNTY_PROGRAM,
+        SIGNS_ARTIFACTS);
   }
 
   @Override
@@ -76,31 +84,39 @@ public class ProjectSecurityAwarenessScore extends FeatureBasedScore {
         "Hey! You have to tell me if the project uses verified signed commits!");
     Value<Boolean> hasBugBountyProgram = findValue(values, HAS_BUG_BOUNTY_PROGRAM,
         "Hey! You have to tell me if the project has a bug bounty program!");
+    Value<Boolean> signsArtifacts = findValue(values, SIGNS_ARTIFACTS,
+        "Hey! You have to tell me if the project signs its artifacts!");
 
     ScoreValue scoreValue = scoreValue(MIN,
-        securityPolicy, securityTeam, signedCommits, hasBugBountyProgram);
+        securityPolicy, securityTeam, signedCommits, hasBugBountyProgram, signsArtifacts);
 
-    securityPolicy.processIfKnown(exist -> {
-      if (exist) {
+    securityPolicy.processIfKnown(exists -> {
+      if (exists) {
         scoreValue.increase(SECURITY_POLICY_POINTS);
       }
     });
 
-    securityTeam.processIfKnown(exist -> {
-      if (exist) {
+    securityTeam.processIfKnown(exists -> {
+      if (exists) {
         scoreValue.increase(SECURITY_TEAM_POINTS);
       }
     });
 
-    signedCommits.processIfKnown(exist -> {
-      if (exist) {
+    signedCommits.processIfKnown(yes -> {
+      if (yes) {
         scoreValue.increase(SIGNED_COMMITS_POINTS);
       }
     });
 
-    hasBugBountyProgram.processIfKnown(exist -> {
-      if (exist) {
+    hasBugBountyProgram.processIfKnown(exists -> {
+      if (exists) {
         scoreValue.increase(BUG_BOUNTY_PROGRAM_POINTS);
+      }
+    });
+
+    signsArtifacts.processIfKnown(yes -> {
+      if (yes) {
+        scoreValue.increase(SIGNED_ARTIFICTS_POINTS);
       }
     });
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinter.java
@@ -86,6 +86,7 @@ public class PrettyPrinter implements Formatter {
     FEATURE_TO_NAME.put(OssFeatures.USES_DEPENDABOT, "Does it use Dependabot?");
     FEATURE_TO_NAME.put(OssFeatures.USES_LGTM_CHECKS, "Does it use LGTM?");
     FEATURE_TO_NAME.put(OssFeatures.HAS_BUG_BOUNTY_PROGRAM, "Does it have a bug bounty program?");
+    FEATURE_TO_NAME.put(OssFeatures.SIGNS_ARTIFACTS, "Does it sign artifacts?");
   }
 
   @Override

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SingleSecurityRatingCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SingleSecurityRatingCalculator.java
@@ -18,6 +18,7 @@ import com.sap.sgs.phosphor.fosstars.data.github.NumberOfWatchers;
 import com.sap.sgs.phosphor.fosstars.data.github.PackageManagement;
 import com.sap.sgs.phosphor.fosstars.data.github.ProgrammingLanguages;
 import com.sap.sgs.phosphor.fosstars.data.github.ScansForVulnerableDependencies;
+import com.sap.sgs.phosphor.fosstars.data.github.SignsJarArtifacts;
 import com.sap.sgs.phosphor.fosstars.data.github.UsesDependabot;
 import com.sap.sgs.phosphor.fosstars.data.github.UsesFindSecBugs;
 import com.sap.sgs.phosphor.fosstars.data.github.UsesGithubForDevelopment;
@@ -134,6 +135,7 @@ class SingleSecurityRatingCalculator extends AbstractRatingCalculator {
         new UsesSanitizers(fetcher),
         new UsesFindSecBugs(fetcher),
         new FuzzedInOssFuzz(fetcher),
+        new SignsJarArtifacts(fetcher),
 
         // currently interactive data provider have to be added to the end, see issue #133
         new AskAboutSecurityTeam<>(),

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
@@ -56,6 +56,11 @@ defaults:
     type: "BooleanFeature"
     name: "If a project has a bug bounty program"
   flag: false
+- type: "BooleanValue"
+  feature:
+    type: "BooleanFeature"
+    name: "If a project signs artifacts"
+  flag: false
 
 # test vectors
 elements:

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityAwarenessScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/ProjectSecurityAwarenessScoreTestVectors.yml
@@ -19,6 +19,10 @@ elements:
     feature:
       type: "BooleanFeature"
       name: "If a project has a bug bounty program"
+  - type: "UnknownValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project signs artifacts"
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -50,6 +54,11 @@ elements:
     feature:
       type: "BooleanFeature"
       name: "If a project has a bug bounty program"
+    flag: false
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project signs artifacts"
     flag: false
   expectedScore:
     type: "DoubleInterval"
@@ -83,6 +92,11 @@ elements:
       type: "BooleanFeature"
       name: "If a project has a bug bounty program"
     flag: false
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project signs artifacts"
+    flag: false
   expectedScore:
     type: "DoubleInterval"
     from: 6.0
@@ -114,6 +128,11 @@ elements:
     feature:
       type: "BooleanFeature"
       name: "If a project has a bug bounty program"
+    flag: false
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project signs artifacts"
     flag: false
   expectedScore:
     type: "DoubleInterval"
@@ -147,6 +166,11 @@ elements:
       type: "BooleanFeature"
       name: "If a project has a bug bounty program"
     flag: false
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project signs artifacts"
+    flag: false
   expectedScore:
     type: "DoubleInterval"
     from: 4.0
@@ -178,6 +202,11 @@ elements:
     feature:
       type: "BooleanFeature"
       name: "If a project has a bug bounty program"
+    flag: false
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project signs artifacts"
     flag: false
   expectedScore:
     type: "DoubleInterval"
@@ -211,6 +240,11 @@ elements:
       type: "BooleanFeature"
       name: "If a project has a bug bounty program"
     flag: false
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project signs artifacts"
+    flag: false
   expectedScore:
     type: "DoubleInterval"
     from: 1.0
@@ -242,6 +276,11 @@ elements:
     feature:
       type: "BooleanFeature"
       name: "If a project has a bug bounty program"
+    flag: false
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project signs artifacts"
     flag: false
   expectedScore:
     type: "DoubleInterval"
@@ -275,6 +314,11 @@ elements:
       type: "BooleanFeature"
       name: "If a project has a bug bounty program"
     flag: false
+  - type: "BooleanValue"
+    feature:
+      type: "BooleanFeature"
+      name: "If a project signs artifacts"
+    flag: false
   expectedScore:
     type: "DoubleInterval"
     from: 7.0
@@ -307,6 +351,11 @@ elements:
         type: "BooleanFeature"
         name: "If a project has a bug bounty program"
       flag: true
+    - type: "BooleanValue"
+      feature:
+        type: "BooleanFeature"
+        name: "If a project signs artifacts"
+      flag: false
   expectedScore:
     type: "DoubleInterval"
     from: 9.0
@@ -338,6 +387,11 @@ elements:
       feature:
         type: "BooleanFeature"
         name: "If a project has a bug bounty program"
+      flag: true
+    - type: "BooleanValue"
+      feature:
+        type: "BooleanFeature"
+        name: "If a project signs artifacts"
       flag: true
   expectedScore:
     type: "DoubleInterval"

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/SignsJarArtifactsTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/SignsJarArtifactsTest.java
@@ -1,0 +1,71 @@
+package com.sap.sgs.phosphor.fosstars.data.github;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.ValueSet;
+import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
+import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
+import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProjectValueCache;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import org.junit.Test;
+
+public class SignsJarArtifactsTest extends TestGitHubDataFetcherHolder {
+
+  @Test
+  public void testSupportedFeature() {
+    SignsJarArtifacts provider = new SignsJarArtifacts(fetcher);
+    assertEquals(SIGNS_ARTIFACTS, provider.supportedFeature());
+  }
+
+  @Test
+  public void testWithMavenGpgPlugin() throws IOException {
+    try (InputStream is = getClass().getResourceAsStream("MavenPomWithMavenGPG.xml")) {
+      checkValue(createProvider(is, "pom.xml"), true);
+    }
+  }
+
+  @Test
+  public void testWithoutMavenGpgPlugin() throws IOException {
+    try (InputStream is = getClass().getResourceAsStream("MavenPomWithoutMavenGPG.xml")) {
+      checkValue(createProvider(is, "pom.xml"), false);
+    }
+  }
+
+  private SignsJarArtifacts createProvider(InputStream is, String filename) throws IOException {
+    final LocalRepository repository = mock(LocalRepository.class);
+    when(repository.read(filename)).thenReturn(Optional.of(is));
+
+    GitHubProject project = new GitHubProject("org", "test");
+    fetcher.addForTesting(project, repository);
+
+    SignsJarArtifacts provider = new SignsJarArtifacts(fetcher);
+    provider.set(new GitHubProjectValueCache());
+
+    return provider;
+  }
+
+  private static void checkValue(SignsJarArtifacts provider, boolean expectedValue)
+      throws IOException {
+
+    GitHubProject project = new GitHubProject("org", "test");
+
+    ValueSet values = new ValueHashSet();
+    provider.update(project, values);
+
+    assertEquals(1, values.size());
+    assertTrue(values.has(SIGNS_ARTIFACTS));
+
+    Optional<Value> something = values.of(SIGNS_ARTIFACTS);
+    assertTrue(something.isPresent());
+
+    Value actualValue = something.get();
+    assertEquals(expectedValue, actualValue.get());
+  }
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
@@ -14,6 +14,7 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_ADDRESS_SANITIZER;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
@@ -87,6 +88,7 @@ public class OssSecurityScoreTest {
         HAS_SECURITY_TEAM.value(false),
         HAS_SECURITY_POLICY.value(false),
         HAS_BUG_BOUNTY_PROGRAM.value(false),
+        SIGNS_ARTIFACTS.value(true),
         SCANS_FOR_VULNERABLE_DEPENDENCIES.value(false),
         VULNERABILITIES.value(new Vulnerabilities()),
         PROJECT_START_DATE.value(new Date()),

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTuningWithCMAESTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTuningWithCMAESTest.java
@@ -14,6 +14,7 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_ADDRESS_SANITIZER;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
@@ -46,6 +47,7 @@ import org.junit.Test;
 public class OssSecurityScoreTuningWithCMAESTest {
 
   private static final Vulnerabilities NO_VULNERABILITIES = new Vulnerabilities();
+
   private static final Date FIVE_YEARS_AGO
       = new Date(System.currentTimeMillis() - 5 * 365 * 24 * 60 * 60 * 1000L);
 
@@ -63,6 +65,7 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(UnknownValue.of(HAS_SECURITY_POLICY))
           .set(UnknownValue.of(HAS_SECURITY_TEAM))
           .set(UnknownValue.of(HAS_BUG_BOUNTY_PROGRAM))
+          .set(UnknownValue.of(SIGNS_ARTIFACTS))
           .set(UnknownValue.of(SCANS_FOR_VULNERABLE_DEPENDENCIES))
           .set(UnknownValue.of(VULNERABILITIES))
           .set(UnknownValue.of(PROJECT_START_DATE))
@@ -95,6 +98,7 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(HAS_SECURITY_POLICY.value(false))
           .set(HAS_SECURITY_TEAM.value(false))
           .set(HAS_BUG_BOUNTY_PROGRAM.value(false))
+          .set(SIGNS_ARTIFACTS.value(false))
           .set(SCANS_FOR_VULNERABLE_DEPENDENCIES.value(false))
           .set(VULNERABILITIES.value(NO_VULNERABILITIES))
           .set(PROJECT_START_DATE.value(FIVE_YEARS_AGO))
@@ -127,6 +131,7 @@ public class OssSecurityScoreTuningWithCMAESTest {
           .set(HAS_SECURITY_POLICY.value(true))
           .set(HAS_SECURITY_TEAM.value(true))
           .set(HAS_BUG_BOUNTY_PROGRAM.value(true))
+          .set(SIGNS_ARTIFACTS.value(true))
           .set(SCANS_FOR_VULNERABLE_DEPENDENCIES.value(true))
           .set(VULNERABILITIES.value(NO_VULNERABILITIES))
           .set(PROJECT_START_DATE.value(FIVE_YEARS_AGO))

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinterTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinterTest.java
@@ -15,6 +15,7 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_ADDRESS_SANITIZER;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
@@ -66,6 +67,7 @@ public class PrettyPrinterTest {
         HAS_SECURITY_TEAM.value(false),
         HAS_SECURITY_POLICY.value(false),
         HAS_BUG_BOUNTY_PROGRAM.value(false),
+        SIGNS_ARTIFACTS.value(false),
         SCANS_FOR_VULNERABLE_DEPENDENCIES.value(false),
         VULNERABILITIES.value(new Vulnerabilities()),
         PROJECT_START_DATE.value(new Date()),
@@ -121,6 +123,7 @@ public class PrettyPrinterTest {
         HAS_SECURITY_TEAM.value(false),
         HAS_SECURITY_POLICY.value(false),
         HAS_BUG_BOUNTY_PROGRAM.value(true),
+        SIGNS_ARTIFACTS.value(true),
         SCANS_FOR_VULNERABLE_DEPENDENCIES.value(false),
         VULNERABILITIES.value(new Vulnerabilities()),
         PROJECT_START_DATE.value(new Date()),

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/MavenPomWithMavenGPG.xml
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/MavenPomWithMavenGPG.xml
@@ -1,0 +1,24 @@
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.6</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+            <configuration>
+              <keyname>${gpg.keyname}</keyname>
+              <passphraseServerId>${gpg.keyname}</passphraseServerId>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/MavenPomWithoutMavenGPG.xml
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/MavenPomWithoutMavenGPG.xml
@@ -1,0 +1,11 @@
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>something-else</artifactId>
+        <version>1.6</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Here is a list of main updates:

- Added a new feature that shows if a project signs its artifacts.
- The new feature contributes to the score for security awareness.
- Added a new data provider for the new feature. The provider checks if a project uses Maven GPG plugin.
- Updated tests and test vectors.

This closes #232 