### PR TITLE
LgtmDataProvider may fail while retrieving check runs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <version.jackson-dataformat-yaml>2.10.3</version.jackson-dataformat-yaml>
     <version.commons-math3>3.6.1</version.commons-math3>
     <version.commons-cli>1.4</version.commons-cli>
-    <version.github-api>1.109</version.github-api>
+    <version.github-api>1.115</version.github-api>
     <version.log4j-api>2.13.1</version.log4j-api>
     <version.log4j-core>2.13.2</version.log4j-core>
     <version.nist-data-mirror>1.4.0</version.nist-data-mirror>

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/LgtmDataProvider.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/LgtmDataProvider.java
@@ -24,6 +24,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.kohsuke.github.GHCheckRun;
 import org.kohsuke.github.GHCommit;
+import org.kohsuke.github.GHException;
 
 /**
  * The data provider gathers info about how a project uses static analysis with LGTM.
@@ -143,11 +144,16 @@ public class LgtmDataProvider extends GitHubCachingDataProvider {
    * @return True if the commit has LGTM checks, false otherwise.
    * @throws IOException If something went wrong.
    */
-  private static boolean hasLgtmChecks(GHCommit commit) throws IOException {
-    for (GHCheckRun checkRun : commit.getCheckRuns()) {
-      if (checkRun.getName().startsWith("LGTM analysis")) {
-        return true;
+  private boolean hasLgtmChecks(GHCommit commit) throws IOException {
+    try {
+      for (GHCheckRun checkRun : commit.getCheckRuns()) {
+        if (checkRun.getName().startsWith("LGTM analysis")) {
+          return true;
+        }
       }
+    } catch (GHException e) {
+      logger.warn("Oops! Something went wrong: {}", e.getMessage());
+      logger.debug("Here is what happened: ", e);
     }
 
     return false;


### PR DESCRIPTION
Here is what has been updated:

- Bump up the version of the GitHub API library.
- Catch exceptions in the provider to prevent it from failing.

This patch is a workaround, unfortunately it doesn't fix the root cause. In fact, it's not quite clear where the root cause is. On the one hand, the library should be able to recognize the `workflow_run` event. On the other hand, I couldn't find that the GitHub docs mention this event. Therefore, I couldn't refer to the official docs if I filed an issue against the library.

Let's try to live with this workaround. At least, it prevents the provider from complete failure. 

This fixes #259