### PR TITLE
Fix deserialization of EnumValue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.jackson-databind>2.10.3</version.jackson-databind>
-    <version.jackson-dataformat-yaml>2.10.3</version.jackson-dataformat-yaml>
+    <version.jackson-databind>2.11.1</version.jackson-databind>
+    <version.jackson-dataformat-yaml>2.11.1</version.jackson-dataformat-yaml>
     <version.commons-math3>3.6.1</version.commons-math3>
     <version.commons-cli>1.4</version.commons-cli>
     <version.github-api>1.109</version.github-api>

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesOwaspDependencyScan.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/UsesOwaspDependencyScan.java
@@ -17,7 +17,6 @@ import com.sap.sgs.phosphor.fosstars.maven.ModelVisitor.Location;
 import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures;
-import com.sap.sgs.phosphor.fosstars.model.value.CVSS;
 import com.sap.sgs.phosphor.fosstars.model.value.OwaspDependencyCheckUsage;
 import com.sap.sgs.phosphor.fosstars.model.value.ValueHashSet;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/Feature.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/Feature.java
@@ -7,6 +7,7 @@ import com.sap.sgs.phosphor.fosstars.model.feature.BoundedDoubleFeature;
 import com.sap.sgs.phosphor.fosstars.model.feature.BoundedIntegerFeature;
 import com.sap.sgs.phosphor.fosstars.model.feature.DateFeature;
 import com.sap.sgs.phosphor.fosstars.model.feature.DoubleFeature;
+import com.sap.sgs.phosphor.fosstars.model.feature.EnumFeature;
 import com.sap.sgs.phosphor.fosstars.model.feature.LgtmGradeFeature;
 import com.sap.sgs.phosphor.fosstars.model.feature.OwaspDependencyCheckCvssThreshold;
 import com.sap.sgs.phosphor.fosstars.model.feature.OwaspDependencyCheckUsageFeature;
@@ -36,7 +37,9 @@ import com.sap.sgs.phosphor.fosstars.model.feature.oss.VulnerabilitiesInProject;
     @JsonSubTypes.Type(value = DoubleFeature.class),
     @JsonSubTypes.Type(value = BooleanFeature.class),
     @JsonSubTypes.Type(value = BoundedIntegerFeature.class),
+    @JsonSubTypes.Type(value = BoundedDoubleFeature.class),
     @JsonSubTypes.Type(value = DateFeature.class),
+    @JsonSubTypes.Type(value = EnumFeature.class),
     @JsonSubTypes.Type(value = VulnerabilitiesInProject.class),
     @JsonSubTypes.Type(value = SecurityReviewDoneExample.class),
     @JsonSubTypes.Type(value = StaticCodeAnalysisDoneExample.class),
@@ -45,7 +48,6 @@ import com.sap.sgs.phosphor.fosstars.model.feature.oss.VulnerabilitiesInProject;
     @JsonSubTypes.Type(value = LgtmGradeFeature.class),
     @JsonSubTypes.Type(value = LanguagesFeature.class),
     @JsonSubTypes.Type(value = PackageManagersFeature.class),
