### PR TITLE
Added a score for assessing vulnerability discovery and security testing

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -34,6 +34,9 @@
     files="BaseMetricV2.java"
     lines="52"/>
   <suppress checks="AbbreviationAsWordInName"
+    files="BaseMetricV3.java"
+    lines="28"/>
+  <suppress checks="AbbreviationAsWordInName"
     files="TestNVD.java"
     lines="9"/>
   <suppress checks="AbbreviationAsWordInName"

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/experimental/VulnerabilitiesFromGitHubAdvisories.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/experimental/VulnerabilitiesFromGitHubAdvisories.java
@@ -2,7 +2,7 @@ package com.sap.sgs.phosphor.fosstars.data.github.experimental;
 
 import static com.sap.sgs.phosphor.fosstars.maven.MavenUtils.readModel;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.date;
-import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.UNKNOWN_INTRODUCED_DATE;
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Builder.newVulnerability;
 
 import com.sap.sgs.phosphor.fosstars.data.github.CachedSingleFeatureGitHubDataProvider;
 import com.sap.sgs.phosphor.fosstars.data.github.GitHubDataFetcher;
@@ -13,7 +13,6 @@ import com.sap.sgs.phosphor.fosstars.data.github.experimental.graphql.data.Node;
 import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.feature.oss.VulnerabilitiesInProject;
-import com.sap.sgs.phosphor.fosstars.model.value.CVSS;
 import com.sap.sgs.phosphor.fosstars.model.value.PackageManager;
 import com.sap.sgs.phosphor.fosstars.model.value.Reference;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
@@ -24,7 +23,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.apache.maven.model.Model;
@@ -137,15 +135,14 @@ public class VulnerabilitiesFromGitHubAdvisories extends CachedSingleFeatureGitH
     Advisory advisory = node.getAdvisory();
 
     String id = advisory.getGhsaId();
-    String description = advisory.getDescription();
-    CVSS cvss = CVSS.UNKNOWN;
-    List<Reference> references = referencesFrom(advisory.getReferences());
-
     Resolution resolution =
         node.getFirstPatchedVersion() != null ? Resolution.PATCHED : Resolution.UNPATCHED;
 
-    Date fixed = date(advisory.getPublishedAt());
-    return new Vulnerability(id, description, cvss, references, resolution, UNKNOWN_INTRODUCED_DATE,
-        fixed);
+    return newVulnerability(id)
+        .description(advisory.getDescription())
+        .set(resolution)
+        .set(referencesFrom(advisory.getReferences()))
+        .fixed(date(advisory.getPublishedAt()))
+        .make();
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutUnpatchedVulnerabilities.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutUnpatchedVulnerabilities.java
@@ -1,19 +1,13 @@
 package com.sap.sgs.phosphor.fosstars.data.interactive;
 
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
-import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.NO_DESCRIPTION;
-import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.NO_REFERENCES;
-import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.UNKNOWN_FIXED_DATE;
-import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.UNKNOWN_INTRODUCED_DATE;
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Builder.newVulnerability;
 import static com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion.Answer.YES;
 
 import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.ValueSet;
-import com.sap.sgs.phosphor.fosstars.model.value.CVSS;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
-import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability;
-import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Resolution;
 import com.sap.sgs.phosphor.fosstars.tool.InputURL;
 import com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion;
 import com.sap.sgs.phosphor.fosstars.tool.YesNoQuestion.Answer;
@@ -37,10 +31,7 @@ public class AskAboutUnpatchedVulnerabilities<T> extends AbstractInteractiveData
         callback.say("[+] This is awesome! Or, no?..");
         callback.say("[?] Please give me a URL for the vulnerability");
         String id = new InputURL(callback).get().toString();
-        Vulnerability vulnerability = new Vulnerability(
-            id, NO_DESCRIPTION, CVSS.UNKNOWN, NO_REFERENCES, Resolution.UNPATCHED,
-            UNKNOWN_INTRODUCED_DATE, UNKNOWN_FIXED_DATE);
-        unpatchedVulnerabilities.add(vulnerability);
+        unpatchedVulnerabilities.add(newVulnerability(id).make());
         answer = new YesNoQuestion(callback, "One more?").ask();
       } while (answer == YES);
     }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorage.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorage.java
@@ -1,12 +1,10 @@
 package com.sap.sgs.phosphor.fosstars.data.json;
 
