### PR TITLE
Update OwaspSecurityLibraries to support Gradle

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/LocalRepository.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/LocalRepository.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ResetCommand.ResetType;
@@ -255,9 +256,10 @@ public class LocalRepository implements AutoCloseable {
    */
   public List<Path> files(Predicate<Path> criteria) throws IOException {
     Objects.requireNonNull(criteria, "Oh no! Search criteria is null!");
-    return Files.walk(info().path())
-        .filter(criteria)
-        .collect(Collectors.toList());
+
+    try (Stream<Path> paths = Files.walk(info().path())) {
+      return paths.filter(criteria).collect(Collectors.toList());
+    }
   }
 
   @Override

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/OwaspSecurityLibraries.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/OwaspSecurityLibraries.java
@@ -64,37 +64,19 @@ public class OwaspSecurityLibraries extends GitHubCachingDataProvider {
   protected ValueSet fetchValuesFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project uses OWASP security libraries ...");
 
-    LocalRepository repository = GitHubDataFetcher.localRepositoryFor(project);
-
     ValueSet values = new ValueHashSet();
 
-    checkMaven(repository, values);
-    if (found(values)) {
-      return values;
-    }
-
-    checkGradle(repository, values);
-    if (found(values)) {
-      return values;
-    }
-
+    // set default values
     values.update(USES_OWASP_ESAPI.value(false));
     values.update(USES_OWASP_JAVA_ENCODER.value(false));
     values.update(USES_OWASP_JAVA_HTML_SANITIZER.value(false));
 
-    return values;
-  }
+    LocalRepository repository = GitHubDataFetcher.localRepositoryFor(project);
 
-  /**
-   * Checks if a value set contains the features for OWASP security tools.
-   *
-   * @param values The value set to be checked.
-   * @return True if the value set contains the features, false otherwise.
-   */
-  private static boolean found(ValueSet values) {
-    return values.has(USES_OWASP_ESAPI)
-        && values.has(USES_OWASP_JAVA_ENCODER)
-        && values.has(USES_OWASP_JAVA_HTML_SANITIZER);
+    checkMaven(repository, values);
+    checkGradle(repository, values);
+
+    return values;
   }
 
   /**
@@ -112,9 +94,18 @@ public class OwaspSecurityLibraries extends GitHubCachingDataProvider {
         Model model = readModel(is);
 
         Visitor visitor = browse(model, withVisitor());
-        values.update(USES_OWASP_ESAPI.value(visitor.foundOwaspEsapi));
-        values.update(USES_OWASP_JAVA_ENCODER.value(visitor.foundOwaspJavaEncoder));
-        values.update(USES_OWASP_JAVA_HTML_SANITIZER.value(visitor.foundOwaspJavaHtmlSanitizer));
+
+        if (visitor.foundOwaspEsapi) {
+          values.update(USES_OWASP_ESAPI.value(true));
+        }
+
+        if (visitor.foundOwaspJavaEncoder) {
+          values.update(USES_OWASP_JAVA_ENCODER.value(true));
+        }
+
+        if (visitor.foundOwaspJavaHtmlSanitizer) {
+          values.update(USES_OWASP_JAVA_HTML_SANITIZER.value(true));
+        }
       }
     }
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectors.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectors.java
@@ -192,7 +192,9 @@ public class TestVectors implements Iterable<TestVector> {
    */
   public static TestVectors loadFromYaml(Path filename) throws IOException {
     Objects.requireNonNull(filename, "Filename can't be null!");
-    return loadFromYaml(Files.newInputStream(filename));
+    try (InputStream is = Files.newInputStream(filename)) {
+      return loadFromYaml(is);
+    }
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/AbstractReporter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/AbstractReporter.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.sgs.phosphor.fosstars.tool.Project;
 import com.sap.sgs.phosphor.fosstars.tool.Reporter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -80,7 +81,9 @@ abstract class AbstractReporter<T extends Project> implements Reporter<T> {
       logger.warn("Oh no! I could not load extra projects from {}", extraSourceFileName);
       return Collections.emptyList();
     }
-    return MAPPER.readValue(Files.newInputStream(path), LIST_OF_GITHUB_PROJECTS_TYPE);
+    try (InputStream is = Files.newInputStream(path)) {
+      return MAPPER.readValue(is, LIST_OF_GITHUB_PROJECTS_TYPE);
+    }
   }
 
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectCache.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectCache.java
@@ -143,7 +143,9 @@ class GitHubProjectCache {
    * @throws IOException If something went wrong.
    */
   static GitHubProjectCache load(Path filename) throws IOException {
-    return load(Files.newInputStream(filename));
+    try (InputStream is = Files.newInputStream(filename)) {
+      return load(is);
+    }
   }
 
   /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectFinder.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/GitHubProjectFinder.java
@@ -283,7 +283,9 @@ public class GitHubProjectFinder {
      * @throws IOException If something went wrong.
      */
     Config parse(String filename) throws IOException {
-      return parse(Files.newInputStream(Paths.get(filename)));
+      try (InputStream is = Files.newInputStream(Paths.get(filename))) {
+        return parse(is);
+      }
     }
 
     /**

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculator.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/github/SecurityRatingCalculator.java
@@ -395,7 +395,9 @@ public class SecurityRatingCalculator {
    * @throws IOException If something went wrong.
    */
   private static Config config(String filename) throws IOException {
-    return config(Files.newInputStream(Paths.get(filename)));
+    try (InputStream is = Files.newInputStream(Paths.get(filename))) {
+      return config(is);
+    }
   }
 
   /**

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/GradleWithOwaspSecurityTools.gradle
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/GradleWithOwaspSecurityTools.gradle
@@ -1,0 +1,15 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
+dependencies {
+    compile 'org.owasp.esapi:esapi:2.1.0'
+    implementation "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:1.2.3"
+    runtime "org.owasp.encoder:encoder"
+}
+
+task test() {
+
+}

--- a/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/GradleWithoutOwaspSecurityTools.gradle
+++ b/src/test/resources/com/sap/sgs/phosphor/fosstars/data/github/GradleWithoutOwaspSecurityTools.gradle
@@ -1,0 +1,13 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
+dependencies {
+    compile 'org.test:something-else'
+}
+
+task test() {
+
+}


### PR DESCRIPTION
Here is a list of main updates:

- Updated the `OwaspSecurityLibraries` provider to search for features in Gradle files. This closes #297
- Updated several classes to close input streams. This fixes #318 
- Added new test cases.