-    @JsonSubTypes.Type(value = BoundedDoubleFeature.class),
     @JsonSubTypes.Type(value = OwaspDependencyCheckUsageFeature.class),
     @JsonSubTypes.Type(value = OwaspDependencyCheckCvssThreshold.class)
 })

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/feature/EnumFeature.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/feature/EnumFeature.java
@@ -1,0 +1,77 @@
+package com.sap.sgs.phosphor.fosstars.model.feature;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sap.sgs.phosphor.fosstars.model.value.EnumValue;
+import java.util.Objects;
+
+/**
+ * This is a feature that holds a enum.
+ *
+ * @param <T> A type of the enum.
+ */
+public class EnumFeature<T extends Enum<T>> extends AbstractFeature<T> {
+
+  /**
+   * A class of the enum.
+   */
+  private final Class<T> enumClass;
+
+  /**
+   * Initializes a feature.
+   *
+   * @param enumClass A class of the enum.
+   * @param name A name of the feature.
+   */
+  @JsonCreator
+  public EnumFeature(
+      @JsonProperty("enumClass") Class<T> enumClass,
+      @JsonProperty("name") String name) {
+
+    super(name);
+    Objects.requireNonNull(enumClass, "Oh no! Enum class is null!");
+    this.enumClass = enumClass;
+  }
+
+  @Override
+  public EnumValue<T> value(T object) {
+    return new EnumValue<>(this, object);
+  }
+
+  @Override
+  public EnumValue<T> parse(String string) {
+    return value(Enum.valueOf(enumClass, string));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o instanceof EnumFeature == false) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    EnumFeature<?> that = (EnumFeature<?>) o;
+    return Objects.equals(enumClass, that.enumClass);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), enumClass);
+  }
+
+  /**
+   * Get the class of the enum. This method is used during serialization.
+   *
+   * @return The class of the enum.
+   */
+  @JsonGetter("enumClass")
+  private Class<T> enumClass() {
+    return enumClass;
+  }
+
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/EnumValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/EnumValue.java
@@ -3,24 +3,21 @@ package com.sap.sgs.phosphor.fosstars.model.value;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sap.sgs.phosphor.fosstars.model.Feature;
 import java.util.Objects;
 
 /**
- * <p>A value of a feature which contains a enum item.</p>
- *
- * <p>For some reason, deserialization of this class doesn't work.
- * It currently fails with the "Cannot deserialize Class java.lang.Enum (of type enum) as a Bean"
- * error. It looks like a problem with Jackson Databind, maybe it is related to the
- * <a href="https://github.com/FasterXML/jackson-databind/issues/2605">issue #2605</a>.</p>
+ * <p>A value of a feature that contains a enum item.</p>
  *
  * @param <T> Enum type.
  */