-import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.UNKNOWN_FIXED_DATE;
-import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.UNKNOWN_INTRODUCED_DATE;
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Builder.newVulnerability;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sap.sgs.phosphor.fosstars.model.value.CVSS;
-import com.sap.sgs.phosphor.fosstars.model.value.Reference;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Resolution;
@@ -170,42 +168,14 @@ public class UnpatchedVulnerabilitiesStorage extends AbstractJsonStorage {
    */
   public static void main(String... args) throws IOException {
     UnpatchedVulnerabilitiesStorage storage = UnpatchedVulnerabilitiesStorage.load();
+
     storage.add(
         "https://github.com/odata4j/odata4j",
-        new Vulnerability(
-            "https://nvd.nist.gov/vuln/detail/CVE-2014-0171",
-            "XML external entity (XXE) vulnerability",
-            CVSS.v2(5.0),
-            Collections.emptyList(),
-            Resolution.UNPATCHED,
-            UNKNOWN_INTRODUCED_DATE,
-            UNKNOWN_FIXED_DATE));
-    storage.add(
-        "https://github.com/odata4j/odata4j",
-        new Vulnerability(
-            "https://nvd.nist.gov/vuln/detail/CVE-2016-11023",
-            "SQL injection (ExecuteCountQueryCommand)",
-            CVSS.v3(9.8),
-            Collections.singletonList(
-                new Reference(
-                    "Public disclosure",
-                    new URL("https://groups.google.com/d/msg/odata4j-discuss/_lBwwXP30g0/Av6zkZMdBwAJ"))),
-            Resolution.UNPATCHED,
-            UNKNOWN_INTRODUCED_DATE,
-            UNKNOWN_FIXED_DATE));
-    storage.add(
-        "https://github.com/odata4j/odata4j",
-        new Vulnerability(
-            "https://nvd.nist.gov/vuln/detail/CVE-2016-11024",
-            "SQL injection (ExecuteJPQLQueryCommand)",
-            CVSS.v3(9.8),
-            Collections.singletonList(
-                new Reference(
-                    "Public disclosure",
-                    new URL("https://groups.google.com/d/msg/odata4j-discuss/_lBwwXP30g0/Av6zkZMdBwAJ"))),
-            Resolution.UNPATCHED,
-            UNKNOWN_INTRODUCED_DATE,
-            UNKNOWN_FIXED_DATE));
+        newVulnerability("https://nvd.nist.gov/vuln/detail/CVE-2014-0171")
+            .set(CVSS.v2(5.0))
+            .set(Resolution.UNPATCHED)
+            .make());
+
     storage.store("src/main/resources/" + RESOURCE_PATH);
   }
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/Confidence.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/Confidence.java
@@ -92,7 +92,6 @@ public interface Confidence {
 
     for (Value value : values) {
       if (value.isUnknown()) {
-
         // if value is unknown, then confidence is min and weight is 1.0
         weightSum += 1.0;
       } else if (value instanceof ScoreValue) {
@@ -103,7 +102,6 @@ public interface Confidence {
         weightedConfidenceSum += ((Confidence) value).confidence();
         weightSum += 1.0;
       } else {
-
         // if it's a regular value, then confidence is max and weight is 1.0 as well
         weightedConfidenceSum += MAX;
         weightSum += 1.0;

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/Score.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/Score.java
@@ -22,6 +22,7 @@ import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessSco
 import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.StaticAnalysisScore;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityLifetimeScore;
 import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import java.util.Set;
@@ -56,7 +57,8 @@ import java.util.Set;
     @JsonSubTypes.Type(value = MemorySafetyTestingScore.class),
     @JsonSubTypes.Type(value = FindSecBugsScore.class),
     @JsonSubTypes.Type(value = FuzzingScore.class),
-    @JsonSubTypes.Type(value = StaticAnalysisScore.class)
+    @JsonSubTypes.Type(value = StaticAnalysisScore.class),
+    @JsonSubTypes.Type(value = VulnerabilityDiscoveryAndSecurityTestingScore.class)
 })
 public interface Score extends Feature<Double> {
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorBuilder.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorBuilder.java
@@ -51,6 +51,16 @@ public class TestVectorBuilder {
   }
 
   /**
+   * Creates a new test vector builder.
+   *
+   * @param alias An alias for the test vector.
+   * @return A new builder.
+   */
+  public static TestVectorBuilder newTestVector(String alias) {
+    return newTestVector().alias(alias);
+  }
+
+  /**
    * Private constructor. Please use the {@link #newTestVector()} method to create an instance.
    */
   private TestVectorBuilder() {

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AbstractScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AbstractScore.java
@@ -66,9 +66,11 @@ public abstract class AbstractScore implements Score {
   public AbstractScore(String name, String description) {
     Objects.requireNonNull(name, "Hey! Score name can't be null!");
     Objects.requireNonNull(description, "Hey! Score description can't be null!");
+
     if (name.isEmpty()) {
       throw new IllegalArgumentException("Hey! Score name can't be empty!");
     }
+
     this.name = name;
     this.description = description;
   }
@@ -131,7 +133,7 @@ public abstract class AbstractScore implements Score {
       return false;
     }
     AbstractScore that = (AbstractScore) o;
-    return Objects.equals(name, that.name) && Objects.equals(description, this.description);
+    return Objects.equals(name, that.name) && Objects.equals(description, that.description);
   }
 
   @Override

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AverageCompositeScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/AverageCompositeScore.java
@@ -5,6 +5,7 @@ import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sap.sgs.phosphor.fosstars.model.Confidence;
 import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.Value;
@@ -42,15 +43,17 @@ public class AverageCompositeScore extends AbstractScore {
    * @param subScores A set of sub-scores.
    */
   @JsonCreator
-  AverageCompositeScore(
+  public AverageCompositeScore(
       @JsonProperty("name") String name,
       @JsonProperty("subScores") Set<Score> subScores) {
 
     super(name);
     Objects.requireNonNull(subScores, "Sub-scores can't be null!");
+
     if (subScores.isEmpty()) {
       throw new IllegalArgumentException("Sub-scores can't be empty!");
     }
+
     this.subScores = new HashSet<>(subScores);
   }
 
@@ -82,7 +85,6 @@ public class AverageCompositeScore extends AbstractScore {
     ScoreValue scoreValue = new ScoreValue(this);
 
     double subScoreSum = 0.0;
-    double confidenceSum = 0.0;
     int numberOfSubScores = 0;
     for (Score subScore : subScores) {
       ScoreValue subScoreValue = calculateIfNecessary(subScore, valueSet);
@@ -92,7 +94,6 @@ public class AverageCompositeScore extends AbstractScore {
       }
       numberOfSubScores++;
       subScoreSum += subScoreValue.get();
-      confidenceSum += subScoreValue.confidence();
     }
 
     if (numberOfSubScores == 0) {
@@ -100,7 +101,7 @@ public class AverageCompositeScore extends AbstractScore {
     }
 
     scoreValue.set(subScoreSum / numberOfSubScores);
-    scoreValue.confidence(confidenceSum / numberOfSubScores);
+    scoreValue.confidence(Confidence.make(scoreValue.usedValues()));
 
     return scoreValue;
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/WeightedCompositeScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/WeightedCompositeScore.java
@@ -49,6 +49,16 @@ public class WeightedCompositeScore extends AbstractScore implements Tunable {
   }
 
   /**
+   * Makes a score from a set of sub-scores.
+   *
+   * @param name A name of the new score.
+   * @param subScores A number of sub-scores.
+   */
+  public WeightedCompositeScore(String name, Set<Score> subScores) {
+    this(name, subScores, ScoreWeights.createFor(subScores));
+  }
+
+  /**
    * Initializes a new score.
    * This constructor is used by Jackson during deserialization.
    *
@@ -84,7 +94,7 @@ public class WeightedCompositeScore extends AbstractScore implements Tunable {
       }
     }
 
-    this.subScores = subScores;
+    this.subScores = new HashSet<>(subScores);
     this.weights = weights;
   }
 
@@ -132,7 +142,6 @@ public class WeightedCompositeScore extends AbstractScore implements Tunable {
 
     double weightSum = 0.0;
     double scoreSum = 0.0;
-    double confidenceSum = 0.0;
 
     ScoreValue scoreValue = new ScoreValue(this);
     boolean allNotApplicable = true;
@@ -148,7 +157,6 @@ public class WeightedCompositeScore extends AbstractScore implements Tunable {
 
       allNotApplicable = false;
       scoreSum += weight.value() * subScoreValue.get();
-      confidenceSum += weight.value() * subScoreValue.confidence();
       weightSum += weight.value();
     }
 
@@ -161,7 +169,7 @@ public class WeightedCompositeScore extends AbstractScore implements Tunable {
     }
 
     scoreValue.set(Score.adjust(scoreSum / weightSum));
-    scoreValue.confidence(Confidence.adjust(confidenceSum / weightSum));
+    scoreValue.confidence(Confidence.make(scoreValue.usedValues()));
 
     return scoreValue;
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore.java
@@ -1,35 +1,51 @@
 package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
+import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.qa.ScoreVerification;
 import com.sap.sgs.phosphor.fosstars.model.qa.TestVectors;
 import com.sap.sgs.phosphor.fosstars.model.score.WeightedCompositeScore;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * <p>This is a security score for open-source projects.
- * The score takes into account multiple factors including:</p>
+ * The score is based on the following sub-scores:</p>
  * <ul>
- *   <li>Information about vulnerabilities</li>
- *   <li>Security testing</li>
- *   <li>Security awareness of the community</li>
- *   <li>Project activity</li>
- *   <li>and so on.</li>
+ *   <li>{@link ProjectSecurityTestingScore}</li>
+ *   <li>{@link ProjectActivityScore}</li>
+ *   <li>{@link ProjectPopularityScore}</li>
+ *   <li>{@link CommunityCommitmentScore}</li>
+ *   <li>{@link ProjectSecurityAwarenessScore}</li>
+ *   <li>{@link UnpatchedVulnerabilitiesScore}</li>
+ *   <li>{@link VulnerabilityDiscoveryAndSecurityTestingScore}</li>
  * </ul>
  */
 public class OssSecurityScore extends WeightedCompositeScore {
 
   /**
+   * A set of sub-scores.
+   */
+  private static final Set<Score> SUB_SCORES = new HashSet<>();
+
+  static {
+    ProjectSecurityTestingScore securityTestingScore = new ProjectSecurityTestingScore();
+
+    SUB_SCORES.add(securityTestingScore);
+    SUB_SCORES.add(new ProjectActivityScore());
+    SUB_SCORES.add(new ProjectPopularityScore());
+    SUB_SCORES.add(new CommunityCommitmentScore());
+    SUB_SCORES.add(new ProjectSecurityAwarenessScore());
+    SUB_SCORES.add(new UnpatchedVulnerabilitiesScore());
+    SUB_SCORES.add(new VulnerabilityDiscoveryAndSecurityTestingScore(securityTestingScore));
+  }
+
+  /**
    * Initializes a new open-source security score.
    */
   public OssSecurityScore() {
-    super("Security score for open-source projects",
-        new ProjectActivityScore(),
-        new ProjectPopularityScore(),
-        new CommunityCommitmentScore(),
-        new ProjectSecurityAwarenessScore(),
-        new ProjectSecurityTestingScore(),
-        new UnpatchedVulnerabilitiesScore());
+    super("Security score for open-source projects", SUB_SCORES);
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScore.java
@@ -2,6 +2,7 @@ package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
 
+import com.sap.sgs.phosphor.fosstars.model.Confidence;
 import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.Value;
@@ -81,6 +82,7 @@ public class StaticAnalysisScore extends AbstractScore {
 
     scoreValue.increase(lgtmScoreValue.orElse(MIN));
     scoreValue.increase(findSecBugsScoreValue.orElse(MIN));
+    scoreValue.confidence(Confidence.make(lgtmScoreValue, findSecBugsScoreValue));
 
     return scoreValue;
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityDiscoveryAndSecurityTestingScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityDiscoveryAndSecurityTestingScore.java
@@ -1,0 +1,147 @@
+package com.sap.sgs.phosphor.fosstars.model.score.oss;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
+import static com.sap.sgs.phosphor.fosstars.model.other.Utils.findValue;
+import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.score.AbstractScore;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
+import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
+import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * <p>The scores checks how security testing is done
+ * and how many vulnerabilities were recently discovered.</p>
+ *
+ * <ul>
+ *   <li>If testing is good, and there are no recent vulnerabilities,
+ *   then the score value is max. If there are vulnerabilities, then the score value is high.</li>
+ *   <li>If testing is bad, and there are not recent vulnerabilities, then the score value is low.
+ *   If there are vulnerabilities, then the score is min.</li>
+ * </ul>
+ *
+ * <p>
+ *   The score considers only vulnerabilities that were published in a specific {@link #TIME_FRAME}.
+ * </p>
+ *
+ * <p>
+ *   The score uses {@link ProjectSecurityTestingScore} to assess the quality of security testing.
+ * </p>
+ */
+public class VulnerabilityDiscoveryAndSecurityTestingScore extends AbstractScore {
+
+  /**
+   * A description of the score.
+   */
+  private static final String DESCRIPTION
+      = "The scores checks how security testing is done "
+      + "and how many vulnerabilities were recently discovered. "
+      + "If testing is good, and there are no recent vulnerabilities, "
+      + "then the score value is max. If there are vulnerabilities, then the score value is high. "
+      + "If testing is bad, and there are not recent vulnerabilities, then the score value is low. "
+      + "If there are vulnerabilities, then the score is min.";
+
+  /**
+   * Low score value.
+   */
+  private static final double LOW = 2.0;
+
+  /**
+   * High score value.
+   */
+  private static final double HIGH = 8.0;
+
+  /**
+   * A threshold that defines good security testing.
+   */
+  private static final double GOOD_TESTING_THRESHOLD = 7.0;
+
+  /**
+   * The score considers only vulnerabilities that were published during this time frame.
+   */
+  private static final Duration TIME_FRAME = Duration.ofDays(365);
+
+  /**
+   * A score that assesses security testing implemented in an open-source project.
+   */
+  private final ProjectSecurityTestingScore securityTestingScore;
+
+  /**
+   * Initializes a new score.
+   *
+   * @param securityTestingScore
+   *        A score that assesses security testing implemented in an open-source project.
+   */
+  public VulnerabilityDiscoveryAndSecurityTestingScore(
+      ProjectSecurityTestingScore securityTestingScore) {
+
+    super("Assesses security testing and vulnerability discovery", DESCRIPTION);
+    Objects.requireNonNull(securityTestingScore, "Oh no! Security testing score is null!");
+    this.securityTestingScore = securityTestingScore;
+  }
+
+  @Override
+  public Set<Feature> features() {
+    return setOf(VULNERABILITIES);
+  }
+
+  @Override
+  public Set<Score> subScores() {
+    return setOf(securityTestingScore);
+  }
+
+  @Override
+  public ScoreValue calculate(Value... values) {
+    Objects.requireNonNull(values, "Oh no! Values is null");
+
+    Value<Vulnerabilities> vulnerabilities = findValue(values, VULNERABILITIES,
+        "Hey! You have to give me info about vulnerabilities");
+
+    ScoreValue securityTestingScoreValue = calculateIfNecessary(securityTestingScore, values);
+
+    ScoreValue scoreValue = scoreValue(MIN, vulnerabilities, securityTestingScoreValue);
+
+    if (securityTestingScoreValue.isNotApplicable() || vulnerabilities.isNotApplicable()) {
+      return scoreValue.makeNotApplicable();
+    }
+
+    if (securityTestingScoreValue.isUnknown() || vulnerabilities.isUnknown()) {
+      return scoreValue.set(MIN);
+    }
+
+    boolean goodTesting = securityTestingScoreValue.get() >= GOOD_TESTING_THRESHOLD;
+    boolean hasRecentVulnerabilities = hasRecent(vulnerabilities);
+
+    if (goodTesting) {
+      return scoreValue.set(hasRecentVulnerabilities ? HIGH : MAX);
+    }
+
+    return scoreValue.set(hasRecentVulnerabilities ? MIN : LOW);
+  }
+
+  /**
+   * Checks if there are recent vulnerabilities.
+   *
+   * @param vulnerabilities The vulnerabilities to be checked.
+   * @return True if there are recent vulnerabilities, false otherwise.
+   */
+  private static boolean hasRecent(Value<Vulnerabilities> vulnerabilities) {
+    Date date = Date.from(Instant.now().minus(TIME_FRAME));
+
+    for (Vulnerability vulnerability : vulnerabilities.get()) {
+      if (vulnerability.published().filter(published -> published.after(date)).isPresent()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityDiscoveryAndSecurityTestingScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityDiscoveryAndSecurityTestingScore.java
@@ -4,6 +4,9 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNER
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.findValue;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.Value;
@@ -42,11 +45,13 @@ public class VulnerabilityDiscoveryAndSecurityTestingScore extends AbstractScore
    * A description of the score.
    */
   private static final String DESCRIPTION
-      = "The scores checks how security testing is done "
-      + "and how many vulnerabilities were recently discovered. "
-      + "If testing is good, and there are no recent vulnerabilities, "
-      + "then the score value is max. If there are vulnerabilities, then the score value is high. "
-      + "If testing is bad, and there are not recent vulnerabilities, then the score value is low. "
+      = "The scores checks how security testing is done\n"
+      + "and how many vulnerabilities were recently discovered.\n"
+      + "If testing is good, and there are no recent vulnerabilities,\n"
+      + "then the score value is max.\n"
+      + "If there are vulnerabilities, then the score value is high.\n"
+      + "If testing is bad, and there are no recent vulnerabilities,\n"
+      + "then the score value is low.\n"
       + "If there are vulnerabilities, then the score is min.";
 
   /**
@@ -80,12 +85,23 @@ public class VulnerabilityDiscoveryAndSecurityTestingScore extends AbstractScore
    * @param securityTestingScore
    *        A score that assesses security testing implemented in an open-source project.
    */
+  @JsonCreator
   public VulnerabilityDiscoveryAndSecurityTestingScore(
-      ProjectSecurityTestingScore securityTestingScore) {
+      @JsonProperty("securityTestingScore") ProjectSecurityTestingScore securityTestingScore) {
 
     super("Assesses security testing and vulnerability discovery", DESCRIPTION);
     Objects.requireNonNull(securityTestingScore, "Oh no! Security testing score is null!");
     this.securityTestingScore = securityTestingScore;
+  }
+
+  /**
+   * A getter to make Jackson happy.
+   *
+   * @return The score for security testing.
+   */
+  @JsonGetter("securityTestingScore")
+  private ProjectSecurityTestingScore securityTestingScore() {
+    return securityTestingScore;
   }
 
   @Override
@@ -125,6 +141,31 @@ public class VulnerabilityDiscoveryAndSecurityTestingScore extends AbstractScore
     }
 
     return scoreValue.set(hasRecentVulnerabilities ? MIN : LOW);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o instanceof VulnerabilityDiscoveryAndSecurityTestingScore == false) {
+      return false;
+    }
+
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    VulnerabilityDiscoveryAndSecurityTestingScore that
+        = (VulnerabilityDiscoveryAndSecurityTestingScore) o;
+
+    return Objects.equals(securityTestingScore, that.securityTestingScore);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), securityTestingScore);
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/NotApplicableValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/NotApplicableValue.java
@@ -32,7 +32,7 @@ public final class NotApplicableValue<T> extends AbstractValue<T> {
   @Override
   @JsonIgnore
   public final boolean isUnknown() {
-    return true;
+    return false;
   }
 
   @Override

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Vulnerability.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Vulnerability.java
@@ -417,6 +417,18 @@ public class Vulnerability {
     }
 
     /**
+     * Set a date when the vulnerability was published.
+     *
+     * @param date The date.
+     * @return The same builder.
+     */
+    public Builder published(Date date) {
+      Objects.requireNonNull(date, "Oh no! Date is null");
+      published = date;
+      return this;
+    }
+
+    /**
      * Set a CVSS score.
      *
      * @param cvss The CVSS score.

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Vulnerability.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Vulnerability.java
@@ -5,6 +5,7 @@ import static com.sap.sgs.phosphor.fosstars.model.other.Utils.date;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sap.sgs.phosphor.fosstars.nvd.data.Impact;
 import com.sap.sgs.phosphor.fosstars.nvd.data.LangString;
 import com.sap.sgs.phosphor.fosstars.nvd.data.NvdEntry;
 import com.sap.sgs.phosphor.fosstars.nvd.data.ReferenceLink;
@@ -53,6 +54,11 @@ public class Vulnerability {
   public static final Date UNKNOWN_FIXED_DATE = null;
 
   /**
+   * This means that it's unknown when a vulnerability was published.
+   */
+  public static final Date UNKNOWN_PUBLISHED_DATE = null;
+
+  /**
    * An identifier of the vulnerability. It may be a URL.
    */
   private final String id;
@@ -90,31 +96,10 @@ public class Vulnerability {
   private final Date fixed;
 
   /**
-   * Initializes a vulnerability just with its identifier.
-   *
-   * @param id The identifier of the vulnerability. It may be a URL.
+   * A date when the vulnerability was published.
    */
-  public Vulnerability(String id) {
-    this(id, NO_DESCRIPTION, CVSS.UNKNOWN, NO_REFERENCES, Resolution.UNKNOWN,
-        UNKNOWN_INTRODUCED_DATE, UNKNOWN_FIXED_DATE);
-  }
-
-  /**
-   * Initializes a vulnerability.
-   *
-   * @param id An identifier of the vulnerability. It may be a URL.
-   * @param description A description of the vulnerability.
-   * @param cvss A CVSS score for the vulnerability.
-   * @param references A list of references
-   *                   which provide additional information about the vulnerability.
-   * @param resolution A resolution status for the vulnerability.
-   */
-  public Vulnerability(String id, String description, CVSS cvss,
-      List<Reference> references, Resolution resolution) {
-
-    this(id, description, cvss, references, resolution,
-        UNKNOWN_INTRODUCED_DATE, UNKNOWN_FIXED_DATE);
-  }
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", locale = "us_US")
+  private final Date published;
 
   /**
    * Initializes a vulnerability.
@@ -127,15 +112,17 @@ public class Vulnerability {
    * @param resolution A resolution status for the vulnerability.
    * @param introduced A date when the vulnerability was introduced.
    * @param fixed A date when the vulnerability was fixed.
+   * @param published A date when the vulnerability was published.
    */
-  public Vulnerability(
+  Vulnerability(
       @JsonProperty("id") String id,
       @JsonProperty("description") String description,
       @JsonProperty("cvss") CVSS cvss,
       @JsonProperty("references") List<Reference> references,
       @JsonProperty("resolution") Resolution resolution,
       @JsonProperty("introduced") Date introduced,
-      @JsonProperty("fixed") Date fixed) {
+      @JsonProperty("fixed") Date fixed,
+      @JsonProperty("published") Date published) {
 
     Objects.requireNonNull(id, "Hey! An identifier can't be null!");
     Objects.requireNonNull(cvss, "Hey! CVSS can't be null!");
@@ -152,6 +139,11 @@ public class Vulnerability {
           "Hey! A vulnerability '%s' can't be fixed before it was introduced!", id));
     }
 
+    if (published != null && introduced != null && published.before(introduced)) {
+      throw new IllegalArgumentException(String.format(
+          "Hey! A vulnerability '%s' can't be published before it was introduced!", id));
+    }
+
     this.id = id;
     this.description = description;
     this.cvss = cvss;
@@ -159,6 +151,7 @@ public class Vulnerability {
     this.resolution = resolution;
     this.introduced = introduced;
     this.fixed = fixed;
+    this.published = published;
   }
 
   /**
@@ -229,6 +222,15 @@ public class Vulnerability {
   }
 
   /**
+   * Get the date when the issue was published.
+   *
+   * @return The date when the vulnerability was published, or null if the date is unknown.
+   */
+  public Optional<Date> published() {
+    return Optional.ofNullable(published);
+  }
+
+  /**
    * equals() and hashCode() methods consider only the identifier.
    */
   @Override
@@ -296,17 +298,17 @@ public class Vulnerability {
     /**
      * A description of the vulnerability.
      */
-    private String description;
+    private String description = Vulnerability.NO_DESCRIPTION;
 
     /**
      * A CVSS score for the vulnerability.
      */
-    private CVSS cvss;
+    private CVSS cvss = CVSS.UNKNOWN;
 
     /**
      * A list of references which provide additional information about the vulnerability.
      */
-    private List<Reference> references;
+    private List<Reference> references = NO_REFERENCES;
 
     /**
      * A resolution status for the vulnerability.
@@ -316,12 +318,31 @@ public class Vulnerability {
     /**
      * A date when the vulnerability was introduced.
      */
-    private Date introduced;
+    private Date introduced = UNKNOWN_INTRODUCED_DATE;
 
     /**
      * A date when the vulnerability was fixed.
      */
-    private Date fixed;
+    private Date fixed = UNKNOWN_FIXED_DATE;
+
+    /**
+     * A date when the vulnerability was published.
+     */
+    private Date published = UNKNOWN_PUBLISHED_DATE;
+
+    /**
+     * Creates a new builder.
+     *
+     * @param id A vulnerability identifier.
+     * @return A new builder.
+     */
+    public static Builder newVulnerability(String id) {
+      Objects.requireNonNull(id, "Oh no! Vulnerability identifier is null!");
+
+      Builder builder = new Builder();
+      builder.id = id;
+      return builder;
+    }
 
     /**
      * Converts an {@link NvdEntry} to a {@link Vulnerability}.
@@ -330,14 +351,15 @@ public class Vulnerability {
      * @return An instance of {@link Vulnerability}.
      */
     public static Builder from(NvdEntry entry) {
+      Objects.requireNonNull(entry, "Oh no! NVD entry is null");
+
       Builder builder = new Builder();
       builder.id = entry.getCve().getCveDataMeta().getId();
 
       builder.description = entry.getCve().getDescription().getDescriptionData().stream()
           .map(LangString::getValue).collect(Collectors.joining("\n\n"));
 
-      // TODO: use CVSSv3 if it's available
-      builder.cvss = CVSS.v2(entry.getImpact().getBaseMetricV2().getCVSSv2().getBaseScore());
+      builder.cvss = cvssFrom(entry);
 
       builder.references = new ArrayList<>();
 
@@ -353,10 +375,69 @@ public class Vulnerability {
       // since most of vulnerabilities in the NVD are fixed
       builder.resolution = Resolution.PATCHED;
 
-      // approximate the date when the vulnerability was fixed by just the published date
-      builder.fixed = date(entry.getPublishedDate());
+      builder.published = date(entry.getPublishedDate());
 
       return builder;
+    }
+
+    /**
+     * Set a description for the vulnerability.
+     *
+     * @param text The description.
+     * @return The same builder.
+     */
+    public Builder description(String text) {
+      Objects.requireNonNull(text, "Oh no! Description is null");
+      description = text;
+      return this;
+    }
+
+    /**
+     * Set a date when the vulnerability was introduced.
+     *
+     * @param date The date.
+     * @return The same builder.
+     */
+    public Builder introduced(Date date) {
+      Objects.requireNonNull(date, "Oh no! Date is null");
+      introduced = date;
+      return this;
+    }
+
+    /**
+     * Set a date when the vulnerability was fixed.
+     *
+     * @param date The date.
+     * @return The same builder.
+     */
+    public Builder fixed(Date date) {
+      Objects.requireNonNull(date, "Oh no! Date is null");
+      fixed = date;
+      return this;
+    }
+
+    /**
+     * Set a CVSS score.
+     *
+     * @param cvss The CVSS score.
+     * @return The same builder.
+     */
+    public Builder set(CVSS cvss) {
+      Objects.requireNonNull(cvss, "Oh no! CVSS score is null!");
+      this.cvss = cvss;
+      return this;
+    }
+
+    /**
+     * Set a list of references.
+     *
+     * @param references The references.
+     * @return The same builder.
+     */
+    public Builder set(List<Reference> references) {
+      Objects.requireNonNull(references, "Oh no! References is null!");
+      this.references = references;
+      return this;
     }
 
     /**
@@ -386,7 +467,31 @@ public class Vulnerability {
      * @return A new instance of {@link Vulnerability}.
      */
     public Vulnerability make() {
-      return new Vulnerability(id, description, cvss, references, resolution, introduced, fixed);
+      return new Vulnerability(
+          id, description, cvss, references, resolution, introduced, fixed, published);
+    }
+
+    /**
+     * Extracts a CVSS score from an NVD entry.
+     *
+     * @param entry The NVD entry.
+     * @return The CVSS score.
+     */
+    private static CVSS cvssFrom(NvdEntry entry) {
+      Impact impact = entry.getImpact();
+      if (impact == null) {
+        return CVSS.UNKNOWN;
+      }
+
+      if (impact.getBaseMetricV3() != null) {
+        return CVSS.v3(entry.getImpact().getBaseMetricV3().getCVSSv3().getBaseScore());
+      }
+
+      if (impact.getBaseMetricV2() != null) {
+        return CVSS.v2(entry.getImpact().getBaseMetricV2().getCVSSv2().getBaseScore());
+      }
+
+      return CVSS.UNKNOWN;
     }
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/weight/ScoreWeights.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/weight/ScoreWeights.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A collection of weights for scores.
@@ -68,6 +69,17 @@ public class ScoreWeights implements Tunable {
       values.put(score.getClass(), new MutableWeight(DEFAULT_WEIGHT));
     }
     return new ScoreWeights(values);
+  }
+
+  /**
+   * Creates a collection of weights for a set of scores.
+   *
+   * @param scores The scores.
+   * @return The collection of weights.
+   */
+  public static ScoreWeights createFor(Set<Score> scores) {
+    Objects.requireNonNull(scores, "Scores can't be null!");
+    return createFor(scores.toArray(new Score[0]));
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/nvd/data/BaseMetricV3.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/nvd/data/BaseMetricV3.java
@@ -23,4 +23,9 @@ public class BaseMetricV3 {
 
   @JsonProperty("impactScore")
   private Double impactScore;
+
+  @JsonProperty("cvssV3")
+  public CVSSv3 getCVSSv3() {
+    return cvssV3;
+  }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/nvd/data/CVSSv3.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/nvd/data/CVSSv3.java
@@ -142,6 +142,11 @@ public class CVSSv3 {
     return version;
   }
 
+  @JsonProperty("baseScore")
+  public double getBaseScore() {
+    return baseScore;
+  }
+
   public enum AttackComplexityType {
 
     HIGH("HIGH"),

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/nvd/data/Impact.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/nvd/data/Impact.java
@@ -24,4 +24,9 @@ public class Impact {
   public BaseMetricV2 getBaseMetricV2() {
     return baseMetricV2;
   }
+
+  @JsonProperty("baseMetricV3")
+  public BaseMetricV3 getBaseMetricV3() {
+    return baseMetricV3;
+  }
 }

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTestVectors.yml
@@ -9,6 +9,7 @@ elements:
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 0.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 0.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 0.0
     expectedScore:
       type: "DoubleInterval"
       from: 0.0
@@ -28,6 +29,7 @@ elements:
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 5.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 0.0
     expectedScore:
       type: "DoubleInterval"
       from: 1.0
@@ -47,6 +49,7 @@ elements:
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 5.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 5.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 5.0
     expectedScore:
       type: "DoubleInterval"
       from: 3.0
@@ -66,6 +69,7 @@ elements:
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 10.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 10.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 2.0
     expectedScore:
       type: "DoubleInterval"
       from: 3.0
@@ -85,6 +89,7 @@ elements:
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 5.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 2.0
     expectedScore:
       type: "DoubleInterval"
       from: 4.0
@@ -104,6 +109,7 @@ elements:
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 5.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 8.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 9.0
     expectedScore:
       type: "DoubleInterval"
       from: 6.0
@@ -123,12 +129,13 @@ elements:
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 5.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 10.0
     expectedScore:
       type: "DoubleInterval"
-      from: 7.0
+      from: 8.0
       openLeft: false
       negativeInfinity: false
-      to: 8.0
+      to: 9.0
       openRight: false
       positiveInfinity: false
     expectedLabel: null
@@ -142,12 +149,13 @@ elements:
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 7.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 7.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 0.0
     expectedScore:
       type: "DoubleInterval"
-      from: 5.0
+      from: 4.0
       openLeft: false
       negativeInfinity: false
-      to: 6.0
+      to: 5.0
       openRight: false
       positiveInfinity: false
     expectedLabel: null
@@ -161,6 +169,7 @@ elements:
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 7.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 7.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 9.0
     expectedScore:
       type: "DoubleInterval"
       from: 8.0
@@ -180,6 +189,7 @@ elements:
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore: 10.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 10.0
       com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 10.0
+      com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 10.0
     expectedScore:
       type: "DoubleInterval"
       from: 9.9

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreWeights.json
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreWeights.json
@@ -23,6 +23,10 @@
     "com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore" : {
       "type" : "MutableWeight",
       "value" : 0.5529742430404292
+    },
+    "com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore" : {
+      "type" : "MutableWeight",
+      "value" : 0.6
     }
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutUnpatchedVulnerabilitiesTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/interactive/AskAboutUnpatchedVulnerabilitiesTest.java
@@ -1,6 +1,7 @@
 package com.sap.sgs.phosphor.fosstars.data.interactive;
 
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Builder.newVulnerability;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -10,7 +11,6 @@ import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
-import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import org.junit.Test;
 
@@ -23,8 +23,8 @@ public class AskAboutUnpatchedVulnerabilitiesTest {
 
     testProvider(
         new Vulnerabilities(
-            new Vulnerability(firstIssueId),
-            new Vulnerability(secondIssueId)),
+            newVulnerability(firstIssueId).make(),
+            newVulnerability(secondIssueId).make()),
         new AskAboutUnpatchedVulnerabilities(),
         new TestUserCallback("yes", firstIssueId, "yes", secondIssueId, "no"));
   }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorageTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorageTest.java
@@ -1,12 +1,11 @@
 package com.sap.sgs.phosphor.fosstars.data.json;
 
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Builder.newVulnerability;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.sap.sgs.phosphor.fosstars.model.value.CVSS;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
-import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Resolution;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -29,12 +28,11 @@ public class UnpatchedVulnerabilitiesStorageTest {
   public void store() throws IOException {
     UnpatchedVulnerabilitiesStorage storage = UnpatchedVulnerabilitiesStorage.load();
     String projectUrl = "https://github.com/holy/moly";
-    storage.add(projectUrl, new Vulnerability(
-        "https://bugtracker/1",
-        Vulnerability.NO_DESCRIPTION,
-        CVSS.UNKNOWN,
-        Vulnerability.NO_REFERENCES,
-        Resolution.UNPATCHED));
+    storage.add(
+        projectUrl,
+        newVulnerability("https://bugtracker/1")
+            .set(Resolution.UNPATCHED)
+            .make());
     Path tmp = Files.createTempFile(
         UnpatchedVulnerabilitiesStorageTest.class.getCanonicalName(), "test");
     String filename = tmp.toString();
@@ -43,7 +41,7 @@ public class UnpatchedVulnerabilitiesStorageTest {
       storage = UnpatchedVulnerabilitiesStorage.load(filename);
       Vulnerabilities vulnerabilities = storage.getFor(projectUrl);
       assertEquals(1, vulnerabilities.entries().size());
-      assertTrue(vulnerabilities.entries().contains(new Vulnerability("https://bugtracker/1")));
+      assertTrue(vulnerabilities.entries().contains(newVulnerability("https://bugtracker/1").make()));
     } finally {
       Files.delete(tmp);
     }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/ConfidenceTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/ConfidenceTest.java
@@ -1,8 +1,12 @@
 package com.sap.sgs.phosphor.fosstars.model;
 
+import static com.sap.sgs.phosphor.fosstars.model.feature.example.ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE;
+import static com.sap.sgs.phosphor.fosstars.model.feature.example.ExampleFeatures.NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE;
+import static com.sap.sgs.phosphor.fosstars.model.score.example.ExampleScores.PROJECT_ACTIVITY_SCORE_EXAMPLE;
+import static com.sap.sgs.phosphor.fosstars.model.score.example.ExampleScores.SECURITY_TESTING_SCORE_EXAMPLE;
 import static org.junit.Assert.assertEquals;
 
-import com.sap.sgs.phosphor.fosstars.model.feature.example.ExampleFeatures;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import org.junit.Test;
 
 public class ConfidenceTest {
@@ -10,24 +14,24 @@ public class ConfidenceTest {
   private static final double DELTA = 0.01;
 
   @Test
-  public void checkValid() {
+  public void testValid() {
     Confidence.check(5.0);
     Confidence.check(0.0);
     Confidence.check(10.0);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void checkNegative() {
+  public void testNegative() {
     Confidence.check(-1);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void checkToBig() {
+  public void testToBig() {
     Confidence.check(11);
   }
 
   @Test
-  public void adjust() {
+  public void testAdjust() {
     assertEquals(Confidence.MIN, Confidence.adjust(-1), DELTA);
     assertEquals(Confidence.MIN, Confidence.adjust(0), DELTA);
     assertEquals(Confidence.MAX, Confidence.adjust(11), DELTA);
@@ -35,26 +39,46 @@ public class ConfidenceTest {
   }
 
   @Test
-  public void make() {
+  public void testMakeWithUnknown() {
     assertEquals(Confidence.MIN,
         Confidence.make(
-            ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.unknown(),
-            ExampleFeatures.NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.unknown()),
+            NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.unknown(),
+            NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.unknown()),
         DELTA);
     assertEquals((Confidence.MAX - Confidence.MIN) / 2,
         Confidence.make(
-            ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
-            ExampleFeatures.NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.unknown()),
+            NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
+            NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.unknown()),
         DELTA);
     assertEquals(Confidence.MAX,
         Confidence.make(
-            ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
-            ExampleFeatures.NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(3)),
+            NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
+            NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(3)),
+        DELTA);
+  }
+
+  @Test
+  public void testMakeWithScoreValues() {
+    assertEquals(6.18,
+        Confidence.make(
+            new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE).confidence(3.0).weight(0.4),
+            new ScoreValue(SECURITY_TESTING_SCORE_EXAMPLE).confidence(8.0).weight(0.7)),
+        DELTA);
+  }
+
+  @Test
+  public void testMakeWithVariousValues() {
+    assertEquals(5.41,
+        Confidence.make(
+            new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE).confidence(3.0).weight(0.4),
+            new ScoreValue(SECURITY_TESTING_SCORE_EXAMPLE).confidence(8.0).weight(0.7),
+            NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
+            NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.unknown()),
         DELTA);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void makeWithNoValues() {
+  public void testMakeWithNoValues() {
     Confidence.make();
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/feature/oss/VulnerabilitiesInProjectTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/feature/oss/VulnerabilitiesInProjectTest.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.model.feature.oss;
 
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Builder.newVulnerability;
 import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Resolution.UNPATCHED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -9,8 +10,6 @@ import static org.junit.Assert.assertTrue;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.value.CVSS;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
-import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability;
-import java.util.Collections;
 import org.junit.Test;
 
 public class VulnerabilitiesInProjectTest {
@@ -19,8 +18,13 @@ public class VulnerabilitiesInProjectTest {
   public void value() {
     VulnerabilitiesInProject feature = new VulnerabilitiesInProject("test");
     assertNotNull(feature.name());
-    Value<Vulnerabilities> value = feature.value(new Vulnerabilities(
-        new Vulnerability("1", "test", CVSS.v3(5.1), Collections.emptyList(), UNPATCHED)));
+    Value<Vulnerabilities> value = feature.value(
+        new Vulnerabilities(
+            newVulnerability("1")
+                .description("test")
+                .set(CVSS.v3(5.1))
+                .set(UNPATCHED)
+                .make()));
     assertNotNull(value);
     assertFalse(value.isUnknown());
     Vulnerabilities vulnerabilities = value.get();
@@ -28,7 +32,11 @@ public class VulnerabilitiesInProjectTest {
     assertNotNull(vulnerabilities.entries());
     assertEquals(1, vulnerabilities.entries().size());
     assertTrue(vulnerabilities.entries().contains(
-        new Vulnerability("1", "test", CVSS.v3(5.1), Collections.emptyList(), UNPATCHED)));
+        newVulnerability("1")
+            .description("test")
+            .set(CVSS.v3(5.1))
+            .set(UNPATCHED)
+            .make()));
   }
 
   @Test

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/AbstractScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/AbstractScoreTest.java
@@ -1,0 +1,58 @@
+package com.sap.sgs.phosphor.fosstars.model.score;
+
+import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.feature.example.ExampleFeatures;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.Test;
+
+public class AbstractScoreTest {
+
+  @Test
+  public void testEquals() {
+    ScoreImpl one = new ScoreImpl("test", "Fine! I'll go build my own lunar lander ...");
+    assertEquals(one, one);
+    assertEquals(one.hashCode(), one.hashCode());
+
+    ScoreImpl two = new ScoreImpl("test", "Fine! I'll go build my own lunar lander ...");
+    assertEquals(one, two);
+    assertEquals(one.hashCode(), two.hashCode());
+
+    ScoreImpl three = new ScoreImpl("test", "Oh, no room for Bender, eh?");
+    assertNotEquals(one, three);
+
+    ScoreImpl four = new ScoreImpl("Bender", "Oh, no room for Bender, eh?");
+    assertNotEquals(three, four);
+  }
+
+  private static class ScoreImpl extends AbstractScore {
+
+    ScoreImpl(String name, String description) {
+      super(name, description);
+    }
+
+    @Override
+    public Set<Feature> features() {
+      return setOf(
+          ExampleFeatures.STATIC_CODE_ANALYSIS_DONE_EXAMPLE,
+          ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
+    }
+
+    @Override
+    public Set<Score> subScores() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public ScoreValue calculate(Value... values) {
+      return scoreValue(1.23);
+    }
+  }
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/AverageCompositeScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/AverageCompositeScoreTest.java
@@ -206,7 +206,7 @@ public class AverageCompositeScoreTest {
 
     @Override
     public ScoreValue calculateImpl(Value... values) {
-      return scoreValue(VALUE, values);
+      return scoreValue(VALUE, values).confidence(Confidence.MAX);
     }
   }
 
@@ -222,7 +222,7 @@ public class AverageCompositeScoreTest {
 
     @Override
     public ScoreValue calculateImpl(Value... values) {
-      return scoreValue(VALUE, values);
+      return scoreValue(VALUE, values).confidence(Confidence.MAX);
     }
   }
 

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/WeightedCompositeScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/WeightedCompositeScoreTest.java
@@ -382,7 +382,7 @@ public class WeightedCompositeScoreTest {
 
     @Override
     public ScoreValue calculateImpl(Value... values) {
-      return scoreValue(VALUE, values);
+      return scoreValue(VALUE, values).confidence(Confidence.MAX);
     }
   }
 
@@ -398,7 +398,7 @@ public class WeightedCompositeScoreTest {
 
     @Override
     public ScoreValue calculateImpl(Value... values) {
-      return scoreValue(VALUE, values);
+      return scoreValue(VALUE, values).confidence(Confidence.MAX);
     }
   }
 

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
@@ -99,10 +99,10 @@ public class OssSecurityScoreTest {
         USES_DEPENDABOT.value(true),
         USES_GITHUB_FOR_DEVELOPMENT.value(true),
         LANGUAGES.value(Languages.of(JAVA)),
-        USES_ADDRESS_SANITIZER.unknown(),
-        USES_MEMORY_SANITIZER.unknown(),
-        USES_UNDEFINED_BEHAVIOR_SANITIZER.unknown(),
-        FUZZED_IN_OSS_FUZZ.unknown(),
+        USES_ADDRESS_SANITIZER.value(false),
+        USES_MEMORY_SANITIZER.value(false),
+        USES_UNDEFINED_BEHAVIOR_SANITIZER.value(false),
+        FUZZED_IN_OSS_FUZZ.value(false),
         USES_FIND_SEC_BUGS.value(true),
         PACKAGE_MANAGERS.value(PackageManagers.from(MAVEN)));
     ScoreValue scoreValue = score.calculate(values);

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScoreTest.java
@@ -64,8 +64,12 @@ public class StaticAnalysisScoreTest {
   public void testCalculateWithAllNotApplicable() {
     StaticAnalysisScore score = new StaticAnalysisScore();
 
-    ScoreValue lgtmScoreValue = new ScoreValue(new LgtmScore()).makeNotApplicable();
-    ScoreValue findSecBugsScoreValue = new ScoreValue(new FindSecBugsScore()).makeNotApplicable();
+    ScoreValue lgtmScoreValue = new ScoreValue(new LgtmScore())
+        .makeNotApplicable()
+        .confidence(Confidence.MAX);
+    ScoreValue findSecBugsScoreValue = new ScoreValue(new FindSecBugsScore())
+        .makeNotApplicable()
+        .confidence(Confidence.MAX);
 
     ScoreValue scoreValue = score.calculate(lgtmScoreValue, findSecBugsScoreValue);
     assertFalse(scoreValue.isUnknown());
@@ -81,8 +85,12 @@ public class StaticAnalysisScoreTest {
   public void testCalculateWithSubScoreValues() {
     StaticAnalysisScore score = new StaticAnalysisScore();
 
-    ScoreValue lgtmScoreValue = new ScoreValue(new LgtmScore()).set(MIN);
-    ScoreValue findSecBugsScoreValue = new ScoreValue(new FindSecBugsScore()).set(MIN);
+    ScoreValue lgtmScoreValue = new ScoreValue(new LgtmScore())
+        .set(MIN)
+        .confidence(Confidence.MAX);
+    ScoreValue findSecBugsScoreValue = new ScoreValue(new FindSecBugsScore())
+        .set(MIN)
+        .confidence(Confidence.MAX);
 
     ScoreValue scoreValue = score.calculate(lgtmScoreValue, findSecBugsScoreValue);
     assertFalse(scoreValue.isUnknown());
@@ -101,8 +109,12 @@ public class StaticAnalysisScoreTest {
 
     final double value = 5.5;
 
-    ScoreValue lgtmScoreValue = new ScoreValue(new LgtmScore()).set(value);
-    ScoreValue findSecBugsScoreValue = new ScoreValue(new FindSecBugsScore()).makeNotApplicable();
+    ScoreValue lgtmScoreValue = new ScoreValue(new LgtmScore())
+        .set(value)
+        .confidence(Confidence.MAX);
+    ScoreValue findSecBugsScoreValue = new ScoreValue(new FindSecBugsScore())
+        .makeNotApplicable()
+        .confidence(Confidence.MAX);
 
     ScoreValue scoreValue = score.calculate(lgtmScoreValue, findSecBugsScoreValue);
     assertFalse(scoreValue.isUnknown());

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityDiscoveryAndSecurityTestingScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityDiscoveryAndSecurityTestingScoreTest.java
@@ -1,0 +1,37 @@
+package com.sap.sgs.phosphor.fosstars.model.score.oss;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Builder.newVulnerability;
+
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.other.Utils;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
+import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
+import java.util.Date;
+import java.util.Set;
+import org.junit.Test;
+
+public class VulnerabilityDiscoveryAndSecurityTestingScoreTest {
+
+  private static ProjectSecurityTestingScore SECURITY_TESTING_SCORE
+      = new ProjectSecurityTestingScore();
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithNoVulnerabilitiesInfo() {
+    VulnerabilityDiscoveryAndSecurityTestingScore score
+        = new VulnerabilityDiscoveryAndSecurityTestingScore(SECURITY_TESTING_SCORE);
+    ScoreValue securityTestingScoreValue = new ScoreValue(SECURITY_TESTING_SCORE);
+    score.calculate(securityTestingScoreValue);
+  }
+
+  @Test
+  public void testCalculate() {
+    Set<Value> values = Utils.allUnknown(SECURITY_TESTING_SCORE.allFeatures());
+    values.add(VULNERABILITIES.value(
+        new Vulnerabilities(
+            newVulnerability("CVE-1")
+                .published(new Date())
+                .make())));
+
+  }
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityDiscoveryAndSecurityTestingScoreVerification.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityDiscoveryAndSecurityTestingScoreVerification.java
@@ -1,0 +1,93 @@
+package com.sap.sgs.phosphor.fosstars.model.score.oss;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
+import static com.sap.sgs.phosphor.fosstars.model.qa.TestVectorBuilder.newTestVector;
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Builder.newVulnerability;
+
+import com.sap.sgs.phosphor.fosstars.model.math.DoubleInterval;
+import com.sap.sgs.phosphor.fosstars.model.other.Utils;
+import com.sap.sgs.phosphor.fosstars.model.qa.ScoreVerification;
+import com.sap.sgs.phosphor.fosstars.model.qa.TestVectors;
+import com.sap.sgs.phosphor.fosstars.model.qa.VerificationFailedException;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
+import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
+import java.sql.Date;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.Test;
+
+public class VulnerabilityDiscoveryAndSecurityTestingScoreVerification {
+
+  private static final Duration SOME_TIME_AGO = Duration.ofDays(30);
+
+  private static final Duration LONG_TIME_AGO = Duration.ofDays(1000);
+
+  private static final Vulnerabilities RECENT_VULNERABILITIES = new Vulnerabilities(
+      newVulnerability("CVE-02")
+          .published(Date.from(Instant.now().minus(SOME_TIME_AGO)))
+          .make(),
+      newVulnerability("CVE-01")
+          .published(Date.from(Instant.now().minus(LONG_TIME_AGO)))
+          .make()
+  );
+
+  private static final Vulnerabilities NO_RECENT_VULNERABILITIES = new Vulnerabilities(
+      newVulnerability("CVE-01")
+          .published(Date.from(Instant.now().minus(LONG_TIME_AGO)))
+          .make()
+  );
+
+  private static ProjectSecurityTestingScore SECURITY_TESTING_SCORE
+      = new ProjectSecurityTestingScore();
+
+  private static final TestVectors TEST_VECTORS = new TestVectors(
+      newTestVector("all unknown")
+          .set(Utils.allUnknown(SECURITY_TESTING_SCORE.allFeatures()))
+          .set(VULNERABILITIES.unknown())
+          .expectedScore(DoubleInterval.closed(0, 1))
+          .make(),
+      newTestVector("unknown security testing")
+          .set(Utils.allUnknown(SECURITY_TESTING_SCORE.allFeatures()))
+          .set(VULNERABILITIES.value(RECENT_VULNERABILITIES))
+          .expectedScore(DoubleInterval.closed(0, 1))
+          .make(),
+      newTestVector("unknown vulnerabilities")
+          .set(SECURITY_TESTING_SCORE.value(5.0))
+          .set(VULNERABILITIES.unknown())
+          .expectedScore(DoubleInterval.closed(0, 1))
+          .make(),
+      newTestVector("security testing not applicable")
+          .set(new ScoreValue(SECURITY_TESTING_SCORE).makeNotApplicable())
+          .set(VULNERABILITIES.value(RECENT_VULNERABILITIES))
+          .expectNotApplicableScore()
+          .make(),
+      newTestVector("bad testing and recent vulnerabilities")
+          .set(SECURITY_TESTING_SCORE.value(1.0))
+          .set(VULNERABILITIES.value(RECENT_VULNERABILITIES))
+          .expectedScore(DoubleInterval.closed(0, 1))
+          .make(),
+      newTestVector("bad testing and no recent vulnerabilities")
+          .set(SECURITY_TESTING_SCORE.value(1.0))
+          .set(VULNERABILITIES.value(NO_RECENT_VULNERABILITIES))
+          .expectedScore(DoubleInterval.closed(1, 3))
+          .make(),
+      newTestVector("good testing and recent vulnerabilities")
+          .set(SECURITY_TESTING_SCORE.value(9.0))
+          .set(VULNERABILITIES.value(RECENT_VULNERABILITIES))
+          .expectedScore(DoubleInterval.closed(7, 9))
+          .make(),
+      newTestVector("good testing and no recent vulnerabilities")
+          .set(SECURITY_TESTING_SCORE.value(9.0))
+          .set(VULNERABILITIES.value(NO_RECENT_VULNERABILITIES))
+          .expectedScore(DoubleInterval.closed(9, 10))
+          .make()
+  );
+
+  @Test
+  public void verify() throws VerificationFailedException {
+    VulnerabilityDiscoveryAndSecurityTestingScore score
+        = new VulnerabilityDiscoveryAndSecurityTestingScore(SECURITY_TESTING_SCORE);
+    new ScoreVerification(score, TEST_VECTORS).run();
+  }
+
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScoreTest.java
@@ -3,6 +3,7 @@ package com.sap.sgs.phosphor.fosstars.model.score.oss;
 import static com.sap.sgs.phosphor.fosstars.TestUtils.assertScore;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Builder.newVulnerability;
 import static org.junit.Assert.assertEquals;
 
 import com.sap.sgs.phosphor.fosstars.model.Score;
@@ -10,12 +11,10 @@ import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.other.Utils;
 import com.sap.sgs.phosphor.fosstars.model.value.CVSS;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
-import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Resolution;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
 import org.junit.Test;
@@ -42,15 +41,14 @@ public class VulnerabilityLifetimeScoreTest {
   public void calculate() throws ParseException {
     Set<Value> values = setOf(
         VULNERABILITIES.value(new Vulnerabilities(
-            new Vulnerability(
-                "CVE-2020-001",
-                "Test",
-                CVSS.v3(10.0),
-                Collections.emptyList(),
-                Resolution.PATCHED,
-                DATE_FORMAT.parse("01/01/2020"),
-                DATE_FORMAT.parse("01/05/2020")
-        ))));
+            newVulnerability("CVE-2020-001")
+                .description("Test")
+                .set(CVSS.v3(10.0))
+                .set(Resolution.PATCHED)
+                .introduced(DATE_FORMAT.parse("01/01/2020"))
+                .fixed(DATE_FORMAT.parse("01/05/2020"))
+                .make()
+        )));
     assertScore(Score.INTERVAL, VULNERABILITY_LIFETIME_SCORE, values);
   }
 

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/NotApplicableValueTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/NotApplicableValueTest.java
@@ -15,7 +15,7 @@ public class NotApplicableValueTest {
 
   @Test
   public void isUnknown() {
-    assertTrue(NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).isUnknown());
+    assertFalse(NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).isUnknown());
   }
 
   @Test

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/VulnerabilitiesTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/VulnerabilitiesTest.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.model.value;
 
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Builder.newVulnerability;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -12,7 +13,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import org.junit.Test;
 
@@ -45,24 +45,21 @@ public class VulnerabilitiesTest {
 
   private static Vulnerabilities vulnerabilities() throws MalformedURLException {
     return new Vulnerabilities(
-        new Vulnerability(
-            "https://bugtracker/1",
-            "test",
-            CVSS.v2(5.0),
-            Collections.emptyList(),
-            Resolution.UNPATCHED),
-        new Vulnerability(
-            "https://bugtracker/2",
-            "test",
-            CVSS.v2(5.0),
-            Arrays.asList(
+        newVulnerability("https://bugtracker/1")
+            .description("test")
+            .set(CVSS.v2(5.0))
+            .set(Resolution.UNPATCHED)
+            .make(),
+        newVulnerability("https://bugtracker/2")
+            .description("test")
+            .set(CVSS.v2(5.0))
+            .set(Arrays.asList(
                 new Reference("text1", new URL("https://vuln.com/1")),
-                new Reference("text2", new URL("https://vuln.com/2"))),
-            Resolution.PATCHED,
-            new Date(),
-            new Date())
-    );
-
+                new Reference("text2", new URL("https://vuln.com/2"))))
+            .set(Resolution.PATCHED)
+            .introduced(new Date())
+            .fixed(new Date())
+            .make());
   }
 
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/VulnerabilitiesValueTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/VulnerabilitiesValueTest.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.model.value;
 
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Builder.newVulnerability;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -14,8 +15,10 @@ public class VulnerabilitiesValueTest {
   public void serialization() throws IOException {
     ObjectMapper mapper = new ObjectMapper();
     VulnerabilitiesValue vulnerabilityValue =
-        new VulnerabilitiesValue(new Vulnerabilities(new Vulnerability("https://bugtracker/1"),
-            new Vulnerability("https://bugtracker/2")));
+        new VulnerabilitiesValue(
+            new Vulnerabilities(
+                newVulnerability("https://bugtracker/1").make(),
+                newVulnerability("https://bugtracker/2").make()));
     byte[] bytes = mapper.writeValueAsBytes(vulnerabilityValue);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/VulnerabilityTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/VulnerabilityTest.java
@@ -1,5 +1,6 @@
 package com.sap.sgs.phosphor.fosstars.model.value;
 
+import static com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Builder.newVulnerability;
 import static org.junit.Assert.assertEquals;
 
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerability.Resolution;
@@ -11,19 +12,26 @@ import org.junit.Test;
 public class VulnerabilityTest {
 
   @Test(expected = IllegalArgumentException.class)
-  public void confusingResolution() {
+  public void testConfusingResolution() {
     new Vulnerability("CVE-1", "test", CVSS.v2(5.0), Collections.emptyList(),
-        Resolution.UNPATCHED, new Date(1), new Date(2));
+        Resolution.UNPATCHED, new Date(1), new Date(2), new Date(3));
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void confusingIntroducedDate() {
+  public void testConfusingIntroducedDate() {
     new Vulnerability("CVE-1", "test", CVSS.v2(5.0), Collections.emptyList(),
-        Resolution.UNPATCHED, new Date(2), new Date(1));
+        Resolution.UNPATCHED, new Date(2), new Date(1), new Date(3));
   }
 
-  public void shoutConstructor() {
-    Vulnerability vulnerability = new Vulnerability("CVE-2019-0001");
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfusingPublishedDate() {
+    new Vulnerability("CVE-1", "test", CVSS.v2(5.0), Collections.emptyList(),
+        Resolution.UNPATCHED, new Date(4), new Date(3), new Date(2));
+  }
+
+  @Test
+  public void testConstructor() {
+    Vulnerability vulnerability = newVulnerability("CVE-2019-0001").make();
     assertEquals("CVE-2019-0001", vulnerability.id());
     assertEquals(Optional.empty(), vulnerability.description());
     assertEquals(CVSS.UNKNOWN, vulnerability.cvss());


### PR DESCRIPTION
Here is a list of main updates:

- Implemented `VulnerabilityDiscoveryAndSecurityTestingScore`.
- Added the new score to the open-source security score.
- Improved `Vulnerability` class and its builder. This fixes #264
- Fixed #262 
- Fixed #265 
- Improved calculation of confidence. This fixes #266

This closes #224