### PR TITLE
Improve docs for the open-source security rating

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See [docs](https://sap.github.io/fosstars-rating-core/) for more details.
 
 ## Security rating for open-source projects
 
-Using open-source software helps a lot but it also may bring new security issues
+Open-source software helps a lot but it also may bring new security issues
 and therefore increase security risks.
 Is it safe to use a particular open-source component?
 Sometimes answering this question is not easy.
@@ -30,20 +30,35 @@ can be found in the [docs](https://sap.github.io/fosstars-rating-core/oss_securi
 
 ## Download and installation
 
-The project can be built and installed with the following command:
+The [jars](https://mvnrepository.com/artifact/com.sap.oss.phosphor/fosstars-rating-core) are available on the Maven Central repository:
+
+```
+<dependency>
+    <groupId>com.sap.oss.phosphor</groupId>
+    <artifactId>fosstars-rating-core</artifactId>
+    <version>0.13.0</version>
+</dependency>
+
+```
+
+Or, the project can be built and installed with the following command:
 
 ```
 mvn clean install
 ```
 
-## Open-source security rating calculator
+## Command line tool for calculating security ratings
 
-The project offers a command line tool that takes a URL to a project on GitHub,
+There is a command line tool that takes a URL to a project on GitHub,
 gathers data about it, and calculates a security rating.
 
-The tool can be run with a command like the following:
+The tool can be run with commands like the following:
 
 ```
+git clone git@github.com:SAP/fosstars-rating-core.git
+cd fosstars-rating-core
+mvn package -DskipTests
+TOKEN=xyz # use your personal token, see below
 java -jar target/fosstars-github-rating-calc.jar --token ${TOKEN} --url https://github.com/apache/beam --no-questions
 ```
 
@@ -68,15 +83,15 @@ The output is going to look like the following:
 [+]    If an open-source project uses FindSecBugs: false
 [+]    If a project signs artifacts: false
 [+]    Info about vulnerabilities in open-source project: 1 vulnerability
-[+]    Number of stars for a GitHub repository: 4172
-[+]    Number of contributors in the last three months: 91
-[+]    Number of commits in the last three months: 1390
+[+]    Number of stars for a GitHub repository: 4199
+[+]    Number of contributors in the last three months: 93
+[+]    Number of commits in the last three months: 1388
 [+]    If an open-source project belongs to Apache Foundation: true
 [+]    If a project uses OWASP Enterprise Security API (ESAPI): false
 [+]    If a project uses signed commits: false
-[+]    If an open-source project is regularly scanned for vulnerable dependencies: false
 [+]    If an open-source project has a security team: true
 [+]    If an open-source project uses MemorySanitizer: false
+[+]    How OWASP Dependency Check is used: NOT_USED
 [+]    If a project uses nohttp tool: false
 [+]    If a project has a bug bounty program: false
 [+]    Number of watchers for a GitHub repository: 257
@@ -84,29 +99,54 @@ The output is going to look like the following:
 [+]    If an open-source project has a security policy: false
 [+]    If an open-source project is included to OSS-Fuzz project: false
 [+]    If a project uses OWASP Java HTML Sanitizer: false
+[+]    A CVSS threshold for OWASP Dependency Check to fail the build: 0.0
 [+]    If an open-source project uses UndefinedBehaviorSanitizer: false
-[+]    The worst LGTM grade of a project: B
 [+]    A set of package managers: GRADLE
+[+]    The worst LGTM grade of a project: B
 [+]    If an open-source project is supported by a company: false
 [+] Here is how the rating was calculated:
 [+]   Score:........Security of project
 [+]   Value:........4.71 out of 10.0
-[+]   Confidence:...High (10.0 out of 10.0)
+[+]   Confidence:...Max (10.0 out of 10.0)
 [+]   Based on:.....7 sub-scores:
 [+]       Sub-score:....Security testing
 [+]       Importance:...High (weight 1.0  out of  1.0)
 [+]       Value:........0.89 out of 10.0
-[+]       Confidence:...High (10.0 out of 10.0)
+[+]       Confidence:...Max (10.0 out of 10.0)
 [+]       Based on:.....5 sub-scores:
+[+]           Sub-score:....Dependency testing
+[+]           Importance:...High (weight 1.0  out of  1.0)
+[+]           Value:........0.0  out of 10.0
+[+]           Confidence:...Max (10.0 out of 10.0)
+[+]           Based on:.....2 sub-scores:
+[+]               Sub-score:....Dependabot score
+[+]               Importance:...High (weight 1.0  out of  1.0)
+[+]               Value:........0.0  out of 10.0
+[+]               Confidence:...Max (10.0 out of 10.0)
+[+]               Based on:...4 features:
+[+]                   A set of package managers:..............................GRADLE
+[+]                   A set of programming languages:.........................C, JAVA, PYTHON, JAVASCRIPT, OTHER
+[+]                   Does it use Dependabot?.................................No
+[+]                   Does it use GitHub as the main development platform?....Yes
+[+] 
+[+]               Sub-score:....OWASP Dependency Check score
+[+]               Importance:...High (weight 1.0  out of  1.0)
+[+]               Value:........0.0  out of 10.0
+[+]               Confidence:...Max (10.0 out of 10.0)
+[+]               Based on:...2 features:
+[+]                   How is OWASP Dependency Check used?..................Not used
+[+]                   What is the threshold for OWASP Dependency Check?....Not specified
+[+] 
+[+] 
 [+]           Sub-score:....Static analysis
 [+]           Importance:...High (weight 1.0  out of  1.0)
 [+]           Value:........4.0  out of 10.0
-[+]           Confidence:...High (10.0 out of 10.0)
+[+]           Confidence:...Max (10.0 out of 10.0)
 [+]           Based on:.....2 sub-scores:
 [+]               Sub-score:....LGTM score
 [+]               Importance:...High (weight 1.0  out of  1.0)
 [+]               Value:........4.0  out of 10.0
-[+]               Confidence:...High (10.0 out of 10.0)
+[+]               Confidence:...Max (10.0 out of 10.0)
 [+]               Based on:...2 features:
 [+]                   Does it use LGTM checks?...............No
 [+]                   The worst LGTM grade of the project:...B
@@ -114,7 +154,7 @@ The output is going to look like the following:
 [+]               Sub-score:....FindSecBugs score
 [+]               Importance:...High (weight 1.0  out of  1.0)
 [+]               Value:........0.0  out of 10.0
-[+]               Confidence:...High (10.0 out of 10.0)
+[+]               Confidence:...Max (10.0 out of 10.0)
 [+]               Based on:...2 features:
 [+]                   A set of programming languages:...C, JAVA, PYTHON, JAVASCRIPT, OTHER
 [+]                   Does it use FindSecBugs?..........No
@@ -123,26 +163,15 @@ The output is going to look like the following:
 [+]           Sub-score:....Fuzzing
 [+]           Importance:...High (weight 1.0  out of  1.0)
 [+]           Value:........0.0  out of 10.0
-[+]           Confidence:...High (10.0 out of 10.0)
+[+]           Confidence:...Max (10.0 out of 10.0)
 [+]           Based on:...2 features:
 [+]               A set of programming languages:...C, JAVA, PYTHON, JAVASCRIPT, OTHER
 [+]               Is it included to OSS-Fuzz?.......No
 [+] 
-[+]           Sub-score:....Dependency testing
-[+]           Importance:...High (weight 1.0  out of  1.0)
-[+]           Value:........0.0  out of 10.0
-[+]           Confidence:...High (10.0 out of 10.0)
-[+]           Based on:...5 features:
-[+]               A set of package managers:..............................GRADLE
-[+]               A set of programming languages:.........................C, JAVA, PYTHON, JAVASCRIPT, OTHER
-[+]               Does it scan for vulnerable dependencies?...............No
-[+]               Does it use Dependabot?.................................No
-[+]               Does it use GitHub as the main development platform?....Yes
-[+] 
 [+]           Sub-score:....Memory-safety testing
 [+]           Importance:...High (weight 1.0  out of  1.0)
 [+]           Value:........0.0  out of 10.0
-[+]           Confidence:...High (10.0 out of 10.0)
+[+]           Confidence:...Max (10.0 out of 10.0)
 [+]           Based on:...4 features:
 [+]               A set of programming languages:............C, JAVA, PYTHON, JAVASCRIPT, OTHER
 [+]               Does it use AddressSanitizer?..............No
@@ -152,7 +181,7 @@ The output is going to look like the following:
 [+]           Sub-score:....nohttp tool
 [+]           Importance:...Medium (weight 0.5  out of  1.0)
 [+]           Value:........0.0  out of 10.0
-[+]           Confidence:...High (10.0 out of 10.0)
+[+]           Confidence:...Max (10.0 out of 10.0)
 [+]           Based on:...2 features:
 [+]               A set of package managers:...GRADLE
 [+]               Does it use nohttp?..........No
@@ -171,8 +200,8 @@ The output is going to look like the following:
 [+]                     the score adds 1.00.
 [+]       Importance:...High (weight 0.9  out of  1.0)
 [+]       Value:........3.0  out of 10.0
-[+]       Confidence:...High (10.0 out of 10.0)
-[+]       Based on:...16 features:
+[+]       Confidence:...Max (10.0 out of 10.0)
+[+]       Based on:...17 features:
 [+]           Does it have a bug bounty program?.........No
 [+]           Does it have a security policy?............No
 [+]           Does it have a security team?..............Yes
@@ -188,12 +217,13 @@ The output is going to look like the following:
 [+]           Does it use UndefinedBehaviorSanitizer?....No
 [+]           Does it use nohttp?........................No
 [+]           Does it use verified signed commits?.......No
+[+]           How is OWASP Dependency Check used?........Not used
 [+]           Is it included to OSS-Fuzz?................No
 [+] 
 [+]       Sub-score:....Unpatched vulnerabilities
 [+]       Importance:...High (weight 0.8  out of  1.0)
 [+]       Value:........10.0 out of 10.0
-[+]       Confidence:...High (10.0 out of 10.0)
+[+]       Confidence:...Max (10.0 out of 10.0)
 [+]       Based on:...1 features:
 [+]           Info about vulnerabilities:...1 vulnerability
 [+]       Explanation:..No unpatched vulnerabilities found which is good
@@ -209,12 +239,12 @@ The output is going to look like the following:
 [+]                     there are vulnerabilities, then the score is min.
 [+]       Importance:...Medium (weight 0.6  out of  1.0)
 [+]       Value:........0.0  out of 10.0
-[+]       Confidence:...High (10.0 out of 10.0)
+[+]       Confidence:...Max (10.0 out of 10.0)
 [+]       Based on:.....1 sub-scores:
 [+]           Sub-score:....Security testing
 [+]           Importance:...High (weight 1.0  out of  1.0)
 [+]           Value:........0.89 out of 10.0
-[+]           Confidence:...High (10.0 out of 10.0)
+[+]           Confidence:...Max (10.0 out of 10.0)
 [+] 
 [+]       Based on:...1 features:
 [+]           Info about vulnerabilities:...1 vulnerability
@@ -232,15 +262,15 @@ The output is going to look like the following:
 [+]                     0 -> 0.10, 5 -> 2.55, 10 -> 4.59
 [+]       Importance:...Medium (weight 0.5  out of  1.0)
 [+]       Value:........10.0 out of 10.0
-[+]       Confidence:...High (10.0 out of 10.0)
+[+]       Confidence:...Max (10.0 out of 10.0)
 [+]       Based on:...2 features:
-[+]           Number of commits in the last three months:........1390
-[+]           Number of contributors in the last three months:...91
+[+]           Number of commits in the last three months:........1388
+[+]           Number of contributors in the last three months:...93
 [+] 
 [+]       Sub-score:....Community commitment
 [+]       Importance:...Medium (weight 0.5  out of  1.0)
 [+]       Value:........7.0  out of 10.0
-[+]       Confidence:...High (10.0 out of 10.0)
+[+]       Confidence:...Max (10.0 out of 10.0)
 [+]       Based on:...3 features:
 [+]           Does it belong to Apache?........Yes
 [+]           Does it belong to Eclipse?.......No
@@ -259,14 +289,14 @@ The output is going to look like the following:
 [+]                     0 -> 0.00 (min), 450 -> 1.50, 750 -> 2.50,
 [+]                     3000 -> 10.00 (max)
 [+]       Importance:...Medium (weight 0.5  out of  1.0)
-[+]       Value:........5.03 out of 10.0
-[+]       Confidence:...High (10.0 out of 10.0)
+[+]       Value:........5.06 out of 10.0
+[+]       Confidence:...Max (10.0 out of 10.0)
 [+]       Based on:...2 features:
-[+]           Number of stars for a GitHub repository:......4172
+[+]           Number of stars for a GitHub repository:......4199
 [+]           Number of watchers for a GitHub repository:...257
 [+] 
 [+] Rating:     4.71 out of 10.0 -> GOOD
-[+] Confidence: High (10.0 out of 10.0)
+[+] Confidence: Max (10.0 out of 10.0)
 [+] Bye!
 ```
 
@@ -277,7 +307,7 @@ and may ask the user a couple of questions.
 
 Please see [GitHub issues](https://github.com/SAP/fosstars-rating-core/issues).
 
-## How to obtain support
+## Support
 
 Please create a new [GitHub issue](https://github.com/SAP/fosstars-rating-core/issues)
 if you found a bug, or you'd like to propose an enhancement.
@@ -286,8 +316,8 @@ If you think you found a security issue, please follow [this guideline](SECURITY
 We currently don't have a support channel.
 If you have a question, please also ask it via GitHub issues.
 
-# Contributing to the project
+# Contributing
 
-We welcome ideas for improvements and pull requests.
+We appreciate feedback, ideas for improvements and, of course, pull requests.
+
 Please follow [this guideline](CONTRIBUTING.md) if you'd like to contribute to the project.
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,5 +6,6 @@
 1.  [Tuning a rating](tuning.md)
 1.  [Rating confidence](confidence.md)
 1.  [Open-source security rating](oss_security_rating.md)
+1.  [Getting the security ratings](getting_oss_security_rating.md)
 1.  [Alternatives](alternatives.md)
 1.  [Notes](notes.md)

--- a/docs/getting_oss_security_rating.md
+++ b/docs/getting_oss_security_rating.md
@@ -1,71 +1,42 @@
-![Java CI](https://github.com/SAP/fosstars-rating-core/workflows/Java%20CI/badge.svg)
-[![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/SAP/fosstars-rating-core.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/SAP/fosstars-rating-core/context:java)
-[![REUSE status](https://api.reuse.software/badge/github.com/SAP/fosstars-rating-core)](https://api.reuse.software/info/github.com/SAP/fosstars-rating-core)
+# Getting the security ratings
 
-# Ratings for open-source projects
-
-This is a framework for defining and calculating ratings for open-source projects.
-See [docs](https://sap.github.io/fosstars-rating-core/) for more details.
-
-## Security rating for open-source projects
-
-Open-source software helps a lot, but it also may bring new security issues
-and therefore increase security risks.
-Is it safe to use a particular open-source component?
-Sometimes answering this question is not easy.
-The security rating for open-source projects helps to answer this question.
-First, it gathers various data about an open-source project.
-Then, it calculates a security rating for it.
-The rating helps to assess the security risk that comes with this open-source project.
-
-More details about the security rating
-can be found in the [docs](https://sap.github.io/fosstars-rating-core/oss_security_rating.html).
-
-## Requirements
-
-*  Java 8+
-*  Maven 3.6.0+
-*  Python 3.6.8+
-*  Jupyter Notebook 4.4.0+
-
-## Download and installation
-
-The [jars](https://mvnrepository.com/artifact/com.sap.oss.phosphor/fosstars-rating-core) are available on the Maven Central repository:
-
-```
-<dependency>
-    <groupId>com.sap.oss.phosphor</groupId>
-    <artifactId>fosstars-rating-core</artifactId>
-    <version>0.13.0</version>
-</dependency>
-
-```
-
-Or, the project can be built and installed with the following command:
-
-```
-mvn clean install
-```
+The page describes how a security rating may be calculated for an open-source project.
 
 ## Command line tool for calculating security ratings
 
-There is a command line tool that takes a URL to a project on GitHub,
-gathers data about it, and calculates a security rating.
+There is a command line tool for gathering data about an open-source project and calculating
+the security rating. Currently, there is not an installer for the tool (should we create one?),
+and the tool should be built locally from the sources.
 
-The tool can be run with commands like the following:
+The following commands download the sources and build the command line tool with Maven:
 
 ```
 git clone git@github.com:SAP/fosstars-rating-core.git
 cd fosstars-rating-core
 mvn package -DskipTests
-TOKEN=xyz # use your personal token, see below
+```
+
+To calculate the security rating for an open-source project,
+the command line tool needs a URL to its source code management system (SCM).
+Currently, the tool works best with projects what stay on GitHub.
+
+### Calculating the security rating by providing a URL to the source code
+
+A URL to SCM can be passed to the tool by using `--url` command line parameter.
+For example, here is how a security rating may be calculated for Apache Beam:
+
+```
 java -jar target/fosstars-github-rating-calc.jar --token ${TOKEN} --url https://github.com/apache/beam --no-questions
 ```
 
-The `TOKEN` variable contains a token for accessing the GitHub API.
+The environment variable `TOKEN` contains a token for accessing the GitHub API.
 You can create a personal token in the
 [settings/tokens](https://github.com/settings/tokens) tab in your profile on GitHub.
+It's okay to run the tool without the token, but the result will be a bit less precise.
 
+The tool will try to gather info about the project.
+In particular, it will try to download the source code,
+make a number of requests to GitHub and other services, fetch data from NVD and so on.
 The output is going to look like the following:
 
 ```
@@ -300,24 +271,29 @@ The output is going to look like the following:
 [+] Bye!
 ```
 
+The tool prints out the gathered data, the structure of the overall security score, used sub-scores,
+their weights and so on. This info may be useful if one would like to understand how the tool
+calculated the rating. It may also give an idea for possible improvements that can improve the rating.
+
 If no `--no-questions` option is specified, the tool becomes a bit interactive,
-and may ask the user a couple of questions.
+and may ask the user a couple of questions about the project.
 
-## Known issues
+### Calculating the security rating by providing GAV coordinates
 
-Please see [GitHub issues](https://github.com/SAP/fosstars-rating-core/issues).
+The command line tool also accepts GAV coordinates of Maven artifacts (group id, artifact id and version).
+If the coordinates are provided,
+then the tool will try to figure out which open-source project produces the artifact.
+In particular, it will try to find a URL to the project's SCM.
+If the URL is found, the tool will use it to calculate the security rating.
+Otherwise, the tool exits with an error.
 
-## Support
+The tool has a command line option `--gav`, that accepts either GAV coordinates or just group id and artifact id.
+Below is an example of getting a rating for Apache Commons Text by passing its group and artifact ids:
 
-Please create a new [GitHub issue](https://github.com/SAP/fosstars-rating-core/issues)
-if you found a bug, or you'd like to propose an enhancement.
-If you think you found a security issue, please follow [this guideline](SECURITY.md).
+```
+java -jar target/fosstars-github-rating-calc.jar --token ${TOKEN} --gav org.apache.commons:commons-text --no-questions
+```
 
-We currently don't have a support channel.
-If you have a question, please also ask it via GitHub issues.
+---
 
-# Contributing
-
-We appreciate feedback, ideas for improvements and, of course, pull requests.
-
-Please follow [this guideline](CONTRIBUTING.md) if you'd like to contribute to the project.
+Next: [Alternatives](alternatives.md)

--- a/docs/getting_oss_security_rating.md
+++ b/docs/getting_oss_security_rating.md
@@ -294,6 +294,12 @@ Below is an example of getting a rating for Apache Commons Text by passing its g
 java -jar target/fosstars-github-rating-calc.jar --token ${TOKEN} --gav org.apache.commons:commons-text --no-questions
 ```
 
+## Further ideas
+
+1.  Add a Maven plugin that looks for dependencies in an application and calculate security ratings for them.
+1.  Add a GitHub App that looks for dependencies in a repository, calculates security ratings for them,
+    and report them via GitHub issues or comments in pull requests.
+
 ---
 
 Next: [Alternatives](alternatives.md)

--- a/docs/getting_oss_security_rating.md
+++ b/docs/getting_oss_security_rating.md
@@ -294,11 +294,88 @@ Below is an example of getting a rating for Apache Commons Text by passing its g
 java -jar target/fosstars-github-rating-calc.jar --token ${TOKEN} --gav org.apache.commons:commons-text --no-questions
 ```
 
+### Building a report for multiple projects
+
+The tool can calculate ratings for multiple projects and generate a report.
+To do that, the tool needs a configuration file that describes which projects should be included
+to the report, and which format should be used for the report.
+
+Here is an example of such a configuration file:
+
+```
+# this is a configuration for generating a report for a number of open-source projects
+
+# a cache to store fetched data about the projects
+cache: .fosstars/project_rating_cache.json
+
+# the following sections lists projects for which the ratings should be calculated
+finder:
+
+  # search for projects in FasterXML organisation on GitHub
+  organizations:
+    - name: FasterXML
+
+      # consider projects with at least the specified number of stars
+      stars: 5000
+
+      # skip projects that contains the following words in its names
+      exclude:
+        - docs
+        - test
+        - benchmark
+
+  # include the following projects
+  repositories:
+    - organization: netty
+      name: netty
+    - organization: openssl
+      name: openssl
+    - organization: curl
+      name: curl
+    - organization: google
+      name: guava
+    - organization: google
+      name: gson
+
+# the following section describes which reports should be generated.
+reports:
+
+  # first, store the gathered data and calculated ratings in a JSON file
+  # then, the file will be used to generate other reports
+  - type: json
+    where: fosstars/github_projects.json
+
+  # generate a report in Markdown format
+  # first, it will read gathered data and calculated ratings from the specified JSON file
+  # then, it will build the report and store it in the specified directory
+  - type: markdown
+    source: fosstars/github_projects.json
+    where: fosstars/report
+```
+
+The config gives the following instructions to the tool:
+
+*  Calculate security ratings for Netty, OpenSSL, Guava, Gson, curl 
+   and projects from FasterXML organisation which have at least 5K stars.
+*  Store gathered data and calculated ratings in a JSON file.
+*  Create a report in Markdown format.
+*  Store the results in the specified directories.
+
+Here is how the tool may be run with the config above:
+
+```
+java -jar target/fosstars-github-rating-calc.jar --token ${TOKEN} --config conf.yml --no-questions
+```
+
+The Markdown report is going to be available in `fosstars/report` directory.
+
 ## Further ideas
 
+1.  Add an installer for the command line tool.
 1.  Add a Maven plugin that looks for dependencies in an application and calculate security ratings for them.
 1.  Add a GitHub App that looks for dependencies in a repository, calculates security ratings for them,
     and report them via GitHub issues or comments in pull requests.
+1.  Offer a GitHub action that regularly generates reports.
 
 ---
 

--- a/docs/oss_security_rating.md
+++ b/docs/oss_security_rating.md
@@ -1,13 +1,54 @@
-# Open-source security rating
+# Security ratings for open-source projects
 
 This section describes a security rating for open-source projects.
 The rating is implemented in the [OssSecurityRating](https://github.com/SAP/fosstars-rating-core/blob/master/src/main/java/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRating.java) class.
 
+The rating may be used to assess how well open-source projects and their communities care about security. 
+This may then be uesd to estimate security risks that may affect an application when it uses open-source components.
+
+[By definition](ratings.md), the security rating produces a score, a label and a confidence score.
+Here is a list of labels:
+
+1.  `GOOD`: the project implements relatively good security measures and in general cares about security.
+1.  `MODERATE`: the security level in the project is not good but definetly not too bad.
+1.  `BAD`: looks like the project doesn't care well about security.
+1.  `UNCLEAR`: there is no enough data to reliably calculate a score and a label for the project.
+
+The security rating uses [thresholds](https://github.com/SAP/fosstars-rating-core/blob/master/src/main/java/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRating.java#L84)
+for score and confidence to assing one of the labels to an open-source project.
+If a confidence score is lower than a certain value, then the project gets the `UNCLEAR` label.
+If a calculated score is higher than a certain threshold, then then the projct gets `GOOD`, `MODERATE` or `BAD` label.
+
+The thresholds depend on scores for the following [projects](oss/security):
+
+*  Relatively popular projects in Apache and Eclipse software foundations
+*  Relatively popular Spring projects
+*  Relatively popular FasterXML projects
+*  And a number of other well-known projects such as curl, Netty, OpenSSL and so on.
+
+Here is how the thresholds are calculated:
+
+*  First, calculate scores for the projects mentioned above.
+*  Second, sort the projects by scores (from low to high).
+*  Then, assign the `BAD` label to first 30% of the projects with the lowest scores.
+   The highest score in this set becomes the threshold for the `BAD` label.
+   In other words, a project gets the `BAD` label if its score is below this threshold.
+*  Next, assing the `MODERATE` label to the next 50% of the projects.
+   The highest score in this set becomes the threshold for the `MODERATE` label accordingly.
+   In other words, a project gets the `MODERATE` label if its score is below this threshold.
+*  Finally, the rest 20% of the projects get the `GOOD` label.
+
+The main goal of the method is to reduce a possible bias that may be introduced if the thresholds are assigned by experts.
+Instead of setting the thresholds directly, the experts gives a list of well-known projects in the industry and specify
+a desired fraction for the labels. At the moment, it is 20-50-30 that looks like a normal distribution.
+As a result, the thresholds don't set a bar that is based on someone's opinion.
+Instead, other open-source projects are compared with the real, well-known, established and trusted ones.
+
+The procedure for calculating the thresholds is implemented in [SecurityRatingAnalysis notebook](https://github.com/SAP/fosstars-rating-core/blob/master/src/main/jupyter/oss/security/SecurityRatingAnalysis.ipynb).
+
 ## Features
 
 Here is a list of features that are currently used in the open-source security rating.
-Implementations of the features can be found in
-[com.sap.sgs.phosphor.fosstars.model.feature.oss](https://github.com/SAP/fosstars-rating-core/blob/master/src/main/java/com/sap/sgs/phosphor/fosstars/model/feature/oss) package.
 
 1.  Info about vulnerabilities in open-source project.
 1.  If an open-source project has a security team.
@@ -42,7 +83,7 @@ Implementations of the features can be found in
 
 ## Scores
 
-The open-source security rating is based on open-source security score
+The open-source security rating is based on the open-source security score
 that is implemented in the [OssSecurityScore](https://github.com/SAP/fosstars-rating-core/blob/master/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore.java) class.
 
 Here is a list of sub-scores that are currently used in the open-source security score.

--- a/docs/oss_security_rating.md
+++ b/docs/oss_security_rating.md
@@ -4,27 +4,28 @@ This section describes a security rating for open-source projects.
 The rating is implemented in the [OssSecurityRating](https://github.com/SAP/fosstars-rating-core/blob/master/src/main/java/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRating.java) class.
 
 The rating may be used to assess how well open-source projects and their communities care about security. 
-This may then be uesd to estimate security risks that may affect an application when it uses open-source components.
+This may then be used to estimate security risks that may affect an application when it uses open-source components.
 
 [By definition](ratings.md), the security rating produces a score, a label and a confidence score.
 Here is a list of labels:
 
 1.  `GOOD`: the project implements relatively good security measures and in general cares about security.
-1.  `MODERATE`: the security level in the project is not good but definetly not too bad.
+1.  `MODERATE`: the security level in the project is not good but definitely not too bad.
 1.  `BAD`: looks like the project doesn't care well about security.
 1.  `UNCLEAR`: there is no enough data to reliably calculate a score and a label for the project.
 
-The security rating uses [thresholds](https://github.com/SAP/fosstars-rating-core/blob/master/src/main/java/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRating.java#L84)
-for score and confidence to assing one of the labels to an open-source project.
+The security rating uses
+[thresholds](https://github.com/SAP/fosstars-rating-core/blob/master/src/main/java/com/sap/sgs/phosphor/fosstars/model/rating/oss/OssSecurityRating.java#L84)
+for score and confidence to assign one of the labels to an open-source project.
 If a confidence score is lower than a certain value, then the project gets the `UNCLEAR` label.
-If a calculated score is higher than a certain threshold, then then the projct gets `GOOD`, `MODERATE` or `BAD` label.
+If a calculated score is higher than a certain threshold, then the project gets `GOOD`, `MODERATE` or `BAD` label.
 
 The thresholds depend on scores for the following [projects](oss/security):
 
 *  Relatively popular projects in Apache and Eclipse software foundations
 *  Relatively popular Spring projects
 *  Relatively popular FasterXML projects
-*  And a number of other well-known projects such as curl, Netty, OpenSSL and so on.
+*  A number of other well-known projects such as curl, Netty, OpenSSL and so on.
 
 Here is how the thresholds are calculated:
 
@@ -33,120 +34,33 @@ Here is how the thresholds are calculated:
 *  Then, assign the `BAD` label to first 30% of the projects with the lowest scores.
    The highest score in this set becomes the threshold for the `BAD` label.
    In other words, a project gets the `BAD` label if its score is below this threshold.
-*  Next, assing the `MODERATE` label to the next 50% of the projects.
+*  Next, assign the `MODERATE` label to the next 50% of the projects.
    The highest score in this set becomes the threshold for the `MODERATE` label accordingly.
    In other words, a project gets the `MODERATE` label if its score is below this threshold.
 *  Finally, the rest 20% of the projects get the `GOOD` label.
 
-The main goal of the method is to reduce a possible bias that may be introduced if the thresholds are assigned by experts.
+The main goal of the method is to reduce a possible bias that may be introduced if experts set the thresholds directly.
 Instead of setting the thresholds directly, the experts gives a list of well-known projects in the industry and specify
 a desired fraction for the labels. At the moment, it is 20-50-30 that looks like a normal distribution.
-As a result, the thresholds don't set a bar that is based on someone's opinion.
+As a result, the thresholds don't set a bar totally based on someone's opinion.
 Instead, other open-source projects are compared with the real, well-known, established and trusted ones.
 
-The procedure for calculating the thresholds is implemented in [SecurityRatingAnalysis notebook](https://github.com/SAP/fosstars-rating-core/blob/master/src/main/jupyter/oss/security/SecurityRatingAnalysis.ipynb).
+The procedure for calculating the thresholds is implemented in 
+[SecurityRatingAnalysis notebook](https://github.com/SAP/fosstars-rating-core/blob/master/src/main/jupyter/oss/security/SecurityRatingAnalysis.ipynb).
 
-## Features
+## What the security rating takes into account
 
-Here is a list of features that are currently used in the open-source security rating.
+The security rating tries to evaluate the following for an open-source project:
 
-1.  Info about vulnerabilities in open-source project.
-1.  If an open-source project has a security team.
-1.  If an open-source project has a security policy.
-1.  If an open-source project has a bug bounty program.
-1.  If an open-source project signs its artifacts.
-1.  If a project uses Dependabot.
-1.  If an open-source project uses FindSecBugs.
-1.  If an open-source project uses AddressSanitizer.
-1.  If an open-source project uses MemorySanitizer.
-1.  If an open-source project uses UndefinedBehaviorSanitizer.
-1.  If a project uses LGTM.
-1.  The worst LGTM grade of a project.
-1.  If an open-source project is included to OSS-Fuzz project.
-1.  If a project uses nohttp tool.
-1.  If a project uses OWASP Enterprise Security API (ESAPI).
-1.  If a project uses OWASP Java HTML Sanitizer.
-1.  If a project uses OWASP Java Encoder.
-1.  If an open-source project is supported by a company.
-1.  If an open-source project belongs to Eclipse Foundation.
-1.  If an open-source project belongs to Apache Foundation.
-1.  If a project uses GitHub as the main development platform.
-1.  If a project uses signed commits.
-1.  Number of stars for a GitHub repository.
-1.  Number of contributors in the last three months.
-1.  Number of commits in the last three months.
-1.  Number of watchers for a GitHub repository.
-1.  Programming languages that are used in a project.
-1.  Package managers that are used in a project.
-1.  If and how a project uses OWASP Dependency Check.
-1.  If and how a project sets a CVSS threshold for OWASP Dependency Check to fail the build.
+1.  How well the project implements security testing.
+1.  If the project has vulnerabilities that have not been fixed.
+1.  How well the community is aware about security.
+1.  How the project is active.
+1.  How the project is popular.
+1.  How the community commits to support the project.
 
-## Scores
-
-The open-source security rating is based on the open-source security score
-that is implemented in the [OssSecurityScore](https://github.com/SAP/fosstars-rating-core/blob/master/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/OssSecurityScore.java) class.
-
-Here is a list of sub-scores that are currently used in the open-source security score.
-Implementations for all the scores can be found in the [com.sap.sgs.phosphor.fosstars.model.score.oss](https://github.com/SAP/fosstars-rating-core/blob/master/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss) package.
-
-1.  **Security testing score** based on the following sub-scores:
-    1.  How a project uses static analysis for security testing. It's based on the following sub-scores:
-        1.  How a project addresses issues reported by LGTM. It's based on the following features:
-            1.  If a project uses LGTM.
-            1.  The worst LGTM grade of a project.
-        1.  How a project uses FindSecBugs. It's based on the following features:
-            1.  Programming languages that are used in a project.
-            1.  If an open-source project uses FindSecBugs.
-    1.  If a project uses nohttp tool. It's based on the following features:
-        1.  Package managers that are used in a project.
-        1.  If a project uses nohttp tool.
-    1.  How a project uses fuzzing. It's based on the following features:
-        1.  Programming languages that are used in a project.
-        1.  If an open-source project is included to OSS-Fuzz project.
-    1.  Dependency testing. It's based on the following sub-scores:
-        1.  Dependabot score based on the following features:
-            1.  Programming languages that are used in a project.
-            1.  Package managers that are used in a project.
-            1.  If a project uses Dependabot.
-            1.  If a project uses GitHub as the main development platform.
-        1.  OWASP Dependency Check score based on the following features:
-            1.  If and how a project uses OWASP Dependency Check.
-            1.  If and how a project sets a CVSS threshold for OWASP Dependency Check to fail the build.
-    1.  Memory-safety testing. It's based on the following features:
-        1.  Programming languages that are used in a project.
-        1.  If an open-source project uses AddressSanitizer.
-        1.  If an open-source project uses MemorySanitizer.
-        1.  If an open-source project uses UndefinedBehaviorSanitizer.
-1.  **Unpatched vulnerabilities score** based on the following features:
-    1.  Info about vulnerabilities in open-source project.
-1.  **Security awareness score** based on the following features:
-    1.  If an open-source project has a security team.
-    1.  If an open-source project has a security policy.
-    1.  If a project uses signed commits.
-    1.  If an open-source project has a bug bounty program.
-    1.  If an open-source project signs its artifacts.
-    1.  If a project uses Dependabot.
-    1.  If an open-source project uses FindSecBugs.
-    1.  If an open-source project uses AddressSanitizer.
-    1.  If an open-source project uses MemorySanitizer.
-    1.  If an open-source project uses UndefinedBehaviorSanitizer.
-    1.  If a project uses LGTM.
-    1.  If an open-source project is included to OSS-Fuzz project.
-    1.  If a project uses nohttp tool.
-    1.  If a project uses OWASP Enterprise Security API (ESAPI).
-    1.  If a project uses OWASP Java HTML Sanitizer.
-    1.  If a project uses OWASP Java Encoder.
-    1.  If and how a project uses OWASP Dependency Check.
-1.  **Project activity score** based on the following features:
-    1.  Number of commits last three months.
-    1.  Number of contributors last three months.
-1.  **Project popularity score** based on the following features:
-    1.  Number of watchers for a GitHub repository.
-    1.  Number of stars for a GitHub repository.
-1.  **Community commitment score** based on the following features:
-    1.  If an open-source project belongs to Apache Foundation.
-    1.  If an open-source project belongs to Eclipse Foundation.
-    1.  If an open-source project is supported by a company.
+For example, here is a [detailed report](oss/security/curl/curl.md)
+that shows all sub-scores, structure and data that were used to calculate a rating for curl.
 
 ## Security ratings for well-known open-source projects
 

--- a/docs/oss_security_rating.md
+++ b/docs/oss_security_rating.md
@@ -69,4 +69,4 @@ in this [report](oss/security).
 
 ---
 
-Next: [Alternatives](alternatives.md)
+Next: [Getting the security ratings](getting_oss_security_rating.md)


### PR DESCRIPTION
Here is a list of updates:

- Update the README with new output of the tool.
- Added a new page that describes how the tool can be used.
- Provided more details in `docs/oss_security_rating.md`: better description of the structure, described labels, described threshold for the labels, described test vectors.

This closes #331 