### PR TITLE
Updated GitHubDataFetcher to reset changes before updating repositories

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/LocalRepository.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/LocalRepository.java
@@ -18,6 +18,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ResetCommand.ResetType;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -136,6 +137,19 @@ public class LocalRepository implements AutoCloseable {
     }
 
     return Optional.of(commits.get(commits.size() - 1));
+  }
+
+  /**
+   * Resets the repository in a hard way by calling "git reset --hard".
+   *
+   * @throws IOException If something went wrong.
+   */
+  public void reset() throws IOException {
+    try (Git git = new Git(repository)) {
+      git.reset().setMode(ResetType.HARD).call();
+    } catch (GitAPIException e) {
+      throw new IOException("Could not reset the repository!", e);
+    }
   }
 
   /**


### PR DESCRIPTION
Here is a list of updates:

- Added a new method `LocalRepository.reset()` that does `git reset --hard` in a cloned repository.
- Updated the `GitHubDataFetcher.loadLocalRepositoryFor()` method to reset changes before pulling updates to a repository.
- Updated the `GitHubDataFetcher.loadLocalRepositoryFor()` method to do a cleanup if an I/O exception occurs.

This fixes #270