### PR TITLE
Updated CodeQL and LGTM scores to take languages into account

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/CodeqlScore.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/score/oss/CodeqlScore.java
@@ -1,14 +1,24 @@
 package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.RUNS_CODEQL_SCANS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_CODEQL_CHECKS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM_CHECKS;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.findValue;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.C;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.CPP;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.C_SHARP;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.GO;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVA;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVASCRIPT;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.PYTHON;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.TYPESCRIPT;
 
 import com.sap.sgs.phosphor.fosstars.model.Value;
 import com.sap.sgs.phosphor.fosstars.model.qa.ScoreVerification;
 import com.sap.sgs.phosphor.fosstars.model.qa.TestVectors;
 import com.sap.sgs.phosphor.fosstars.model.score.FeatureBasedScore;
+import com.sap.sgs.phosphor.fosstars.model.value.Languages;
 import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,9 +30,18 @@ import java.io.InputStream;
  *  <li>{@link com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#USES_LGTM_CHECKS}</li>
  *  <li>{@link com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#USES_CODEQL_CHECKS}</li>
  *  <li>{@link com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#RUNS_CODEQL_SCANS}</li>
+ *  <li>{@link com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures#LANGUAGES}</li>
  * </ul>
  */
 public class CodeqlScore extends FeatureBasedScore {
+
+  /**
+   * Programming languages supported by CodeQL.
+   *
+   * @see <a href="https://help.semmle.com/QL/ql-support/language-support.html">CodeQL - Languages and compilers</a>
+   */
+  private static final Languages SUPPORTED_LANGUAGES = Languages.of(
+      C, CPP, JAVA, C_SHARP, PYTHON, GO, JAVASCRIPT, TYPESCRIPT);
 
   /**
    * Defines how the score value is increased if a project runs CodeQL scans.
@@ -38,7 +57,8 @@ public class CodeqlScore extends FeatureBasedScore {
    * Initializes a new {@link CodeqlScore}.
    */
   CodeqlScore() {
-    super("How a project uses CodeQL", USES_LGTM_CHECKS, USES_CODEQL_CHECKS, RUNS_CODEQL_SCANS);
+    super("How a project uses CodeQL",
+        USES_LGTM_CHECKS, USES_CODEQL_CHECKS, RUNS_CODEQL_SCANS, LANGUAGES);
   }
 
   @Override
@@ -49,13 +69,20 @@ public class CodeqlScore extends FeatureBasedScore {
         "Hey! You have to tell me if the project uses CodeQL checks!");
     Value<Boolean> runsCodeqlScans = findValue(values, RUNS_CODEQL_SCANS,
         "Hey! You have to tell me if the project runs CodeQL scans!");
+    Value<Languages> languages = findValue(values, LANGUAGES,
+        "Hey! You have to tell me which languages the project uses!");
 
-    // TODO: The score should check languages that CodeQL supports
+    ScoreValue scoreValue = scoreValue(MIN,
+        usesLgtmChecks, usesCodeqlChecks, runsCodeqlScans, languages);
 
-    ScoreValue scoreValue = scoreValue(MIN, usesLgtmChecks, usesCodeqlChecks, runsCodeqlScans);
+    if (allUnknown(usesLgtmChecks, usesCodeqlChecks, runsCodeqlScans, languages)) {
+      return scoreValue.makeUnknown().explain(
+          "The score value is unknown because all required features are unknown.");
+    }
 
-    if (allUnknown(usesLgtmChecks, usesCodeqlChecks, runsCodeqlScans)) {
-      return scoreValue.makeUnknown();
+    if (!languages.isUnknown() && !SUPPORTED_LANGUAGES.containsAnyOf(languages.get())) {
+      return scoreValue.makeNotApplicable().explain(
+          "The score is N/A because the project uses languages that are not supported by CodeQL.");
     }
 
     if (usesLgtmChecks.orElse(false) || usesCodeqlChecks.orElse(false)) {

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Language.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Language.java
@@ -15,7 +15,7 @@ public enum Language {
   // .NET languages
   C_SHARP, F_SHARP, VISUALBASIC,
 
-  PHP, RUBY, PYTHON, JAVASCRIPT,
+  PHP, RUBY, PYTHON, JAVASCRIPT, TYPESCRIPT, GO,
 
   OTHER;
 
@@ -40,6 +40,9 @@ public enum Language {
         return C_SHARP;
       case "F#":
         return F_SHARP;
+      case "go":
+      case "golang":
+        return GO;
       default:
         return OTHER;
     }

--- a/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Language.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/model/value/Language.java
@@ -28,6 +28,12 @@ public enum Language {
    */
   public static Language parse(String string) {
     Objects.requireNonNull(string, "String can't be null!");
+
+    string = string.trim();
+    if (string.isEmpty()) {
+      throw new IllegalArgumentException("String can't be empty!");
+    }
+
     for (Language language : values()) {
       if (string.equalsIgnoreCase(language.name())) {
         return language;
@@ -40,8 +46,8 @@ public enum Language {
         return C_SHARP;
       case "F#":
         return F_SHARP;
-      case "go":
-      case "golang":
+      case "GO":
+      case "GOLANG":
         return GO;
       default:
         return OTHER;

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/CodeqlScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/CodeqlScoreTestVectors.yml
@@ -1,5 +1,12 @@
 ---
-defaults: []
+defaults:
+- type: "LanguagesValue"
+  feature:
+    type: "LanguagesFeature"
+    name: "A set of programming languages"
+  languages:
+    elements:
+      - "JAVA"
 elements:
 - type: "StandardTestVector"
   values:
@@ -15,6 +22,10 @@ elements:
     feature:
       type: "BooleanFeature"
       name: "If a project runs CodeQL scans"
+  - type: "UnknownValue"
+    feature:
+      type: "LanguagesFeature"
+      name: "A set of programming languages"
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -160,4 +171,39 @@ elements:
     openRight: false
     positiveInfinity: false
   expectedLabel: null
+  alias: "test_vector_5"
+- type: "StandardTestVector"
+  values:
+    - type: "BooleanValue"
+      feature:
+        type: "BooleanFeature"
+        name: "If a project uses LGTM checks for commits"
+      flag: false
+    - type: "BooleanValue"
+      feature:
+        type: "BooleanFeature"
+        name: "If a project runs CodeQL checks for commits"
+      flag: false
+    - type: "BooleanValue"
+      feature:
+        type: "BooleanFeature"
+        name: "If a project runs CodeQL scans"
+      flag: false
+    - type: "LanguagesValue"
+      feature:
+        type: "LanguagesFeature"
+        name: "A set of programming languages"
+      languages:
+        elements:
+          - "OTHER"
+  expectedScore:
+    type: "DoubleInterval"
+    from: 9.0
+    openLeft: false
+    negativeInfinity: false
+    to: 10.0
+    openRight: false
+    positiveInfinity: false
+  expectedLabel: null
+  expectedNotApplicableScore: true
   alias: "test_vector_5"

--- a/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScoreTestVectors.yml
+++ b/src/main/resources/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScoreTestVectors.yml
@@ -1,5 +1,12 @@
 ---
-defaults: []
+defaults:
+- type: "LanguagesValue"
+  feature:
+    type: "LanguagesFeature"
+    name: "A set of programming languages"
+  languages:
+    elements:
+      - "JAVA"
 elements:
 - type: "StandardTestVector"
   values:
@@ -7,6 +14,10 @@ elements:
     feature:
       type: "LgtmGradeFeature"
       name: "The worst LGTM grade of a project"
+  - type: "UnknownValue"
+    feature:
+      type: "LanguagesFeature"
+      name: "A set of programming languages"
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -120,3 +131,27 @@ elements:
     positiveInfinity: false
   expectedLabel: null
   alias: "test_vector_6"
+- type: "StandardTestVector"
+  values:
+    - type: "UnknownValue"
+      feature:
+        type: "LgtmGradeFeature"
+        name: "The worst LGTM grade of a project"
+    - type: "LanguagesValue"
+      feature:
+        type: "LanguagesFeature"
+        name: "A set of programming languages"
+      languages:
+        elements:
+          - "OTHER"
+  expectedScore:
+    type: "DoubleInterval"
+    from: 0.0
+    openLeft: false
+    negativeInfinity: false
+    to: 10.0
+    openRight: false
+    positiveInfinity: false
+  expectedLabel: null
+  expectedNotApplicableScore: true
+  alias: "test_vector_7"

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/CodeqlScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/CodeqlScoreTest.java
@@ -1,15 +1,18 @@
 package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
 import static com.sap.sgs.phosphor.fosstars.TestUtils.assertScore;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.RUNS_CODEQL_SCANS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_CODEQL_CHECKS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM_CHECKS;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.value.Languages;
 import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import org.junit.Test;
 
@@ -19,10 +22,11 @@ public class CodeqlScoreTest {
   public void smokeTest() {
     CodeqlScore score = new CodeqlScore();
     assertFalse(score.name().isEmpty());
-    assertEquals(3, score.features().size());
+    assertEquals(4, score.features().size());
     assertTrue(score.features().contains(USES_LGTM_CHECKS));
     assertTrue(score.features().contains(USES_CODEQL_CHECKS));
     assertTrue(score.features().contains(RUNS_CODEQL_SCANS));
+    assertTrue(score.features().contains(LANGUAGES));
     assertTrue(score.subScores().isEmpty());
   }
 
@@ -30,7 +34,10 @@ public class CodeqlScoreTest {
   public void testCalculate() {
     CodeqlScore score = new CodeqlScore();
     ScoreValue scoreValue = score.calculate(
-        USES_CODEQL_CHECKS.unknown(), USES_LGTM_CHECKS.unknown(), RUNS_CODEQL_SCANS.unknown());
+        USES_CODEQL_CHECKS.unknown(),
+        USES_LGTM_CHECKS.unknown(),
+        RUNS_CODEQL_SCANS.unknown(),
+        LANGUAGES.unknown());
     assertTrue(scoreValue.isUnknown());
 
     assertScore(
@@ -39,21 +46,25 @@ public class CodeqlScoreTest {
         setOf(
             USES_CODEQL_CHECKS.value(true),
             USES_LGTM_CHECKS.value(true),
-            RUNS_CODEQL_SCANS.value(true)));
+            RUNS_CODEQL_SCANS.value(true),
+            LANGUAGES.value(Languages.of(JAVA))));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testCalculateWithoutUsesLgtmChecksValue() {
-    new CodeqlScore().calculate(USES_CODEQL_CHECKS.unknown(), RUNS_CODEQL_SCANS.unknown());
+    new CodeqlScore().calculate(
+        USES_CODEQL_CHECKS.unknown(), RUNS_CODEQL_SCANS.unknown(), LANGUAGES.unknown());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testCalculateWithoutUsesCodeqlChecksValue() {
-    new CodeqlScore().calculate(USES_LGTM_CHECKS.unknown(), RUNS_CODEQL_SCANS.unknown());
+    new CodeqlScore().calculate(
+        USES_LGTM_CHECKS.unknown(), RUNS_CODEQL_SCANS.unknown(), LANGUAGES.unknown());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testCalculateWithoutRunsCodeqlChecksValue() {
-    new CodeqlScore().calculate(USES_CODEQL_CHECKS.unknown(), USES_LGTM_CHECKS.unknown());
+    new CodeqlScore().calculate(
+        USES_CODEQL_CHECKS.unknown(), USES_LGTM_CHECKS.unknown(), LANGUAGES.unknown());
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScoreTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/score/oss/LgtmScoreTest.java
@@ -1,14 +1,17 @@
 package com.sap.sgs.phosphor.fosstars.model.score.oss;
 
 import static com.sap.sgs.phosphor.fosstars.TestUtils.assertScore;
+import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM_CHECKS;
 import static com.sap.sgs.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_LGTM_GRADE;
 import static com.sap.sgs.phosphor.fosstars.model.other.Utils.setOf;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.sap.sgs.phosphor.fosstars.model.Score;
+import com.sap.sgs.phosphor.fosstars.model.value.Languages;
 import com.sap.sgs.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.sgs.phosphor.fosstars.model.value.ScoreValue;
 import org.junit.Test;
@@ -19,21 +22,23 @@ public class LgtmScoreTest {
   public void smokeTest() {
     LgtmScore score = new LgtmScore();
     assertFalse(score.name().isEmpty());
-    assertEquals(1, score.features().size());
+    assertEquals(2, score.features().size());
     assertTrue(score.features().contains(WORST_LGTM_GRADE));
+    assertTrue(score.features().contains(LANGUAGES));
     assertTrue(score.subScores().isEmpty());
   }
 
   @Test
   public void testCalculate() {
     LgtmScore score = new LgtmScore();
-    ScoreValue scoreValue = score.calculate(WORST_LGTM_GRADE.unknown());
+    ScoreValue scoreValue = score.calculate(WORST_LGTM_GRADE.unknown(), LANGUAGES.unknown());
     assertTrue(scoreValue.isUnknown());
-    assertScore(Score.INTERVAL, score, setOf(WORST_LGTM_GRADE.value(LgtmGrade.A_PLUS)));
+    assertScore(Score.INTERVAL, score,
+        setOf(WORST_LGTM_GRADE.value(LgtmGrade.A_PLUS), LANGUAGES.value(Languages.of(JAVA))));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testCalculateWithoutUsesWorseLgtmGradeValue() {
-    new LgtmScore().calculate(USES_LGTM_CHECKS.unknown());
+    new LgtmScore().calculate(LANGUAGES.unknown());
   }
 }

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/LanguageTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/model/value/LanguageTest.java
@@ -1,0 +1,32 @@
+package com.sap.sgs.phosphor.fosstars.model.value;
+
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.C;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.CPP;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.C_SHARP;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.F_SHARP;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.GO;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVA;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.JAVASCRIPT;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.TYPESCRIPT;
+import static com.sap.sgs.phosphor.fosstars.model.value.Language.VISUALBASIC;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class LanguageTest {
+
+  @Test
+  public void testParse() {
+    assertEquals(GO, Language.parse("Go"));
+    assertEquals(GO, Language.parse("Golang"));
+    assertEquals(JAVA, Language.parse("Java"));
+    assertEquals(C_SHARP, Language.parse("C#"));
+    assertEquals(F_SHARP, Language.parse("F#"));
+    assertEquals(JAVASCRIPT, Language.parse("JavaScript"));
+    assertEquals(TYPESCRIPT, Language.parse("TypeScript"));
+    assertEquals(VISUALBASIC, Language.parse("VisualBasic"));
+    assertEquals(CPP, Language.parse("C++"));
+    assertEquals(C, Language.parse("C"));
+  }
+
+}


### PR DESCRIPTION
Here is a list of updates:

- Updated `CodeqlScore` and `LgtmScore` to take into account programming languages that are used in a project.
- Updated tests and test vectors.

Fixes #361 