### PR TITLE
CodeqlDataProvider should check if .github/workflows exists

### DIFF
--- a/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/LocalRepository.java
+++ b/src/main/java/com/sap/sgs/phosphor/fosstars/data/github/LocalRepository.java
@@ -200,6 +200,16 @@ public class LocalRepository implements AutoCloseable {
   }
 
   /**
+   * Checks if the repository has a specified directory.
+   *
+   * @param path A path to the directory.
+   * @return Ture if the repository contains the specified directory, false otherwise.
+   */
+  public boolean hasDirectory(Path path) {
+    return Files.isDirectory(info.path().resolve(path));
+  }
+
+  /**
    * Returns a stream of a file if it exists.
    *
    * @param file The file name.

--- a/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/CodeqlDataProviderTest.java
+++ b/src/test/java/com/sap/sgs/phosphor/fosstars/data/github/CodeqlDataProviderTest.java
@@ -18,6 +18,7 @@ import com.sap.sgs.phosphor.fosstars.model.ValueSet;
 import com.sap.sgs.phosphor.fosstars.tool.github.GitHubProject;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Optional;
@@ -83,11 +84,13 @@ public class CodeqlDataProviderTest extends TestGitHubDataFetcherHolder {
   }
 
   private static void mockFile(String filename, String content) throws IOException {
+    Path path = Paths.get(filename);
     LocalRepository repository = mock(LocalRepository.class);
     when(repository.file(filename)).thenReturn(Optional.of(content));
-    when(repository.read(Paths.get(filename)))
+    when(repository.read(path))
         .thenReturn(Optional.of(IOUtils.toInputStream(content)));
     when(repository.files(any(), any())).thenReturn(Collections.singletonList(Paths.get(filename)));
+    when(repository.hasDirectory(path.getParent())).thenReturn(true);
     addForTesting(PROJECT, repository);
   }
 


### PR DESCRIPTION
Here is a list of updates:

- Updated `CodeqlDataProvider` to check if `.github/workflows` directory exists before attempting to browse it.
- Added a new `LocalRepository.hasDirectory(Path)` method.

Fixes #370