### PR TITLE
OwaspDependencyCheckCvssThresholdValue should contains a valid value

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/feature/OwaspDependencyCheckCvssThreshold.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/feature/OwaspDependencyCheckCvssThreshold.java
@@ -16,13 +16,6 @@ import com.sap.sgs.phosphor.fosstars.model.value.OwaspDependencyCheckCvssThresho
 public class OwaspDependencyCheckCvssThreshold extends BoundedDoubleFeature {
 
   /**
-   * A junk value, x < 0.0 or x > 10.0.
-   */
-  // TODO: this constant will need to be removed,
-  //       and the feature/value need to check in n belongs to [0. 10]
-  private static final double JUNK_VALUE = 11.0;
-
-  /**
    * Initializes a feature.
    */
   @JsonCreator
@@ -42,6 +35,9 @@ public class OwaspDependencyCheckCvssThreshold extends BoundedDoubleFeature {
    * @return An instance of {@link OwaspDependencyCheckCvssThresholdValue}.
    */
   public OwaspDependencyCheckCvssThresholdValue notSpecifiedValue() {
-    return new OwaspDependencyCheckCvssThresholdValue(this, JUNK_VALUE, false);
+    // it doesn't matter what CVSS score value is used here because the created value throws
+    // and exception if the get() method is called
+    // therefore, it just uses MIN value
+    return new OwaspDependencyCheckCvssThresholdValue(this, MIN, false);
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/CVSS.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/CVSS.java
@@ -132,14 +132,16 @@ public class CVSS {
    * @return The score value if it's valid or null.
    * @throws IllegalArgumentException If the score value is invalid.
    */
-  private static Double check(Double value) {
+  public static Double check(Double value) {
     if (value == null) {
       return null;
     }
-    if (value < MIN || value > MAX) {
+
+    if (Double.compare(value, MIN) < 0 || Double.compare(value, MAX) > 0) {
       throw new IllegalArgumentException(String.format(
-          "What the heck? %s doesn't look like a CVSS score!", value));
+          "What the heck? %f doesn't look like a CVSS score!", value));
     }
+
     return value;
   }
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/DoubleValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/DoubleValue.java
@@ -28,6 +28,7 @@ public class DoubleValue extends AbstractValue<Double> {
       @JsonProperty("number") Double number) {
 
     super(feature);
+    Objects.requireNonNull(number, "Oh no! Number is null!");
     this.number = number;
   }
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/OwaspDependencyCheckCvssThresholdValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/OwaspDependencyCheckCvssThresholdValue.java
@@ -3,7 +3,8 @@ package com.sap.sgs.phosphor.fosstars.model.value;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.feature.OwaspDependencyCheckCvssThreshold;
+import java.util.Objects;
 
 /**
  * This feature value contains a CVSS threshold used in OWASP Dependency Check.
@@ -19,21 +20,22 @@ public class OwaspDependencyCheckCvssThresholdValue extends DoubleValue {
    * Initializes a {@link OwaspDependencyCheckCvssThresholdValue} of a specified feature.
    *
    * @param feature The feature.
-   * @param number The value.
-   * @param specified if the appropriate value is specified.
+   * @param cvss A CVSS score.
+   * @param specified Tells if the CVSS score is specified.
    */
   @JsonCreator
   public OwaspDependencyCheckCvssThresholdValue(
-      @JsonProperty("feature") Feature<Double> feature,
-      @JsonProperty("number") Double number,
+      @JsonProperty("feature") OwaspDependencyCheckCvssThreshold feature,
+      @JsonProperty("number") Double cvss,
       @JsonProperty("specified") boolean specified) {
 
-    super(feature, number);
+    super(feature, cvss);
+    CVSS.check(cvss);
     this.specified = specified; 
   }
 
   /**
-   * Returns if a valid CVSS threshold is specified or not.
+   * Checks if a valid CVSS threshold is specified or not.
    *  
    * @return True if a valid threshold is set, false otherwise.
    */
@@ -42,6 +44,12 @@ public class OwaspDependencyCheckCvssThresholdValue extends DoubleValue {
     return specified;
   }
 
+  /**
+   * Get the CVSS score if it's specified.
+   *
+   * @return The CVSS score.
+   * @throws IllegalStateException If the CVSS score is not specified.
+   */
   @Override
   @JsonGetter("number")
   public Double get() {
@@ -49,6 +57,26 @@ public class OwaspDependencyCheckCvssThresholdValue extends DoubleValue {
       return number;
     }
 
-    throw new IllegalArgumentException("On no! The value is not specified!");
+    throw new IllegalStateException("On no! The value is not specified!");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o instanceof OwaspDependencyCheckCvssThresholdValue == false) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    OwaspDependencyCheckCvssThresholdValue value = (OwaspDependencyCheckCvssThresholdValue) o;
+    return specified == value.specified;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), specified);
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/CvssTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/CvssTest.java
@@ -1,0 +1,78 @@
+package com.sap.sgs.phosphor.fosstars.model.value;
+
+import static com.sap.sgs.phosphor.fosstars.model.value.CVSS.MAX;
+import static com.sap.sgs.phosphor.fosstars.model.value.CVSS.MIN;
+import static com.sap.sgs.phosphor.fosstars.model.value.CVSS.Version.V2;
+import static com.sap.sgs.phosphor.fosstars.model.value.CVSS.Version.V3;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class CvssTest {
+
+  private static final double ACCURACY = 0.001;
+
+  @Test
+  public void testWithValidValues() {
+    final double value = 7.2;
+    CVSS cvss = CVSS.v2(value);
+    assertEquals(value, cvss.value(), ACCURACY);
+    cvss = CVSS.v2(MIN);
+    assertEquals(MIN, cvss.value(), ACCURACY);
+    cvss = CVSS.v2(MAX);
+    assertEquals(MAX, cvss.value(), ACCURACY);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithNegativeValue() {
+    new CVSS(V3, -1.0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithTooBigValue() {
+    new CVSS(V3, 11.0);
+  }
+
+  @Test
+  public void testIsUnknown() {
+    assertTrue(new CVSS(V3, null).isUnknown());
+    assertFalse(new CVSS(V3, 5.1).isUnknown());
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    CVSS one = new CVSS(V3, 1.0);
+    assertEquals(one, one);
+
+    CVSS two = new CVSS(V3, 1.0);
+    assertEquals(one, two);
+    assertEquals(one.hashCode(), two.hashCode());
+
+    CVSS three = new CVSS(V2, 1.0);
+    assertNotEquals(one, three);
+
+    CVSS four = new CVSS(V3, 2.0);
+    assertNotEquals(one, four);
+  }
+
+  @Test
+  public void testCheckWithValidValues() {
+    CVSS.check(MIN);
+    CVSS.check(5.0);
+    CVSS.check(MAX);
+    CVSS.check(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCheckWithNegativeValue() {
+    CVSS.check(-2.0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCheckWithTooBigValue() {
+    CVSS.check(42.0);
+  }
+}

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/OwaspDependencyCheckCvssThresholdValueTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/OwaspDependencyCheckCvssThresholdValueTest.java
@@ -1,0 +1,78 @@
+package com.sap.sgs.phosphor.fosstars.model.value;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.sgs.phosphor.fosstars.model.feature.OwaspDependencyCheckCvssThreshold;
+import java.io.IOException;
+import org.junit.Test;
+
+public class OwaspDependencyCheckCvssThresholdValueTest {
+
+  private static final OwaspDependencyCheckCvssThreshold FEATURE
+      = new OwaspDependencyCheckCvssThreshold();
+
+  private static final double ACCURACY = 0.001;
+
+  @Test
+  public void testSpecifiedAndGet() {
+    final double cvssScore = 1.23;
+
+    OwaspDependencyCheckCvssThresholdValue value
+        = new OwaspDependencyCheckCvssThresholdValue(FEATURE, cvssScore, true);
+    assertTrue(value.specified());
+    assertEquals(cvssScore, value.get(), ACCURACY);
+
+    value = new OwaspDependencyCheckCvssThresholdValue(FEATURE, cvssScore, false);
+    assertFalse(value.specified());
+
+    value = FEATURE.value(cvssScore);
+    assertTrue(value.specified());
+    assertEquals(cvssScore, value.get(), ACCURACY);
+
+    value = FEATURE.notSpecifiedValue();
+    assertFalse(value.specified());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testGettingNotSpecifiedValue() {
+    OwaspDependencyCheckCvssThresholdValue value = FEATURE.notSpecifiedValue();
+    value.get();
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    OwaspDependencyCheckCvssThresholdValue one
+        = new OwaspDependencyCheckCvssThresholdValue(FEATURE, 1.23, true);
+    assertEquals(one, one);
+
+    OwaspDependencyCheckCvssThresholdValue two
+        = new OwaspDependencyCheckCvssThresholdValue(FEATURE, 1.23, true);
+    assertEquals(one, two);
+    assertEquals(one.hashCode(), two.hashCode());
+
+    OwaspDependencyCheckCvssThresholdValue three
+        = new OwaspDependencyCheckCvssThresholdValue(FEATURE, 2.34, true);
+    assertNotEquals(one, three);
+
+    OwaspDependencyCheckCvssThresholdValue four
+        = new OwaspDependencyCheckCvssThresholdValue(FEATURE, 1.23, false);
+    assertNotEquals(one, four);
+
+    assertNotEquals(three, four);
+  }
+
+  @Test
+  public void testSerializationAndDeserialization() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+
+    OwaspDependencyCheckCvssThresholdValue value = FEATURE.value(5.7);
+    OwaspDependencyCheckCvssThresholdValue clone = mapper.readValue(
+        mapper.writeValueAsBytes(value), OwaspDependencyCheckCvssThresholdValue.class);
+    assertEquals(value, clone);
+    assertEquals(value.hashCode(), clone.hashCode());
+  }
+}


### PR DESCRIPTION
Here is a list of main updates:

- Updated `OwaspDependencyCheckCvssThresholdValue` to check if a number is a valid CVSS.
- Added `equals()` and `hashCode()` methods in `OwaspDependencyCheckCvssThresholdValue`.
- Updated `CVSS.check()` method.
- Added new test cases.

This fixes #283