### PR TITLE
IsEclipse should consider eclipse-ee4j org

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/IsEclipse.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/IsEclipse.java
@@ -13,6 +13,8 @@ import java.io.IOException;
  */
 public class IsEclipse extends CachedSingleFeatureGitHubDataProvider {
 
+  private static final String[] KNOWN_ECLIPSE_ORGANISATIONS = { "eclipse", "eclipse-ee4j" };
+
   /**
    * Initializes a data provider.
    *
@@ -23,13 +25,18 @@ public class IsEclipse extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Boolean> supportedFeature() {
     return IS_ECLIPSE;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Boolean> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project belongs to the Eclipse Software Foundation ...");
-    return IS_ECLIPSE.value("eclipse".equalsIgnoreCase(project.organization().name()));
+    for (String organisation : KNOWN_ECLIPSE_ORGANISATIONS) {
+      if (organisation.equalsIgnoreCase(project.organization().name())) {
+        return IS_ECLIPSE.value(true);
+      }
+    }
+    return IS_ECLIPSE.value(false);
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/IsEclipseTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/IsEclipseTest.java
@@ -1,0 +1,30 @@
+package com.sap.sgs.phosphor.fosstars.data.github;
+
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.IS_ECLIPSE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
+import java.io.IOException;
+import org.junit.Test;
+
+
+public class IsEclipseTest extends TestGitHubDataFetcherHolder {
+
+  @Test
+  public void testProjects() throws IOException {
+    IsEclipse provider = new IsEclipse(fetcher);
+    assertTrue(provider.fetchValueFor(
+        GitHubProject.parse("https://github.com/eclipse/jgit")).get());
+    assertTrue(provider.fetchValueFor(
+        GitHubProject.parse("https://github.com/eclipse-ee4j/eclipselink")).get());
+    assertFalse(provider.fetchValueFor(
+        GitHubProject.parse("https://github.com/apache/nifi")).get());
+  }
+
+  @Test
+  public void testSupportedFeature() {
+    assertEquals(IS_ECLIPSE, new IsEclipse(fetcher).supportedFeature());
+  }
+}


### PR DESCRIPTION
Here is a list of updates:

- Updated `IsEclipse` data provider to check the eclipse-ee4j organisation on GitHub.
- Added `IsEclipseTest`.

Fixes #349