### PR TITLE
Update weights in the open-source security score

### DIFF
--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
@@ -404,7 +404,7 @@ elements:
     feature:
       type: "BooleanFeature"
       name: "If an open-source project has a security policy"
-    flag: false
+    flag: true
   - type: "IntegerValue"
     feature:
       type: "PositiveIntegerFeature"
@@ -509,7 +509,7 @@ elements:
         - "MAVEN"
   expectedScore:
     type: "DoubleInterval"
-    from: 4.0
+    from: 4.8
     openLeft: false
     negativeInfinity: false
     to: 6.0

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreTestVectors.yml
@@ -92,10 +92,10 @@ elements:
       com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 2.0
     expectedScore:
       type: "DoubleInterval"
-      from: 4.0
+      from: 3.0
       openLeft: false
       negativeInfinity: false
-      to: 5.0
+      to: 4.0
       openRight: false
       positiveInfinity: false
     expectedLabel: null
@@ -152,10 +152,10 @@ elements:
       com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 0.0
     expectedScore:
       type: "DoubleInterval"
-      from: 4.0
+      from: 3.0
       openLeft: false
       negativeInfinity: false
-      to: 5.0
+      to: 4.0
       openRight: false
       positiveInfinity: false
     expectedLabel: null

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreWeights.json
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScoreWeights.json
@@ -2,31 +2,31 @@
   "values" : {
     "com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore" : {
       "type" : "MutableWeight",
-      "value" : 0.5383270608555468
+      "value" : 0.7
     },
     "com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore" : {
       "type" : "MutableWeight",
-      "value" : 0.8362090433439393
+      "value" : 0.8
     },
     "com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore" : {
       "type" : "MutableWeight",
-      "value" : 0.30515788031015273
+      "value" : 0.5
     },
     "com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore" : {
       "type" : "MutableWeight",
-      "value" : 0.6300785405632551
+      "value" : 0.5
     },
     "com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore" : {
       "type" : "MutableWeight",
-      "value" : 0.6283118906878548
+      "value" : 1.0
     },
     "com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore" : {
       "type" : "MutableWeight",
-      "value" : 0.5529742430404292
+      "value" : 0.5
     },
     "com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore" : {
       "type" : "MutableWeight",
-      "value" : 0.6
+      "value" : 0.7
     }
   }
 }


### PR DESCRIPTION
Here is a list of main updates:

- Tuned weights in the open-source security score.
- Updated the existing test vectors.

This closes #269