### PR TITLE
Added a Markdown formatter for the tool

### DIFF
--- a/docs/oss/security/curl/curl.md
+++ b/docs/oss/security/curl/curl.md
@@ -1,184 +1,313 @@
 # curl/curl
 
-```
-Here is how the rating was calculated:
-  Score:........Security of project
-  Value:........6.56 out of 10.0
-  Confidence:...High (10.0 out of 10.0)
-  Based on:.....7 sub-scores:
-      Sub-score:....Security testing
-      Importance:...High (weight 1.0  out of  1.0)
-      Value:........5.44 out of 10.0
-      Confidence:...High (10.0 out of 10.0)
-      Based on:.....5 sub-scores:
-          Sub-score:....Static analysis
-          Importance:...High (weight 1.0  out of  1.0)
-          Value:........6.0  out of 10.0
-          Confidence:...High (10.0 out of 10.0)
-          Based on:.....2 sub-scores:
-              Sub-score:....LGTM score
-              Importance:...High (weight 1.0  out of  1.0)
-              Value:........6.0  out of 10.0
-              Confidence:...High (10.0 out of 10.0)
-              Based on:...2 features:
-                  Does it use LGTM checks?...............No
-                  The worst LGTM grade of the project:...A_PLUS
+https://github.com/curl/curl
 
-              Sub-score:....FindSecBugs score
-              Importance:...High (weight 1.0  out of  1.0)
-              Value:........N/A  
-              Confidence:...High (10.0 out of 10.0)
-              Based on:...2 features:
-                  A set of programming languages:...C, CPP, PYTHON, OTHER
-                  Does it use FindSecBugs?..........No
+Last updated on Aug 25, 2020
+
+**Rating**: GOOD
+
+**Score**: 5.53, where max score value is 10.0
+
+**Confidence**: Max (10.0, where max confidence value is 10.0)
+
+## Details
+
+The rating is based on **security score for open-source projects**.
 
 
-          Sub-score:....Fuzzing
-          Importance:...High (weight 1.0  out of  1.0)
-          Value:........10.0 out of 10.0
-          Confidence:...High (10.0 out of 10.0)
-          Based on:...2 features:
-              A set of programming languages:...C, CPP, PYTHON, OTHER
-              Is it included to OSS-Fuzz?.......Yes
-
-          Sub-score:....Dependency testing
-          Importance:...High (weight 1.0  out of  1.0)
-          Value:........0.0  out of 10.0
-          Confidence:...High (10.0 out of 10.0)
-          Based on:...5 features:
-              A set of package managers:..............................
-              A set of programming languages:.........................C, CPP, PYTHON, OTHER
-              Does it scan for vulnerable dependencies?...............No
-              Does it use Dependabot?.................................No
-              Does it use GitHub as the main development platform?....Yes
-
-          Sub-score:....Memory-safety testing
-          Importance:...High (weight 1.0  out of  1.0)
-          Value:........8.5  out of 10.0
-          Confidence:...High (10.0 out of 10.0)
-          Based on:...4 features:
-              A set of programming languages:............C, CPP, PYTHON, OTHER
-              Does it use AddressSanitizer?..............Yes
-              Does it use MemorySanitizer?...............No
-              Does it use UndefinedBehaviorSanitizer?....Yes
-
-          Sub-score:....nohttp tool
-          Importance:...Medium (weight 0.5  out of  1.0)
-          Value:........0.0  out of 10.0
-          Confidence:...High (10.0 out of 10.0)
-          Based on:...2 features:
-              A set of package managers:...
-              Does it use nohttp?..........No
 
 
-      Sub-score:....Security awareness
-      Description:..The score shows how a project is aware of
-                    security. If the project has a security policy,
-                    then the score adds 2.00. If the project has a
-                    security team, then the score adds 3.00. If the
-                    project uses verified signed commits, then the
-                    score adds 0.50. If the project has a bug bounty
-                    program, then the score adds 4.00. If the project
-                    signs its artifacts, then the score adds 0.50. If
-                    the project uses a security tool or library, then
-                    the score adds 1.00.
-      Importance:...High (weight 0.9  out of  1.0)
-      Value:........9.0  out of 10.0
-      Confidence:...High (10.0 out of 10.0)
-      Based on:...16 features:
-          Does it have a bug bounty program?.........Yes
-          Does it have a security policy?............Yes
-          Does it have a security team?..............No
-          Does it sign artifacts?....................No
-          Does it use AddressSanitizer?..............Yes
-          Does it use Dependabot?....................No
-          Does it use FindSecBugs?...................No
-          Does it use LGTM checks?...................No
-          Does it use MemorySanitizer?...............No
-          Does it use OWASP ESAPI?...................No
-          Does it use OWASP Java Encoder?............No
-          Does it use OWASP Java HTML Sanitizer?.....No
-          Does it use UndefinedBehaviorSanitizer?....Yes
-          Does it use nohttp?........................No
-          Does it use verified signed commits?.......No
-          Is it included to OSS-Fuzz?................Yes
 
-      Sub-score:....Unpatched vulnerabilities
-      Importance:...High (weight 0.8  out of  1.0)
-      Value:........10.0 out of 10.0
-      Confidence:...High (10.0 out of 10.0)
-      Based on:...1 features:
-          Info about vulnerabilities:...68 vulnerabilities
-      Explanation:..No unpatched vulnerabilities found which is good
+The score uses the following sub-scores:
 
-      Sub-score:....Vulnerability discovery and security testing
-      Description:..The scores checks how security testing is done and
-                    how many vulnerabilities were recently discovered.
-                    If testing is good, and there are no recent
-                    vulnerabilities, then the score value is max. If
-                    there are vulnerabilities, then the score value is
-                    high. If testing is bad, and there are no recent
-                    vulnerabilities, then the score value is low. If
-                    there are vulnerabilities, then the score is min.
-      Importance:...Medium (weight 0.6  out of  1.0)
-      Value:........0.0  out of 10.0
-      Confidence:...High (10.0 out of 10.0)
-      Based on:.....1 sub-scores:
-          Sub-score:....Security testing
-          Importance:...High (weight 1.0  out of  1.0)
-          Value:........5.44 out of 10.0
-          Confidence:...High (10.0 out of 10.0)
+1.  **[Security testing](#security-testing)**: 5.44, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[Dependency testing](#dependency-testing)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+        1.  **[Dependabot score](#dependabot-score)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+        1.  **[OWASP Dependency Check score](#owasp-dependency-check-score)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[Static analysis](#static-analysis)**: 6.0, confidence is 10.0 (max), importance is 1.0 (high)
+        1.  **[LGTM score](#lgtm-score)**: 6.0, confidence is 10.0 (max), importance is 1.0 (high)
+        1.  **[FindSecBugs score](#findsecbugs-score)**: N/A, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[Fuzzing](#fuzzing)**: 10.0, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[Memory-safety testing](#memory-safety-testing)**: 8.5, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[nohttp tool](#nohttp-tool)**: 0.0, confidence is 10.0 (max), importance is 0.5 (medium)
+1.  **[Security awareness](#security-awareness)**: 9.0, confidence is 10.0 (max), importance is 0.9 (high)
+1.  **[Unpatched vulnerabilities](#unpatched-vulnerabilities)**: 10.0, confidence is 10.0 (max), importance is 0.8 (high)
+1.  **[Vulnerability discovery and security testing](#vulnerability-discovery-and-security-testing)**: 0.0, confidence is 10.0 (max), importance is 0.6 (medium)
+    1.  **[Security testing](#security-testing)**: 5.44, confidence is 10.0 (max), importance is 1.0 (high)
+        1.  **[Dependency testing](#dependency-testing)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+            1.  **[Dependabot score](#dependabot-score)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+            1.  **[OWASP Dependency Check score](#owasp-dependency-check-score)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+        1.  **[Static analysis](#static-analysis)**: 6.0, confidence is 10.0 (max), importance is 1.0 (high)
+            1.  **[LGTM score](#lgtm-score)**: 6.0, confidence is 10.0 (max), importance is 1.0 (high)
+            1.  **[FindSecBugs score](#findsecbugs-score)**: N/A, confidence is 10.0 (max), importance is 1.0 (high)
+        1.  **[Fuzzing](#fuzzing)**: 10.0, confidence is 10.0 (max), importance is 1.0 (high)
+        1.  **[Memory-safety testing](#memory-safety-testing)**: 8.5, confidence is 10.0 (max), importance is 1.0 (high)
+        1.  **[nohttp tool](#nohttp-tool)**: 0.0, confidence is 10.0 (max), importance is 0.5 (medium)
+1.  **[Project activity](#project-activity)**: 0.0, confidence is 10.0 (max), importance is 0.5 (medium)
+1.  **[Community commitment](#community-commitment)**: 0.0, confidence is 10.0 (max), importance is 0.5 (medium)
+1.  **[Project popularity](#project-popularity)**: 10.0, confidence is 10.0 (max), importance is 0.5 (medium)
 
-      Based on:...1 features:
-          Info about vulnerabilities:...68 vulnerabilities
 
-      Sub-score:....Project activity
-      Description:..The score is based on number of commits and
-                    contributors.
-                    Here is how the number of commits
-                    contributes to the score (up to 5.10):
-                    0 -> 0.10,
-                    200 -> 2.55, 310 -> 4.59
-                    Here is how the number of
-                    contributors contributes to the score (up to
-                    5.10):
-                    0 -> 0.10, 5 -> 2.55, 10 -> 4.59
-      Importance:...Medium (weight 0.5  out of  1.0)
-      Value:........9.93 out of 10.0
-      Confidence:...High (10.0 out of 10.0)
-      Based on:...2 features:
-          Number of commits in the last three months:........287
-          Number of contributors in the last three months:...10
+## Sub-scores
 
-      Sub-score:....Community commitment
-      Importance:...Medium (weight 0.5  out of  1.0)
-      Value:........0.0  out of 10.0
-      Confidence:...High (10.0 out of 10.0)
-      Based on:...3 features:
-          Does it belong to Apache?........No
-          Does it belong to Eclipse?.......No
-          Is it supported by a company?....No
+Below are the details about all the used sub-scores.
 
-      Sub-score:....Project popularity
-      Description:..The score is based on number of stars and
-                    watchers.
-                    Here is how a number of stars
-                    contributes to the score:
-                    0 -> 0.00 (min), 2500 ->
-                    2.50, 5000 -> 5.00, 10000 -> 10.00 (max)
-                    Here is
-                    how a number of watchers contributes to the
-                    score:
-                    0 -> 0.00 (min), 450 -> 1.50, 750 -> 2.50,
-                    3000 -> 10.00 (max)
-      Importance:...Medium (weight 0.5  out of  1.0)
-      Value:........10.0 out of 10.0
-      Confidence:...High (10.0 out of 10.0)
-      Based on:...2 features:
-          Number of stars for a GitHub repository:......17816
-          Number of watchers for a GitHub repository:...704
+### Security testing
 
-Rating:     6.56 out of 10.0 -> GOOD
-Confidence: High (10.0 out of 10.0)
+Score: 5.44, confidence is 10.0 (max), importance is 1.0 (high)
 
-```
+
+
+
+
+The sub-score uses the following sub-scores:
+
+1.  **[Dependency testing](#dependency-testing)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[Dependabot score](#dependabot-score)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[OWASP Dependency Check score](#owasp-dependency-check-score)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+1.  **[Static analysis](#static-analysis)**: 6.0, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[LGTM score](#lgtm-score)**: 6.0, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[FindSecBugs score](#findsecbugs-score)**: N/A, confidence is 10.0 (max), importance is 1.0 (high)
+1.  **[Fuzzing](#fuzzing)**: 10.0, confidence is 10.0 (max), importance is 1.0 (high)
+1.  **[Memory-safety testing](#memory-safety-testing)**: 8.5, confidence is 10.0 (max), importance is 1.0 (high)
+1.  **[nohttp tool](#nohttp-tool)**: 0.0, confidence is 10.0 (max), importance is 0.5 (medium)
+
+
+### Security awareness
+
+Score: 9.0, confidence is 10.0 (max), importance is 0.9 (high)
+
+The score shows how a project is aware of security. If the project has a security policy, then the score adds 2.00. If the project has a security team, then the score adds 3.00. If the project uses verified signed commits, then the score adds 0.50. If the project has a bug bounty program, then the score adds 4.00. If the project signs its artifacts, then the score adds 0.50. If the project uses a security tool or library, then the score adds 1.00.
+
+
+
+The sub-score uses 17 features:
+
+1.  Does it have a bug bounty program? Yes
+1.  Does it have a security policy? Yes
+1.  Does it have a security team? No
+1.  Does it sign artifacts? No
+1.  Does it use AddressSanitizer? Yes
+1.  Does it use Dependabot? No
+1.  Does it use FindSecBugs? No
+1.  Does it use LGTM checks? No
+1.  Does it use MemorySanitizer? No
+1.  Does it use OWASP ESAPI? No
+1.  Does it use OWASP Java Encoder? No
+1.  Does it use OWASP Java HTML Sanitizer? No
+1.  Does it use UndefinedBehaviorSanitizer? Yes
+1.  Does it use nohttp? No
+1.  Does it use verified signed commits? No
+1.  How is OWASP Dependency Check used? Not used
+1.  Is it included to OSS-Fuzz? Yes
+
+### Unpatched vulnerabilities
+
+Score: 10.0, confidence is 10.0 (max), importance is 0.8 (high)
+
+
+
+No unpatched vulnerabilities found which is good
+
+The sub-score uses 1 feature:
+
+1.  Info about vulnerabilities: 68 vulnerabilities
+
+### Vulnerability discovery and security testing
+
+Score: 0.0, confidence is 10.0 (max), importance is 0.6 (medium)
+
+The scores checks how security testing is done and how many vulnerabilities were recently discovered. If testing is good, and there are no recent vulnerabilities, then the score value is max. If there are vulnerabilities, then the score value is high. If testing is bad, and there are no recent vulnerabilities, then the score value is low. If there are vulnerabilities, then the score is min.
+
+
+
+The sub-score uses the following sub-score:
+
+1.  **[Security testing](#security-testing)**: 5.44, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[Dependency testing](#dependency-testing)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+        1.  **[Dependabot score](#dependabot-score)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+        1.  **[OWASP Dependency Check score](#owasp-dependency-check-score)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[Static analysis](#static-analysis)**: 6.0, confidence is 10.0 (max), importance is 1.0 (high)
+        1.  **[LGTM score](#lgtm-score)**: 6.0, confidence is 10.0 (max), importance is 1.0 (high)
+        1.  **[FindSecBugs score](#findsecbugs-score)**: N/A, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[Fuzzing](#fuzzing)**: 10.0, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[Memory-safety testing](#memory-safety-testing)**: 8.5, confidence is 10.0 (max), importance is 1.0 (high)
+    1.  **[nohttp tool](#nohttp-tool)**: 0.0, confidence is 10.0 (max), importance is 0.5 (medium)
+
+The sub-score uses 1 feature:
+
+1.  Info about vulnerabilities: 68 vulnerabilities
+
+### Project activity
+
+Score: 0.0, confidence is 10.0 (max), importance is 0.5 (medium)
+
+The score is based on number of commits and contributors.
+Here is how the number of commits contributes to the score (up to 5.10):
+0 -> 0.10, 200 -> 2.55, 310 -> 4.59
+Here is how the number of contributors contributes to the score (up to 5.10):
+0 -> 0.10, 5 -> 2.55, 10 -> 4.59
+
+
+
+The sub-score uses 2 features:
+
+1.  Number of commits in the last three months: 0
+1.  Number of contributors in the last three months: 0
+
+### Community commitment
+
+Score: 0.0, confidence is 10.0 (max), importance is 0.5 (medium)
+
+
+
+
+
+The sub-score uses 3 features:
+
+1.  Does it belong to Apache? No
+1.  Does it belong to Eclipse? No
+1.  Is it supported by a company? No
+
+### Project popularity
+
+Score: 10.0, confidence is 10.0 (max), importance is 0.5 (medium)
+
+The score is based on number of stars and watchers.
+Here is how a number of stars contributes to the score:
+0 -> 0.00 (min), 2500 -> 2.50, 5000 -> 5.00, 10000 -> 10.00 (max)
+Here is how a number of watchers contributes to the score:
+0 -> 0.00 (min), 450 -> 1.50, 750 -> 2.50, 3000 -> 10.00 (max)
+
+
+
+The sub-score uses 2 features:
+
+1.  Number of stars for a GitHub repository: 17910
+1.  Number of watchers for a GitHub repository: 705
+
+### Dependency testing
+
+Score: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+
+
+
+
+
+The sub-score uses the following sub-scores:
+
+1.  **[Dependabot score](#dependabot-score)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+1.  **[OWASP Dependency Check score](#owasp-dependency-check-score)**: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+
+
+### Static analysis
+
+Score: 6.0, confidence is 10.0 (max), importance is 1.0 (high)
+
+
+
+
+
+The sub-score uses the following sub-scores:
+
+1.  **[LGTM score](#lgtm-score)**: 6.0, confidence is 10.0 (max), importance is 1.0 (high)
+1.  **[FindSecBugs score](#findsecbugs-score)**: N/A, confidence is 10.0 (max), importance is 1.0 (high)
+
+
+### Fuzzing
+
+Score: 10.0, confidence is 10.0 (max), importance is 1.0 (high)
+
+
+
+
+
+The sub-score uses 2 features:
+
+1.  A set of programming languages: C, CPP, PYTHON, OTHER
+1.  Is it included to OSS-Fuzz? Yes
+
+### Memory-safety testing
+
+Score: 8.5, confidence is 10.0 (max), importance is 1.0 (high)
+
+
+
+
+
+The sub-score uses 4 features:
+
+1.  A set of programming languages: C, CPP, PYTHON, OTHER
+1.  Does it use AddressSanitizer? Yes
+1.  Does it use MemorySanitizer? No
+1.  Does it use UndefinedBehaviorSanitizer? Yes
+
+### nohttp tool
+
+Score: 0.0, confidence is 10.0 (max), importance is 0.5 (medium)
+
+
+
+
+
+The sub-score uses 2 features:
+
+1.  A set of package managers: 
+1.  Does it use nohttp? No
+
+### Dependabot score
+
+Score: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+
+
+
+
+
+The sub-score uses 4 features:
+
+1.  A set of package managers: 
+1.  A set of programming languages: C, CPP, PYTHON, OTHER
+1.  Does it use Dependabot? No
+1.  Does it use GitHub as the main development platform? Yes
+
+### OWASP Dependency Check score
+
+Score: 0.0, confidence is 10.0 (max), importance is 1.0 (high)
+
+
+
+
+
+The sub-score uses 2 features:
+
+1.  How is OWASP Dependency Check used? Not used
+1.  What is the threshold for OWASP Dependency Check? Not specified
+
+### LGTM score
+
+Score: 6.0, confidence is 10.0 (max), importance is 1.0 (high)
+
+
+
+
+
+The sub-score uses 2 features:
+
+1.  Does it use LGTM checks? No
+1.  The worst LGTM grade of the project: A_PLUS
+
+### FindSecBugs score
+
+Score: N/A, confidence is 10.0 (max), importance is 1.0 (high)
+
+
+
+
+
+The sub-score uses 2 features:
+
+1.  A set of programming languages: C, CPP, PYTHON, OTHER
+1.  Does it use FindSecBugs? No
+
+
+

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/CommonFormatter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/CommonFormatter.java
@@ -1,0 +1,188 @@
+package com.sap.sgs.phosphor.fosstars.tool.format;
+
+import com.sap.sgs.phosphor.fosstars.model.Confidence;
+import com.sap.sgs.phosphor.fosstars.model.Feature;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.DependabotScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.DependencyScanScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.FindSecBugsScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.FuzzingScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.LgtmScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.MemorySafetyTestingScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.NoHttpToolScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.OssSecurityScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.OwaspDependencyScanScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.StaticAnalysisScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore;
+import com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityLifetimeScore;
+import com.sap.sgs.phosphor.fosstars.model.value.BooleanValue;
+import com.sap.sgs.phosphor.fosstars.model.value.OwaspDependencyCheckCvssThresholdValue;
+import com.sap.sgs.phosphor.fosstars.model.value.OwaspDependencyCheckUsageValue;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * The class contains common methods for formatters.
+ */
+public class CommonFormatter {
+
+  /**
+   * Maps a class of feature to its shorter name which should be used in output.
+   */
+  private static final Map<Class<? extends Feature>, String> FEATURE_CLASS_TO_NAME
+      = new HashMap<>();
+
+  static {
+    FEATURE_CLASS_TO_NAME.put(OssSecurityScore.class, "Security of project");
+    FEATURE_CLASS_TO_NAME.put(CommunityCommitmentScore.class, "Community commitment");
+    FEATURE_CLASS_TO_NAME.put(ProjectActivityScore.class, "Project activity");
+    FEATURE_CLASS_TO_NAME.put(ProjectPopularityScore.class, "Project popularity");
+    FEATURE_CLASS_TO_NAME.put(ProjectSecurityAwarenessScore.class, "Security awareness");
+    FEATURE_CLASS_TO_NAME.put(ProjectSecurityTestingScore.class, "Security testing");
+    FEATURE_CLASS_TO_NAME.put(UnpatchedVulnerabilitiesScore.class, "Unpatched vulnerabilities");
+    FEATURE_CLASS_TO_NAME.put(VulnerabilityLifetimeScore.class, "Vulnerability lifetime");
+    FEATURE_CLASS_TO_NAME.put(MemorySafetyTestingScore.class, "Memory-safety testing");
+    FEATURE_CLASS_TO_NAME.put(DependabotScore.class, "Dependabot score");
+    FEATURE_CLASS_TO_NAME.put(OwaspDependencyScanScore.class, "OWASP Dependency Check score");
+    FEATURE_CLASS_TO_NAME.put(DependencyScanScore.class, "Dependency testing");
+    FEATURE_CLASS_TO_NAME.put(FuzzingScore.class, "Fuzzing");
+    FEATURE_CLASS_TO_NAME.put(StaticAnalysisScore.class, "Static analysis");
+    FEATURE_CLASS_TO_NAME.put(NoHttpToolScore.class, "nohttp tool");
+    FEATURE_CLASS_TO_NAME.put(LgtmScore.class, "LGTM score");
+    FEATURE_CLASS_TO_NAME.put(FindSecBugsScore.class, "FindSecBugs score");
+    FEATURE_CLASS_TO_NAME.put(VulnerabilityDiscoveryAndSecurityTestingScore.class,
+        "Vulnerability discovery and security testing");
+  }
+
+  /**
+   * Maps a feature to its shorter name which should be used in output.
+   */
+  private static final Map<Feature, String> FEATURE_TO_NAME = new HashMap<>();
+
+  static {
+    FEATURE_TO_NAME.put(OssFeatures.HAS_SECURITY_TEAM, "Does it have a security team?");
+    FEATURE_TO_NAME.put(OssFeatures.HAS_SECURITY_POLICY, "Does it have a security policy?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_SIGNED_COMMITS, "Does it use verified signed commits?");
+    FEATURE_TO_NAME.put(OssFeatures.VULNERABILITIES, "Info about vulnerabilities");
+    FEATURE_TO_NAME.put(OssFeatures.IS_APACHE, "Does it belong to Apache?");
+    FEATURE_TO_NAME.put(OssFeatures.IS_ECLIPSE, "Does it belong to Eclipse?");
+    FEATURE_TO_NAME.put(OssFeatures.SUPPORTED_BY_COMPANY, "Is it supported by a company?");
+    FEATURE_TO_NAME.put(OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES,
+        "Does it scan for vulnerable dependencies?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_GITHUB_FOR_DEVELOPMENT,
+        "Does it use GitHub as the main development platform?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_ADDRESS_SANITIZER, "Does it use AddressSanitizer?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_MEMORY_SANITIZER, "Does it use MemorySanitizer?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_UNDEFINED_BEHAVIOR_SANITIZER,
+        "Does it use UndefinedBehaviorSanitizer?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_NOHTTP, "Does it use nohttp?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_FIND_SEC_BUGS, "Does it use FindSecBugs?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_OWASP_ESAPI, "Does it use OWASP ESAPI?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_OWASP_JAVA_ENCODER, "Does it use OWASP Java Encoder?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_OWASP_JAVA_HTML_SANITIZER,
+        "Does it use OWASP Java HTML Sanitizer?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_DEPENDABOT, "Does it use Dependabot?");
+    FEATURE_TO_NAME.put(OssFeatures.USES_LGTM_CHECKS, "Does it use LGTM checks?");
+    FEATURE_TO_NAME.put(OssFeatures.HAS_BUG_BOUNTY_PROGRAM, "Does it have a bug bounty program?");
+    FEATURE_TO_NAME.put(OssFeatures.SIGNS_ARTIFACTS, "Does it sign artifacts?");
+    FEATURE_TO_NAME.put(OssFeatures.WORST_LGTM_GRADE, "The worst LGTM grade of the project");
+    FEATURE_TO_NAME.put(OssFeatures.FUZZED_IN_OSS_FUZZ, "Is it included to OSS-Fuzz?");
+    FEATURE_TO_NAME.put(OssFeatures.OWASP_DEPENDENCY_CHECK_USAGE,
+        "How is OWASP Dependency Check used?");
+    FEATURE_TO_NAME.put(OssFeatures.OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD,
+        "What is the threshold for OWASP Dependency Check?");
+  }
+
+  /**
+   * Returns a human-readable label for a confidence.
+   *
+   * @param confidence The confidence.
+   * @return A human-readable label.
+   */
+  static String confidenceLabelFor(double confidence) {
+    if (Double.compare(confidence, Confidence.MAX) == 0) {
+      return "Max";
+    }
+    if (Double.compare(confidence, Confidence.MIN) == 0) {
+      return "Min";
+    }
+    return confidence >= 9.0 ? "High" : "Low";
+  }
+
+  /**
+   * Returns a human-readable label for a weight.
+   *
+   * @param weight The weight.
+   * @return A human-readable label.
+   */
+  static String importanceLabel(double weight) {
+    if (weight < 0.3) {
+      return "Low";
+    }
+    if (weight < 0.66) {
+      return "Medium";
+    }
+    return "High";
+  }
+
+  /**
+   * Figures out how a name of a feature should be printed out.
+   *
+   * @param feature The feature.
+   * @return A name of the feature.
+   */
+  static String nameOf(Feature feature) {
+    for (Map.Entry<Class<? extends Feature>, String> entry : FEATURE_CLASS_TO_NAME.entrySet()) {
+      if (feature.getClass() == entry.getKey()) {
+        return entry.getValue();
+      }
+    }
+
+    for (Map.Entry<Feature, String> entry : FEATURE_TO_NAME.entrySet()) {
+      if (feature.equals(entry.getKey())) {
+        return entry.getValue();
+      }
+    }
+
+    return feature.name();
+  }
+
+  /**
+   * Formats a specified value.
+   *
+   * @param value The value to be printed out.
+   * @return A formatted value.
+   */
+  static String actualValueOf(Value value) {
+    if (value.isUnknown()) {
+      return "unknown";
+    }
+
+    if (value instanceof BooleanValue) {
+      BooleanValue booleanValue = (BooleanValue) value;
+      return booleanValue.get() ? "Yes" : "No";
+    }
+
+    if (value instanceof OwaspDependencyCheckUsageValue) {
+      OwaspDependencyCheckUsageValue usageValue = (OwaspDependencyCheckUsageValue) value;
+      return StringUtils.capitalize(
+          usageValue.get().toString().replace("_", " ").toLowerCase());
+    }
+
+    if (value instanceof OwaspDependencyCheckCvssThresholdValue) {
+      OwaspDependencyCheckCvssThresholdValue threshold
+          = (OwaspDependencyCheckCvssThresholdValue) value;
+      return threshold.specified() ? String.valueOf(threshold.get()) : "Not specified";
+    }
+
+    return value.get().toString();
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/MarkdownFormatter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/MarkdownFormatter.java
@@ -1,0 +1,298 @@
+package com.sap.sgs.phosphor.fosstars.tool.format;
+
+import static com.sap.sgs.phosphor.fosstars.tool.format.CommonFormatter.confidenceLabelFor;
+import static com.sap.sgs.phosphor.fosstars.tool.format.CommonFormatter.importanceLabel;
+import static com.sap.sgs.phosphor.fosstars.tool.format.CommonFormatter.nameOf;
+
+import com.sap.sgs.phosphor.fosstars.model.Confidence;
+import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.Value;
+import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
+import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import org.apache.commons.io.IOUtils;
+
+/**
+ * The class prints a rating value in Markdown.
+ */
+public class MarkdownFormatter implements Formatter {
+
+  /**
+   * A resource with a Markdown template.
+   */
+  private static final String RESOURCE = "MarkdownRatingValueTemplate.md";
+
+  /**
+   * A Markdown template for a rating value.
+   */
+  private static final String TEMPLATE = loadFrom(RESOURCE);
+
+  /**
+   * An indent for building nested lists.
+   */
+  private static final String LIST_INDENT_STEP = "    ";
+
+  /**
+   * A formatter for doubles.
+   */
+  private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#.#");
+
+  static {
+    DECIMAL_FORMAT.setMinimumFractionDigits(1);
+    DECIMAL_FORMAT.setMaximumFractionDigits(2);
+  }
+
+  @Override
+  public String print(RatingValue ratingValue) {
+    Objects.requireNonNull(ratingValue, "Hey! Rating can't be null!");
+
+    ScoreValue scoreValue = ratingValue.scoreValue();
+    return TEMPLATE
+        .replaceAll("%MAX_SCORE%", formatted(Score.MAX))
+        .replaceAll("%MAX_CONFIDENCE%", formatted(Confidence.MAX))
+        .replace("%SCORE_VALUE%", formatted(scoreValue.get()))
+        .replace("%RATING_LABEL%", ratingValue.label().name())
+        .replace("%CONFIDENCE_LABEL%", confidenceLabelFor(ratingValue.confidence()))
+        .replace("%CONFIDENCE_VALUE%", formatted(ratingValue.confidence()))
+        .replace("%MAIN_SCORE_NAME%", scoreValue.score().name().toLowerCase())
+        .replace("%MAIN_SCORE_VALUE_DETAILS%", highLevelDescriptionOf(scoreValue))
+        .replace("%MAIN_SCORE_DESCRIPTION%", scoreValue.score().description())
+        .replace("%MAIN_SCORE_EXPLANATION%", explanationOf(scoreValue))
+        .replace("%SUB_SCORE_DETAILS%", descriptionOfSubScoresIn(scoreValue));
+  }
+
+  /**
+   * Builds a string with explanations for a score value if they are available.
+   *
+   * @param scoreValue The score value.
+   * @return A formatted string.
+   */
+  private static String explanationOf(ScoreValue scoreValue) {
+    return String.join("\n", scoreValue.explanation());
+  }
+
+  /**
+   * Looks for sub-score values that were used in a specified score value.
+   *
+   * @param scoreValue The score value.
+   * @return A list of sub-score values.
+   */
+  private static List<ScoreValue> usedSubScoreValuesIn(ScoreValue scoreValue) {
+    return scoreValue.usedValues().stream()
+        .filter(value -> value instanceof ScoreValue)
+        .map(ScoreValue.class::cast)
+        .sorted(Collections.reverseOrder(Comparator.comparingDouble(ScoreValue::weight)))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Builds a list of short descriptions of sub-score values for a specified score value.
+   *
+   * @param scoreValue The score value.
+   * @return A formatted text.
+   */
+  private static String highLevelDescriptionOf(ScoreValue scoreValue) {
+    return highLevelDescriptionOf(scoreValue, "");
+  }
+
+  /**
+   * Builds a list of short descriptions of sub-score values for a specified score value.
+   *
+   * @param scoreValue The score value.
+   * @param indent An indent for the list.
+   * @return A formatted list.
+   */
+  private static String highLevelDescriptionOf(ScoreValue scoreValue, String indent) {
+    StringBuilder sb = new StringBuilder();
+
+    usedSubScoreValuesIn(scoreValue).forEach(subScoreValue -> {
+      sb.append(String.format("%s1.  %s%n", indent, shortDescriptionOf(subScoreValue)));
+      sb.append(highLevelDescriptionOf(subScoreValue, indent + LIST_INDENT_STEP));
+    });
+
+    return sb.toString();
+  }
+
+  /**
+   * Builds a short description of a score value.
+   *
+   * @param scoreValue The score value.
+   * @return A formatted text.
+   */
+  private static String shortDescriptionOf(ScoreValue scoreValue) {
+    return String.format("**%s**: %s, confidence is %s (%s), importance is %s (%s)",
+        anchorFor(nameOf(scoreValue.score())),
+        actualValueOf(scoreValue),
+        formatted(scoreValue.confidence()),
+        confidenceLabelFor(scoreValue.confidence()).toLowerCase(),
+        formatted(scoreValue.weight()),
+        importanceLabel(scoreValue.weight()).toLowerCase()
+    );
+  }
+
+  /**
+   * Builds a Markdown anchor for a section.
+   *
+   * @param section The section's name.
+   * @return The anchor.
+   */
+  private static String anchorFor(String section) {
+    return String.format("[%s](#%s)", section, section.toLowerCase().replaceAll("\\s+", "-"));
+  }
+
+  /**
+   * Formats a double.
+   *
+   * @param n The double to be formatted.
+   * @return A formatted string.
+   */
+  private static String formatted(double n) {
+    return DECIMAL_FORMAT.format(n);
+  }
+
+  /**
+   * Build details about sub-scores in a specified score value.
+   * Each sub-score is printed out in a separate section.
+   * The method implements BFS, therefore it prints out the direct sub-scores first.
+   *
+   * @param scoreValue The score value to be printed out.
+   * @return A formatted text.
+   */
+  private static String descriptionOfSubScoresIn(ScoreValue scoreValue) {
+    StringBuilder sb = new StringBuilder();
+
+    Set<Score> processedScores = new HashSet<>();
+    Queue<ScoreValue> queue = new LinkedList<>(usedSubScoreValuesIn(scoreValue));
+    while (!queue.isEmpty()) {
+      ScoreValue subScoreValue = queue.poll();
+      if (processedScores.contains(subScoreValue.score())) {
+        continue;
+      }
+      processedScores.add(subScoreValue.score());
+
+      queue.addAll(usedSubScoreValuesIn(subScoreValue));
+
+      sb.append(detailsOf(subScoreValue));
+    }
+
+    return sb.toString();
+  }
+
+  /**
+   * Build details of a score value in a separate section.
+   * The method prints out sub-scores and feature that were are used in the score value.
+   *
+   * @param scoreValue The score value to be printed.
+   * @return A formatted score value.
+   */
+  private static String detailsOf(ScoreValue scoreValue) {
+    StringBuilder sb = new StringBuilder();
+
+    sb.append(String.format("### %s%n%n", nameOf(scoreValue.score())));
+
+    sb.append(String.format("Score: %s, confidence is %s (%s), importance is %s (%s)%n%n",
+        actualValueOf(scoreValue),
+        formatted(scoreValue.confidence()),
+        confidenceLabelFor(scoreValue.confidence()).toLowerCase(),
+        formatted(scoreValue.weight()),
+        importanceLabel(scoreValue.weight()).toLowerCase()));
+
+    sb.append(scoreValue.score().description());
+    sb.append("\n\n");
+
+    sb.append(explanationOf(scoreValue));
+    sb.append("\n\n");
+
+    List<ScoreValue> subScoreValues = new ArrayList<>();
+    List<Value> featureValues = new ArrayList<>();
+    for (Value usedValue : scoreValue.usedValues()) {
+      if (usedValue instanceof ScoreValue) {
+        subScoreValues.add((ScoreValue) usedValue);
+      } else {
+        featureValues.add(usedValue);
+      }
+    }
+
+    if (!subScoreValues.isEmpty()) {
+      subScoreValues.sort(Collections.reverseOrder(Comparator.comparingDouble(ScoreValue::weight)));
+
+      sb.append(String.format("The sub-score uses the following sub-score%s:%n%n",
+          subScoreValues.size() == 1 ? "" : "s"));
+      sb.append(highLevelDescriptionOf(scoreValue));
+      sb.append("\n");
+    }
+
+    if (!featureValues.isEmpty()) {
+      sb.append(String.format("The sub-score uses %d feature%s:%n%n",
+          featureValues.size(), featureValues.size() == 1 ? "" : "s"));
+
+      Map<String, Object> nameToValue = new TreeMap<>(String::compareTo);
+      for (Value usedValue : featureValues) {
+        String name = nameOf(usedValue.feature());
+
+        if (!name.endsWith("?")) {
+          name += ":";
+        }
+
+        nameToValue.put(name, CommonFormatter.actualValueOf(usedValue));
+      }
+
+      for (Map.Entry<String, Object> entry : nameToValue.entrySet()) {
+        sb.append(String.format("1.  %s %s%n", entry.getKey(), entry.getValue()));
+      }
+    }
+
+    sb.append("\n");
+
+    return sb.toString();
+  }
+
+  /**
+   * Build a string that shows an actual value of a score value. The method takes care about
+   * unknown and not-applicable score values.
+   *
+   * @param scoreValue The score value.
+   * @return A string that represents the score value.
+   */
+  public static String actualValueOf(ScoreValue scoreValue) {
+    if (scoreValue.isNotApplicable()) {
+      return "N/A";
+    }
+
+    if (scoreValue.isUnknown()) {
+      return "unknown";
+    }
+
+    return formatted(scoreValue.get());
+  }
+
+  /**
+   * Loads a resource.
+   *
+   * @param resource A name of the resource.
+   * @return The content of the resource.
+   */
+  static String loadFrom(String resource) {
+    try (InputStream is = CommonFormatter.class.getResourceAsStream(resource)) {
+      return IOUtils.toString(is, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Holy moly! Could not load template!", e);
+    }
+  }
+}

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinter.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/tool/format/PrettyPrinter.java
@@ -1,38 +1,19 @@
 package com.sap.sgs.phosphor.fosstars.tool.format;
 
+import static com.sap.sgs.phosphor.fosstars.tool.format.CommonFormatter.confidenceLabelFor;
+import static com.sap.sgs.phosphor.fosstars.tool.format.CommonFormatter.importanceLabel;
+import static com.sap.sgs.phosphor.fosstars.tool.format.CommonFormatter.nameOf;
+
 import com.sap.sgs.phosphor.fosstars.model.Confidence;
-import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.Weight;
-import com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.CommunityCommitmentScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.DependabotScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.DependencyScanScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.FindSecBugsScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.FuzzingScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.LgtmScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.MemorySafetyTestingScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.NoHttpToolScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.OssSecurityScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.OwaspDependencyScanScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectActivityScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectPopularityScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.StaticAnalysisScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore;
-import com.sap.sgs.phosphor.fosstars.model.score.oss.VulnerabilityLifetimeScore;
-import com.sap.sgs.phosphor.fosstars.model.value.BooleanValue;
-import com.sap.sgs.phosphor.fosstars.model.value.OwaspDependencyCheckCvssThresholdValue;
 import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
 import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -42,7 +23,7 @@ import java.util.TreeMap;
 import org.apache.commons.text.WordUtils;
 
 /**
- * The class print a pretty rating value.
+ * The class prints a pretty rating value.
  */
 public class PrettyPrinter implements Formatter {
 
@@ -66,69 +47,6 @@ public class PrettyPrinter implements Formatter {
     DECIMAL_FORMAT.setMaximumFractionDigits(2);
   }
 
-  /**
-   * Maps a class of feature to its shorter name which should be used in output.
-   */
-  private static final Map<Class<? extends Feature>, String> FEATURE_CLASS_TO_NAME
-      = new HashMap<>();
-
-  static {
-    FEATURE_CLASS_TO_NAME.put(OssSecurityScore.class, "Security of project");
-    FEATURE_CLASS_TO_NAME.put(CommunityCommitmentScore.class, "Community commitment");
-    FEATURE_CLASS_TO_NAME.put(ProjectActivityScore.class, "Project activity");
-    FEATURE_CLASS_TO_NAME.put(ProjectPopularityScore.class, "Project popularity");
-    FEATURE_CLASS_TO_NAME.put(ProjectSecurityAwarenessScore.class, "Security awareness");
-    FEATURE_CLASS_TO_NAME.put(ProjectSecurityTestingScore.class, "Security testing");
-    FEATURE_CLASS_TO_NAME.put(UnpatchedVulnerabilitiesScore.class, "Unpatched vulnerabilities");
-    FEATURE_CLASS_TO_NAME.put(VulnerabilityLifetimeScore.class, "Vulnerability lifetime");
-    FEATURE_CLASS_TO_NAME.put(MemorySafetyTestingScore.class, "Memory-safety testing");
-    FEATURE_CLASS_TO_NAME.put(DependabotScore.class, "Dependabot score");
-    FEATURE_CLASS_TO_NAME.put(OwaspDependencyScanScore.class, "OWASP Dependency Check score");
-    FEATURE_CLASS_TO_NAME.put(DependencyScanScore.class, "Dependency testing");
-    FEATURE_CLASS_TO_NAME.put(FuzzingScore.class, "Fuzzing");
-    FEATURE_CLASS_TO_NAME.put(StaticAnalysisScore.class, "Static analysis");
-    FEATURE_CLASS_TO_NAME.put(NoHttpToolScore.class, "nohttp tool");
-    FEATURE_CLASS_TO_NAME.put(LgtmScore.class, "LGTM score");
-    FEATURE_CLASS_TO_NAME.put(FindSecBugsScore.class, "FindSecBugs score");
-    FEATURE_CLASS_TO_NAME.put(VulnerabilityDiscoveryAndSecurityTestingScore.class,
-        "Vulnerability discovery and security testing");
-  }
-
-  /**
-   * Maps a feature to its shorter name which should be used in output.
-   */
-  private static final Map<Feature, String> FEATURE_TO_NAME = new HashMap<>();
-
-  static {
-    FEATURE_TO_NAME.put(OssFeatures.HAS_SECURITY_TEAM, "Does it have a security team?");
-    FEATURE_TO_NAME.put(OssFeatures.HAS_SECURITY_POLICY, "Does it have a security policy?");
-    FEATURE_TO_NAME.put(OssFeatures.USES_SIGNED_COMMITS, "Does it use verified signed commits?");
-    FEATURE_TO_NAME.put(OssFeatures.VULNERABILITIES, "Info about vulnerabilities");
-    FEATURE_TO_NAME.put(OssFeatures.IS_APACHE, "Does it belong to Apache?");
-    FEATURE_TO_NAME.put(OssFeatures.IS_ECLIPSE, "Does it belong to Eclipse?");
-    FEATURE_TO_NAME.put(OssFeatures.SUPPORTED_BY_COMPANY, "Is it supported by a company?");
-    FEATURE_TO_NAME.put(OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES,
-        "Does it scan for vulnerable dependencies?");
-    FEATURE_TO_NAME.put(OssFeatures.USES_GITHUB_FOR_DEVELOPMENT,
-        "Does it use GitHub as the main development platform?");
-    FEATURE_TO_NAME.put(OssFeatures.USES_ADDRESS_SANITIZER, "Does it use AddressSanitizer?");
-    FEATURE_TO_NAME.put(OssFeatures.USES_MEMORY_SANITIZER, "Does it use MemorySanitizer?");
-    FEATURE_TO_NAME.put(OssFeatures.USES_UNDEFINED_BEHAVIOR_SANITIZER,
-        "Does it use UndefinedBehaviorSanitizer?");
-    FEATURE_TO_NAME.put(OssFeatures.USES_NOHTTP, "Does it use nohttp?");
-    FEATURE_TO_NAME.put(OssFeatures.USES_FIND_SEC_BUGS, "Does it use FindSecBugs?");
-    FEATURE_TO_NAME.put(OssFeatures.USES_OWASP_ESAPI, "Does it use OWASP ESAPI?");
-    FEATURE_TO_NAME.put(OssFeatures.USES_OWASP_JAVA_ENCODER, "Does it use OWASP Java Encoder?");
-    FEATURE_TO_NAME.put(OssFeatures.USES_OWASP_JAVA_HTML_SANITIZER,
-        "Does it use OWASP Java HTML Sanitizer?");
-    FEATURE_TO_NAME.put(OssFeatures.USES_DEPENDABOT, "Does it use Dependabot?");
-    FEATURE_TO_NAME.put(OssFeatures.USES_LGTM_CHECKS, "Does it use LGTM checks?");
-    FEATURE_TO_NAME.put(OssFeatures.HAS_BUG_BOUNTY_PROGRAM, "Does it have a bug bounty program?");
-    FEATURE_TO_NAME.put(OssFeatures.SIGNS_ARTIFACTS, "Does it sign artifacts?");
-    FEATURE_TO_NAME.put(OssFeatures.WORST_LGTM_GRADE, "The worst LGTM grade of the project");
-    FEATURE_TO_NAME.put(OssFeatures.FUZZED_IN_OSS_FUZZ, "Is it included to OSS-Fuzz?");
-  }
-
   @Override
   public String print(RatingValue ratingValue) {
     StringBuilder sb = new StringBuilder();
@@ -137,7 +55,7 @@ public class PrettyPrinter implements Formatter {
     sb.append(String.format("Rating:     %s -> %s%n",
         tellMeActualValueOf(ratingValue.scoreValue()), ratingValue.label()));
     sb.append(String.format("Confidence: %s (%s)%n",
-        confidenceLabel(ratingValue.confidence()),
+        confidenceLabelFor(ratingValue.confidence()),
         printValueAndMax(ratingValue.confidence(), Confidence.MAX)));
     return sb.toString();
   }
@@ -184,7 +102,7 @@ public class PrettyPrinter implements Formatter {
         append(String.format("%s", tellMeActualValueOf(scoreValue)), ' ', 4)));
     sb.append(String.format("%sConfidence:...%s (%s)%n",
         indent,
-        confidenceLabel(scoreValue.confidence()),
+        confidenceLabelFor(scoreValue.confidence()),
         printValueAndMax(scoreValue.confidence(), Confidence.MAX)));
 
     if (printedScores.contains(scoreValue.score())) {
@@ -221,19 +139,7 @@ public class PrettyPrinter implements Formatter {
       int maxLength = 0;
       for (Value usedValue : featureValues) {
         String name = nameOf(usedValue.feature());
-
-        if (usedValue.isUnknown()) {
-          nameToValue.put(name, "unknown");
-        } else if (usedValue instanceof BooleanValue) {
-          BooleanValue booleanValue = (BooleanValue) usedValue;
-          nameToValue.put(name, booleanValue.get() ? "Yes" : "No");
-        } else if (usedValue instanceof OwaspDependencyCheckCvssThresholdValue) {
-          OwaspDependencyCheckCvssThresholdValue threshold
-              = (OwaspDependencyCheckCvssThresholdValue) usedValue;
-          nameToValue.put(name, threshold.specified() ? threshold.get() : "Not specified");
-        } else {
-          nameToValue.put(name, usedValue.get());
-        }
+        nameToValue.put(name, CommonFormatter.actualValueOf(usedValue));
 
         if (maxLength < name.length()) {
           maxLength = name.length();
@@ -311,52 +217,6 @@ public class PrettyPrinter implements Formatter {
       sb.append(c);
     }
     return sb.toString();
-  }
-
-  /**
-   * Figures out how a name of a feature should be printed out.
-   *
-   * @param feature The feature.
-   * @return A name of the feature.
-   */
-  static String nameOf(Feature feature) {
-    for (Map.Entry<Class<? extends Feature>, String> entry : FEATURE_CLASS_TO_NAME.entrySet()) {
-      if (feature.getClass() == entry.getKey()) {
-        return entry.getValue();
-      }
-    }
-    for (Map.Entry<Feature, String> entry : FEATURE_TO_NAME.entrySet()) {
-      if (feature.equals(entry.getKey())) {
-        return entry.getValue();
-      }
-    }
-    return feature.name();
-  }
-
-  /**
-   * Returns a human-readable label for a weight.
-   *
-   * @param weight The weight.
-   * @return A human-readable label.
-   */
-  private static String importanceLabel(double weight) {
-    if (weight < 0.3) {
-      return "Low";
-    }
-    if (weight < 0.66) {
-      return "Medium";
-    }
-    return "High";
-  }
-
-  /**
-   * Returns a human-readable label for a confidence.
-   *
-   * @param confidence The confidence.
-   * @return A human-readable label.
-   */
-  private static String confidenceLabel(double confidence) {
-    return confidence >= 9.0 ? "High" : "Low";
   }
 
 }

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/tool/format/MarkdownRatingValueTemplate.md
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/tool/format/MarkdownRatingValueTemplate.md
@@ -1,0 +1,23 @@
+**Rating**: %RATING_LABEL%
+
+**Score**: %SCORE_VALUE%, where max score value is %MAX_SCORE%
+
+**Confidence**: %CONFIDENCE_LABEL% (%CONFIDENCE_VALUE%, where max confidence value is %MAX_CONFIDENCE%)
+
+## Details
+
+The rating is based on **%MAIN_SCORE_NAME%**.
+
+%MAIN_SCORE_DESCRIPTION%
+
+%MAIN_SCORE_EXPLANATION%
+
+The score uses the following sub-scores:
+
+%MAIN_SCORE_VALUE_DETAILS%
+
+## Sub-scores
+
+Below are the details about all the used sub-scores.
+
+%SUB_SCORE_DETAILS%

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/tool/github/MarkdownProjectDetailsTemplate.md
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/tool/github/MarkdownProjectDetailsTemplate.md
@@ -1,5 +1,7 @@
 # %PROJECT_NAME%
 
-```
+%PROJECT_URL%
+
+Last updated on %UPDATED_DATE%
+
 %DETAILS%
-```

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/tool/format/MarkdownFormatterTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/tool/format/MarkdownFormatterTest.java
@@ -33,16 +33,12 @@ import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_U
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.VULNERABILITIES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_LGTM_GRADE;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
-import static com.sap.sgs.phosphor.fosstars.model.score.example.ExampleScores.SECURITY_SCORE_EXAMPLE;
 import static com.sap.sgs.phosphor.fosstars.model.value.Language.C;
 import static com.sap.sgs.phosphor.fosstars.model.value.OwaspDependencyCheckUsage.NOT_USED;
 import static com.sap.sgs.phosphor.fosstars.model.value.PackageManager.MAVEN;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
-import com.sap.sgs.phosphor.fosstars.model.Feature;
 import com.sap.sgs.phosphor.fosstars.model.RatingRepository;
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.rating.oss.OssSecurityRating;
@@ -50,13 +46,12 @@ import com.sap.sgs.phosphor.fosstars.model.value.Languages;
 import com.sap.sgs.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.sgs.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.sgs.phosphor.fosstars.model.value.RatingValue;
-import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import com.sap.sgs.phosphor.fosstars.model.value.Vulnerabilities;
 import java.util.Date;
 import java.util.Set;
 import org.junit.Test;
 
-public class PrettyPrinterTest {
+public class MarkdownFormatterTest {
 
   private static final OssSecurityRating RATING
       = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
@@ -99,59 +94,11 @@ public class PrettyPrinterTest {
   public void testPrint() {
     RatingValue ratingValue = RATING.calculate(TEST_VALUES);
 
-    PrettyPrinter printer = new PrettyPrinter();
-    String text = printer.print(ratingValue);
+    MarkdownFormatter formatter = new MarkdownFormatter();
+    String text = formatter.print(ratingValue);
 
     assertNotNull(text);
     assertFalse(text.isEmpty());
     System.out.println(text);
-    for (Value value : ratingValue.scoreValue().usedValues()) {
-      assertTrue(text.contains(CommonFormatter.nameOf(value.feature())));
-    }
-    for (Feature feature : RATING.allFeatures()) {
-      assertTrue(String.format("'%s' feature should be there!", feature.name()),
-          text.contains(CommonFormatter.nameOf(feature)));
-    }
-    assertTrue(text.contains("Value"));
-    assertTrue(text.contains("Confidence"));
-    assertTrue(text.contains("Importance"));
-    assertTrue(text.contains("Based on"));
-    assertTrue(text.contains("Description"));
-    assertTrue(text.contains("Explanation"));
-  }
-
-  @Test
-  public void testConsistency() {
-    RatingValue ratingValue = RATING.calculate(TEST_VALUES);
-
-    PrettyPrinter printer = new PrettyPrinter();
-    String text = printer.print(ratingValue);
-    for (int i = 0; i < 100; i++) {
-      assertEquals(text, printer.print(ratingValue));
-    }
-  }
-
-  @Test
-  public void testTellMeActualValueOf() {
-    assertEquals(
-        "10.0 out of 10.0",
-        PrettyPrinter.tellMeActualValueOf(new ScoreValue(SECURITY_SCORE_EXAMPLE).set(10)));
-    assertEquals(
-        "1.23 out of 10.0",
-        PrettyPrinter.tellMeActualValueOf(new ScoreValue(SECURITY_SCORE_EXAMPLE).set(1.23)));
-  }
-
-  @Test
-  public void testFormatValueAndMax() {
-    assertEquals("0.0  out of 10.0",
-        PrettyPrinter.printValueAndMax(0.0, 10.0));
-    assertEquals("1.23 out of 10.0",
-        PrettyPrinter.printValueAndMax(1.23, 10.0));
-    assertEquals("1.23 out of 10.0",
-        PrettyPrinter.printValueAndMax(1.23345, 10.0));
-    assertEquals("10.0 out of 10.0",
-        PrettyPrinter.printValueAndMax(10.0, 10.0));
-    assertEquals("9.0  out of 10.0",
-        PrettyPrinter.printValueAndMax(9.0, 10.0));
   }
 }


### PR DESCRIPTION
Here is a list of main updates:

- Added a new class `MarkdownFormatter` that builds a Markdown report for a rating.
- Added a new class `CommonFormatter` that provides common methods for the existing formatters.
- Updated the tool to use the new formatter when it generates reports for multiple projects.
- Added a smoke test for the new formatter.
- Updated the report for curl.

Closes #320