-public class EnumValue<T extends Enum> extends AbstractValue<T> {
+public class EnumValue<T extends Enum<T>> extends AbstractValue<T> {
 
   /**
    * The value item.
    */
+  @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
   private final T value;
 
   /**
@@ -31,7 +28,7 @@ public class EnumValue<T extends Enum> extends AbstractValue<T> {
    */
   @JsonCreator
   public EnumValue(
-      @JsonProperty("feature") Feature feature,
+      @JsonProperty("feature") Feature<T> feature,
       @JsonProperty("value") T value) {
 
     super(feature);

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/feature/EnumFeatureTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/feature/EnumFeatureTest.java
@@ -1,0 +1,82 @@
+package com.sap.sgs.phosphor.fosstars.model.feature;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.sgs.phosphor.fosstars.model.value.EnumValue;
+import java.io.IOException;
+import org.junit.Test;
+
+public class EnumFeatureTest {
+
+  private enum TestEnum {
+    A, B, C
+  }
+
+  private enum AnotherEnum {
+    A, B, C, D
+  }
+
+  @Test
+  public void testValue() {
+    EnumFeature<TestEnum> feature = new EnumFeature<>(TestEnum.class, "test");
+    EnumValue<TestEnum> value = feature.value(TestEnum.A);
+    assertNotNull(value);
+    assertSame(feature, value.feature());
+    assertSame(TestEnum.A, value.get());
+  }
+
+  @Test
+  public void testParseValid() {
+    EnumFeature<TestEnum> feature = new EnumFeature<>(TestEnum.class, "test");
+    EnumValue<TestEnum> value = feature.parse("A");
+    assertNotNull(value);
+    assertSame(feature, value.feature());
+    assertSame(TestEnum.A, value.get());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParseInvalid() {
+    EnumFeature<TestEnum> feature = new EnumFeature<>(TestEnum.class, "test");
+    EnumValue<TestEnum> value = feature.parse("D");
+    assertNotNull(value);
+    assertSame(feature, value.feature());
+    assertSame(TestEnum.A, value.get());
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    EnumFeature<TestEnum> one = new EnumFeature<>(TestEnum.class, "test");
+    assertEquals(one, one);
+
+    EnumFeature<TestEnum> two = new EnumFeature<>(TestEnum.class, "test");
+    assertEquals(one, two);
+    assertEquals(one.hashCode(), two.hashCode());
+
+    EnumFeature<TestEnum> three = new EnumFeature<>(TestEnum.class, "another");
+    assertNotEquals(one, three);
+
+    EnumFeature<AnotherEnum> four = new EnumFeature<>(AnotherEnum.class, "name");
+    assertNotEquals(one, four);
+  }
+
+  @Test
+  public void testSerializeAndDeserialize() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+
+    EnumFeature<TestEnum> feature = new EnumFeature<>(TestEnum.class, "feature");
+    byte[] bytes = mapper.writeValueAsBytes(feature);
+    assertNotNull(bytes);
+    assertTrue(bytes.length > 0);
+
+    Object clone = mapper.readValue(bytes, EnumFeature.class);
+    assertNotNull(clone);
+    assertEquals(feature, clone);
+    assertEquals(feature.hashCode(), clone.hashCode());
+  }
+
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/EnumValueTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/EnumValueTest.java
@@ -6,46 +6,22 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.sgs.phosphor.fosstars.model.Value;
-import com.sap.sgs.phosphor.fosstars.model.feature.AbstractFeature;
+import com.sap.sgs.phosphor.fosstars.model.feature.EnumFeature;
 import java.io.IOException;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class EnumValueTest {
 
   private enum TestEnum {
-
-    A, B, C;
-
-    @JsonCreator
-    public static TestEnum parse(String string) {
-      return TestEnum.valueOf(string);
-    }
-  }
-
-  private static class EnumFeatureImpl extends AbstractFeature<TestEnum> {
-
-    EnumFeatureImpl(String name) {
-      super(name);
-    }
-
-    @Override
-    public EnumValue<TestEnum> value(TestEnum object) {
-      return new EnumValue<>(this, object);
-    }
-
-    @Override
-    public Value<TestEnum> parse(String string) {
-      throw new UnsupportedOperationException();
-    }
+    A, B, C
   }
 
   @Test
   public void smokeTest() {
-    EnumValue value = new EnumFeatureImpl("feature").value(TestEnum.B);
+    EnumFeature<TestEnum> feature = new EnumFeature<>(TestEnum.class, "feature");
+    EnumValue<TestEnum> value = feature.value(TestEnum.B);
     assertNotNull(value);
     assertFalse(value.isUnknown());
     assertEquals(TestEnum.B, value.get());
@@ -53,16 +29,17 @@ public class EnumValueTest {
 
   @Test
   public void testUnknown() {
-    Value value = new EnumFeatureImpl("test").unknown();
+    Value value = new EnumFeature<>(TestEnum.class, "test").unknown();
+    assertNotNull(value);
     assertTrue(value.isUnknown());
   }
 
   @Test
-  public void equalsAndHashCode() {
-    final Value a = new EnumFeatureImpl("feature").value(TestEnum.A);
-    final Value b = new EnumFeatureImpl("feature").value(TestEnum.B);
-    final Value aa = new EnumFeatureImpl("feature").value(TestEnum.A);
-    final Value unknown = new EnumFeatureImpl("test").unknown();
+  public void testEqualsAndHashCode() {
+    final EnumValue<TestEnum> a = new EnumFeature<>(TestEnum.class, "feature").value(TestEnum.A);
+    final EnumValue<TestEnum> b = new EnumFeature<>(TestEnum.class, "feature").value(TestEnum.B);
+    final EnumValue<TestEnum> aa = new EnumFeature<>(TestEnum.class, "feature").value(TestEnum.A);
+    final Value unknown = new EnumFeature<>(TestEnum.class, "test").unknown();
 
     assertEquals(a, a);
     assertEquals(a, aa);
@@ -79,16 +56,10 @@ public class EnumValueTest {
   }
 
   @Test
-  @Ignore
-  /*
-   * This test fails with "Cannot deserialize Class java.lang.Enum (of type enum) as a Bean".
-   * It looks like a problem with Jackson Databind, maybe it is related to
-   * https://github.com/FasterXML/jackson-databind/issues/2605
-   */
-  public void serializeAndDeserialize() throws IOException {
+  public void testSerializeAndDeserialize() throws IOException {
     ObjectMapper mapper = new ObjectMapper();
 
-    EnumFeatureImpl feature = new EnumFeatureImpl("feature");
+    EnumFeature<TestEnum> feature = new EnumFeature<>(TestEnum.class, "feature");
     EnumValue a = feature.value(TestEnum.A);
     byte[] bytes = mapper.writeValueAsBytes(a);
     assertNotNull(bytes);


### PR DESCRIPTION
Here is a list of main updates:

- Added `EnumFeature`.
- Updated Jackson version.
- Added `JsonTypeInfo` annotation to `EnumValue.value`.
- Updated tests.

This fixes #273