### PR TITLE
WeightedCompositeScore should return unknown score if all values are unknown

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/Value.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/Value.java
@@ -48,7 +48,7 @@ public interface Value<T> {
    *
    * @return A feature which the value is for.
    */
-  Feature feature();
+  Feature<T> feature();
 
   /**
    * Tells if the value is unknown.
@@ -68,6 +68,7 @@ public interface Value<T> {
    * Get the value.
    *
    * @return The value.
+   * @throws IllegalStateException If the value is unknown.
    */
   T get();
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/AbstractTestVector.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/AbstractTestVector.java
@@ -16,6 +16,11 @@ public abstract class AbstractTestVector implements TestVector {
   final Interval expectedScore;
 
   /**
+   * If it's set to true, then an unknown score value is expected.
+   */
+  final boolean expectedUnknownScore;
+
+  /**
    * If it's set to true, then a not-applicable score value is expected.
    */
   final boolean expectedNotApplicableScore;
@@ -36,22 +41,26 @@ public abstract class AbstractTestVector implements TestVector {
    * @param expectedScore An interval for an expected score.
    * @param expectedLabel An expected label (can be null).
    * @param alias A alias of the test vector.
+   * @param expectedUnknownScore
+   *        If it's set to true, then an unknown score value is expected.
    * @param expectedNotApplicableScore
    *        If it's set to true, then a not-applicable score value is expected.
    */
   AbstractTestVector(Interval expectedScore, Label expectedLabel, String alias,
+      boolean expectedUnknownScore,
       boolean expectedNotApplicableScore) {
 
     Objects.requireNonNull(alias, "Hey! alias can't be null!");
 
-    if (expectedScore == null && !expectedNotApplicableScore) {
-      throw new IllegalArgumentException(
-          "Hey! Expected score can't be null unless a not-applicable value is expected!");
+    if (expectedScore == null && !expectedNotApplicableScore && !expectedUnknownScore) {
+      throw new IllegalArgumentException("Hey! Expected score can't be null "
+          + "unless a not-applicable or unknown value is expected!");
     }
 
     this.expectedScore = expectedScore;
     this.expectedLabel = expectedLabel;
     this.alias = alias;
+    this.expectedUnknownScore = expectedUnknownScore;
     this.expectedNotApplicableScore = expectedNotApplicableScore;
   }
 
@@ -59,6 +68,12 @@ public abstract class AbstractTestVector implements TestVector {
   @JsonGetter("expectedScore")
   public final Interval expectedScore() {
     return expectedScore;
+  }
+
+  @Override
+  @JsonGetter("expectedUnknownScore")
+  public boolean expectsUnknownScore() {
+    return expectedUnknownScore;
   }
 
   @Override
@@ -93,7 +108,8 @@ public abstract class AbstractTestVector implements TestVector {
       return false;
     }
     AbstractTestVector that = (AbstractTestVector) o;
-    return expectedNotApplicableScore == that.expectedNotApplicableScore
+    return expectedUnknownScore == that.expectedUnknownScore
+        && expectedNotApplicableScore == that.expectedNotApplicableScore
         && Objects.equals(expectedScore, that.expectedScore)
         && Objects.equals(expectedLabel, that.expectedLabel)
         && Objects.equals(alias, that.alias);
@@ -101,6 +117,7 @@ public abstract class AbstractTestVector implements TestVector {
 
   @Override
   public int hashCode() {
-    return Objects.hash(expectedScore, expectedNotApplicableScore, expectedLabel, alias);
+    return Objects.hash(
+        expectedScore, expectedUnknownScore, expectedNotApplicableScore, expectedLabel, alias);
   }
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/AbstractVerifier.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/AbstractVerifier.java
@@ -84,6 +84,16 @@ public abstract class AbstractVerifier implements Verifier {
           Status.FAILED, "Expected N/A score, but got a real score value");
     }
 
+    // next, check if the test vector expects an unknown score value
+    if (vector.expectsUnknownScore() && scoreValue.isUnknown()) {
+      return new TestVectorResult(vector, index, scoreValue,
+          Status.PASSED, "Ok, score is unknown as expected");
+    }
+    if (vector.expectsUnknownScore() && !scoreValue.isUnknown()) {
+      return new TestVectorResult(vector, index, scoreValue,
+          Status.FAILED, "Expected an unknown score, but got a real score value");
+    }
+
     // now we know that the test vector expects a real score value
     // it means that the vector contains an expected interval
 
@@ -91,6 +101,13 @@ public abstract class AbstractVerifier implements Verifier {
     if (scoreValue.isNotApplicable()) {
       String message = String.format(
           "Expected a score in interval %s got N/A", vector.expectedScore());
+      return new TestVectorResult(vector, index, scoreValue, Status.FAILED, message);
+    }
+
+    // then, check if the score value is unknown
+    if (scoreValue.isUnknown()) {
+      String message = String.format(
+          "Expected a score in interval %s got unknown", vector.expectedScore());
       return new TestVectorResult(vector, index, scoreValue, Status.FAILED, message);
     }
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreTestVector.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreTestVector.java
@@ -29,6 +29,8 @@ public class ScoreTestVector extends AbstractTestVector {
    * @param expectedScore An interval for an expected score.
    * @param expectedLabel An expected label (can be null).
    * @param alias A alias of the test vector.
+   * @param expectedUnknownScore
+   *        If it's set to true, then an unknown score value is expected.
    * @param expectedNotApplicableScore
    *        If it's set to true, then a not-applicable score value is expected.
    */
@@ -39,10 +41,13 @@ public class ScoreTestVector extends AbstractTestVector {
       @JsonProperty("expectedLabel") Label expectedLabel,
       @JsonProperty("alias") String alias,
       @JsonProperty(
+          value = "expectedUnknownScore",
+          defaultValue = "false") boolean expectedUnknownScore,
+      @JsonProperty(
           value = "expectedNotApplicableScore",
           defaultValue = "false") boolean expectedNotApplicableScore) {
 
-    super(expectedScore, expectedLabel, alias, expectedNotApplicableScore);
+    super(expectedScore, expectedLabel, alias, expectedUnknownScore, expectedNotApplicableScore);
 
     Objects.requireNonNull(values, "Hey! Values can't be null!");
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/StandardTestVector.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/StandardTestVector.java
@@ -32,7 +32,7 @@ public class StandardTestVector extends AbstractTestVector {
   public StandardTestVector(
       Set<Value> values, Interval expectedScore, Label expectedLabel, String alias) {
 
-    this(values, expectedScore, expectedLabel, alias, false);
+    this(values, expectedScore, expectedLabel, alias, false, false);
   }
 
   /**
@@ -42,6 +42,8 @@ public class StandardTestVector extends AbstractTestVector {
    * @param expectedScore An interval for an expected score.
    * @param expectedLabel An expected label (can be null).
    * @param alias A alias of the test vector.
+   * @param expectedUnknownScore
+   *        If it's set to true, then an unknown score value is expected.
    * @param expectedNotApplicableScore
    *        If it's set to true, then a not-applicable score value is expected.
    */
@@ -52,10 +54,13 @@ public class StandardTestVector extends AbstractTestVector {
       @JsonProperty("expectedLabel") Label expectedLabel,
       @JsonProperty("alias") String alias,
       @JsonProperty(
+          value = "expectedUnknownScore",
+          defaultValue = "false") boolean expectedUnknownScore,
+      @JsonProperty(
           value = "expectedNotApplicableScore",
           defaultValue = "false") boolean expectedNotApplicableScore) {
 
-    super(expectedScore, expectedLabel, alias, expectedNotApplicableScore);
+    super(expectedScore, expectedLabel, alias, expectedUnknownScore, expectedNotApplicableScore);
 
     Objects.requireNonNull(values, "Hey! Values can't be null!");
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVector.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVector.java
@@ -75,4 +75,11 @@ public interface TestVector {
    */
   boolean expectsNotApplicableScore();
 
+  /**
+   * Tells if the test vector expects an unknown value.
+   *
+   * @return True if a not-applicable score value is expected, false otherwise.
+   */
+  boolean expectsUnknownScore();
+
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorBuilder.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorBuilder.java
@@ -27,6 +27,11 @@ public class TestVectorBuilder {
   private Interval expectedScore;
 
   /**
+   * If it's set to true, then an unknown score value is expected.
+   */
+  private boolean expectUnknownScore = false;
+
+  /**
    * If it's set to true, then a not-applicable score value is expected.
    */
   private boolean expectNotApplicableScore = false;
@@ -75,6 +80,16 @@ public class TestVectorBuilder {
    */
   public TestVectorBuilder expectedScore(Interval interval) {
     expectedScore = interval;
+    return this;
+  }
+
+  /**
+   * Makes a test vector to expect an unknown value.
+   *
+   * @return This instance of TestVectorBuilder.
+   */
+  public TestVectorBuilder expectUnknownScore() {
+    expectUnknownScore = true;
     return this;
   }
 
@@ -161,9 +176,9 @@ public class TestVectorBuilder {
    * @return An instance of TestVector.
    */
   public StandardTestVector make() {
-    if (expectedScore == null && !expectNotApplicableScore) {
-      throw new IllegalArgumentException(
-          "Hey! Expected score can't be null unless a not-applicable value is expected!");
+    if (expectedScore == null && !expectNotApplicableScore && !expectUnknownScore) {
+      throw new IllegalArgumentException("Hey! Expected score can't be null "
+          + "unless a not-applicable or unknown value is expected!");
     }
 
     if (values.isEmpty()) {
@@ -172,7 +187,7 @@ public class TestVectorBuilder {
     }
 
     return new StandardTestVector(Collections.unmodifiableSet(values), expectedScore, expectedLabel,
-        alias, expectNotApplicableScore);
+        alias, expectUnknownScore, expectNotApplicableScore);
   }
 
 }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorWithDefaults.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/TestVectorWithDefaults.java
@@ -94,6 +94,11 @@ public class TestVectorWithDefaults implements TestVector {
   }
 
   @Override
+  public boolean expectsUnknownScore() {
+    return vector.expectsUnknownScore();
+  }
+
+  @Override
   public boolean expectsNotApplicableScore() {
     return vector.expectsNotApplicableScore();
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/VerificationFailedException.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/qa/VerificationFailedException.java
@@ -5,10 +5,19 @@ package com.sap.sgs.phosphor.fosstars.model.qa;
  */
 public class VerificationFailedException extends Exception {
 
+  /**
+   * Creates an exception with a generic message.
+   */
   public VerificationFailedException() {
     super("One of the test vectors failed!");
   }
 
+  /**
+   * Creates an exception with a specified message.
+   *
+   * @param format A format string.
+   * @param params A number of parameters for the format string.
+   */
   public VerificationFailedException(String format, Object... params) {
     super(String.format(format, params));
   }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValue.java
@@ -142,6 +142,10 @@ public class ScoreValue implements Value<Double>, Confidence {
   @Override
   @JsonGetter("value")
   public Double get() {
+    if (isUnknown()) {
+      throw new IllegalStateException(
+          "It's an unknown value, get() method is not supposed to be called!");
+    }
     return value;
   }
 

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/UnknownValue.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/UnknownValue.java
@@ -15,7 +15,7 @@ public final class UnknownValue<T> implements Value<T> {
   /**
    * A feature.
    */
-  private final Feature feature;
+  private final Feature<T> feature;
 
   /**
    * This factory method returns an unknown values of a specified feature.
@@ -33,14 +33,14 @@ public final class UnknownValue<T> implements Value<T> {
    *
    * @param feature The feature.
    */
-  public UnknownValue(@JsonProperty("feature") Feature feature) {
+  public UnknownValue(@JsonProperty("feature") Feature<T> feature) {
     Objects.requireNonNull(feature, "Feature can't be null!");
     this.feature = feature;
   }
 
   @Override
   @JsonGetter("feature")
-  public final Feature feature() {
+  public final Feature<T> feature() {
     return feature;
   }
 
@@ -58,7 +58,7 @@ public final class UnknownValue<T> implements Value<T> {
 
   @Override
   public final T get() {
-    throw new UnsupportedOperationException(
+    throw new IllegalStateException(
         "It's an unknown value, get() method is not supposed to be called!");
   }
 

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/FindSecBugsScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/FindSecBugsScoreTestVectors.yml
@@ -20,6 +20,7 @@ elements:
       openRight: false
       positiveInfinity: false
     expectedLabel: null
+    expectedUnknownScore: true
     alias: "all_unknown"
 
   - type: "StandardTestVector"

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScoreTestVectors.yml
@@ -20,7 +20,8 @@ elements:
     openRight: false
     positiveInfinity: false
   expectedLabel: null
-  alias: "test_vector_0"
+  expectedUnknownScore: true
+  alias: "all_unknown"
 - type: "StandardTestVector"
   values:
   - type: "UnknownValue"

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreTestVectorTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/ScoreTestVectorTest.java
@@ -28,7 +28,7 @@ public class ScoreTestVectorTest {
 
     Interval expectedScore = DoubleInterval.init().from(4.0).to(6.4).closed().make();
     ScoreTestVector vector = new ScoreTestVector(
-        values, expectedScore, null, "test", false);
+        values, expectedScore, null, "test", false, false);
 
     vector.values();
   }
@@ -41,7 +41,7 @@ public class ScoreTestVectorTest {
 
     Interval expectedScore = DoubleInterval.init().from(4.0).to(6.4).closed().make();
     ScoreTestVector vector = new ScoreTestVector(
-        values, expectedScore, null, "test", false);
+        values, expectedScore, null, "test", false, false);
 
     Set<Value> set = vector.valuesFor(ExampleScores.SECURITY_SCORE_EXAMPLE);
     assertNotNull(set);
@@ -58,7 +58,7 @@ public class ScoreTestVectorTest {
 
     Interval expectedScore = DoubleInterval.init().from(4.0).to(6.4).closed().make();
     ScoreTestVector vector = new ScoreTestVector(
-        values, expectedScore, null, "test", false);
+        values, expectedScore, null, "test", false, false);
 
     YAMLFactory factory = new YAMLFactory();
     factory.disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID);

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/StandardTestVectorTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/qa/StandardTestVectorTest.java
@@ -30,6 +30,8 @@ public class StandardTestVectorTest {
 
   private static final boolean NOT_APPLICABLE = true;
 
+  private static final boolean IS_KNOWN = false;
+
   @Test
   public void smoke() {
     Set<Value> values = new HashSet<>();
@@ -76,7 +78,7 @@ public class StandardTestVectorTest {
     Set<Value> values = new HashSet<>();
     values.add(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 1));
     new StandardTestVector(
-        values, NO_EXPECTED_SCORE, SecurityLabelExample.OKAY, "test", NOT_APPLICABLE);
+        values, NO_EXPECTED_SCORE, SecurityLabelExample.OKAY, "test", IS_KNOWN, NOT_APPLICABLE);
   }
 
   @Test
@@ -203,7 +205,7 @@ public class StandardTestVectorTest {
     Set<Value> values = new HashSet<>();
     values.add(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 1));
     StandardTestVector vector = new StandardTestVector(
-        values, null, SecurityLabelExample.OKAY, "test", true);
+        values, null, SecurityLabelExample.OKAY, "test", false, true);
 
     ObjectMapper mapper = new ObjectMapper();
     byte[] bytes = mapper.writeValueAsBytes(vector);

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/FindSecBugsScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/FindSecBugsScoreTest.java
@@ -3,12 +3,14 @@ package com.sap.sgs.phosphor.fosstars.model.score.oss;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_FIND_SEC_BUGS;
 import static com.sap.sgs.phosphor.fosstars.model.qa.TestVectorBuilder.newTestVector;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVA;
 import static org.junit.Assert.assertTrue;
 
 import com.sap.sgs.phosphor.fosstars.model.Score;
 import com.sap.sgs.phosphor.fosstars.model.qa.TestVectors;
 import com.sap.sgs.phosphor.fosstars.model.qa.VerificationFailedException;
 import com.sap.sgs.phosphor.fosstars.model.score.oss.FindSecBugsScore.Verification;
+import com.sap.sgs.phosphor.fosstars.model.value.Languages;
 import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -38,10 +40,10 @@ public class FindSecBugsScoreTest {
   public void testVerification() throws VerificationFailedException, IOException {
     TestVectors vectors = new TestVectors(
         newTestVector()
-            .alias("1")
+            .alias("test")
             .expectedScore(Score.INTERVAL)
-            .set(USES_FIND_SEC_BUGS.unknown())
-            .set(LANGUAGES.unknown())
+            .set(USES_FIND_SEC_BUGS.value(true))
+            .set(LANGUAGES.value(Languages.of(JAVA)))
             .make()
     );
 

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/StaticAnalysisScoreTest.java
@@ -54,7 +54,6 @@ public class StaticAnalysisScoreTest {
 
     assertTrue(scoreValue.isUnknown());
     assertFalse(scoreValue.isNotApplicable());
-    assertEquals(MIN, scoreValue.get(), DELTA);
     assertEquals(Confidence.MIN, scoreValue.confidence(), DELTA);
     assertSame(score, scoreValue.score());
     assertEquals(2, scoreValue.usedValues().size());

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValueTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/ScoreValueTest.java
@@ -198,4 +198,9 @@ public class ScoreValueTest {
     assertEquals(3.0, notApplicable.orElse(3.0), ACCURACY);
   }
 
+  @Test(expected = IllegalStateException.class)
+  public void testGetWithUnknownValue() {
+    new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE).makeUnknown().get();
+  }
+
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/UnknownValueTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/UnknownValueTest.java
@@ -13,7 +13,7 @@ public class UnknownValueTest {
 
   @Test
   public void testGetFeature() {
-    Value value = new UnknownValue(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
+    Value<Integer> value = new UnknownValue<>(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
     assertEquals(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, value.feature());
   }
 
@@ -22,7 +22,7 @@ public class UnknownValueTest {
     assertTrue(new UnknownValue<>(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).isUnknown());
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test(expected = IllegalStateException.class)
   public void testGet() {
     new UnknownValue<>(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).get();
   }
@@ -30,8 +30,8 @@ public class UnknownValueTest {
   @Test
   public void testSerializationAndDeserialization() throws IOException {
     ObjectMapper mapper = new ObjectMapper();
-    UnknownValue value = UnknownValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
-    UnknownValue clone = mapper.readValue(
+    UnknownValue<Integer> value = UnknownValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
+    UnknownValue<Integer> clone = mapper.readValue(
         mapper.writeValueAsBytes(value), UnknownValue.class);
     assertEquals(value, clone);
     assertEquals(value.hashCode(), clone.hashCode());


### PR DESCRIPTION
Here is a list of updates:

- Updated `WeightedCompositeScore` to check if all sub-scores are unknown and return an unknown score value if so.
- Test vectors now supports unknown scores.
- Minor improvements.
- Updated tests and test vectors.

Fixes #356