### PR TITLE
Set default locale to en/US for tests

### DIFF
--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinterTest.java
@@ -56,7 +56,9 @@ import com.sap.oss.phosphor.fosstars.model.value.RatingValue;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Set;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class PrettyPrinterTest {
@@ -99,6 +101,11 @@ public class PrettyPrinterTest {
       OWASP_DEPENDENCY_CHECK_USAGE.value(NOT_USED),
       OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.notSpecifiedValue(),
       PACKAGE_MANAGERS.value(new PackageManagers(MAVEN)));
+
+  @BeforeClass
+  public static void setup() {
+    Locale.setDefault(new Locale("en", "US"));
+  }
 
   @Test
   public void testPrint() {

--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinterTest.java
@@ -58,6 +58,7 @@ import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Set;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -102,8 +103,11 @@ public class PrettyPrinterTest {
       OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.notSpecifiedValue(),
       PACKAGE_MANAGERS.value(new PackageManagers(MAVEN)));
 
+  private static Locale savedLocale;
+
   @BeforeClass
   public static void setup() {
+    savedLocale = Locale.getDefault();
     Locale.setDefault(new Locale("en", "US"));
   }
 
@@ -166,4 +170,10 @@ public class PrettyPrinterTest {
     assertEquals("9.0  out of 10.0",
         PrettyPrinter.printValueAndMax(9.0, 10.0));
   }
+
+  @AfterClass
+  public static void cleanup() {
+    Locale.setDefault(savedLocale);
+  }
+
 }


### PR DESCRIPTION
Set default locale to en/US for tests as the test fails on a machine with another (not en) locale.

Currently the locale is only set but not reset after the test.
As from my understanding resetting is not required.
But please let me know if it is required to set it back to previous locale for some reason.

Closes #407