### PR TITLE
Added a holder for ObjectMapper

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -29,7 +29,7 @@
     lines="48"/>
   <suppress checks="AbbreviationAsWordInName"
     files="NVD.java"
-    lines="32"/>
+    lines="31"/>
   <suppress checks="AbbreviationAsWordInName"
     files="BaseMetricV2.java"
     lines="52"/>

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/StandardValueCache.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/StandardValueCache.java
@@ -3,12 +3,12 @@ package com.sap.oss.phosphor.fosstars.data;
 import static com.sap.oss.phosphor.fosstars.model.value.ExpiringValue.NO_EXPIRATION;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Feature;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.ValueSet;
 import com.sap.oss.phosphor.fosstars.model.value.ExpiringValue;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -25,11 +25,6 @@ import java.util.Optional;
  * This is a cache of feature values which use string as keys.
  */
 public class StandardValueCache implements Cache<String, ValueSet> {
-
-  /**
-   * An ObjectMapper for serialization and deserialization.
-   */
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * A map of cache entries.
@@ -66,7 +61,7 @@ public class StandardValueCache implements Cache<String, ValueSet> {
    *
    * @param key The key
    * @param feature The feature.
-   * @param <T> Type of data.
+   * @param <T> Type of data that the feature holds.
    * @return An {@link Optional} with a cached value if it's available.
    */
   public <T> Optional<Value<T>> get(String key, Feature<T> feature) {
@@ -101,6 +96,7 @@ public class StandardValueCache implements Cache<String, ValueSet> {
    * The method extracts an original value from a ExpiringValue if it's not expired.
    *
    * @param value The ExpiringValue.
+   * @param <T> Type of data that the value holds.
    * @return The original value if it's not expired.
    * @throws IllegalStateException If the value is not an instance of ExpiringValue.
    */
@@ -150,8 +146,8 @@ public class StandardValueCache implements Cache<String, ValueSet> {
    *
    * @param key The key.
    * @param value The value to store in the cache.
+   * @param <T> Type of data that the value holds
    * @param expiration The expiration date.
-   * @param <T> A type of the value.
    */
   public <T> void put(String key, Value<T> value, Date expiration) {
     ValueSet set = entries.get(key);
@@ -175,7 +171,7 @@ public class StandardValueCache implements Cache<String, ValueSet> {
     if (!Files.exists(dir)) {
       Files.createDirectories(dir);
     }
-    Files.write(path, MAPPER.writerWithDefaultPrettyPrinter().writeValueAsBytes(this));
+    Files.write(path, Json.toBytes(this));
   }
 
   /**
@@ -190,7 +186,7 @@ public class StandardValueCache implements Cache<String, ValueSet> {
     if (!file.exists()) {
       throw new FileNotFoundException(String.format("Can't find %s", path));
     }
-    return MAPPER.readValue(file, StandardValueCache.class);
+    return Json.mapper().readValue(file, StandardValueCache.class);
   }
 
   @Override

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/GitHubDataFetcher.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/GitHubDataFetcher.java
@@ -1,8 +1,8 @@
 package com.sap.oss.phosphor.fosstars.data.github;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
@@ -48,11 +48,6 @@ public class GitHubDataFetcher {
    * A logger.
    */
   private static final Logger LOGGER = LogManager.getLogger(GitHubDataFetcher.class);
-
-  /**
-   * An {@link ObjectMapper} for serialization.
-   */
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * A type reference for serializing {@link #LOCAL_REPOSITORIES_INFO}.
@@ -414,7 +409,7 @@ public class GitHubDataFetcher {
       try (InputStream is = Files.newInputStream(LOCAL_REPOSITORIES_INFO_FILE)) {
         LOCAL_REPOSITORIES_INFO.clear();
         LOCAL_REPOSITORIES_INFO.putAll(
-            MAPPER.readValue(is, LOCAL_REPOSITORIES_TYPE_REF));
+            Json.mapper().readValue(is, LOCAL_REPOSITORIES_TYPE_REF));
       }
     }
   }
@@ -428,7 +423,7 @@ public class GitHubDataFetcher {
     synchronized (LOCAL_REPOSITORIES_INFO) {
       Files.write(
           LOCAL_REPOSITORIES_INFO_FILE,
-          MAPPER.writeValueAsBytes(LOCAL_REPOSITORIES_INFO));
+          Json.toBytes(LOCAL_REPOSITORIES_INFO));
     }
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/LgtmDataProvider.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/LgtmDataProvider.java
@@ -5,7 +5,6 @@ import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_
 import static com.sap.oss.phosphor.fosstars.model.other.Utils.setOf;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Feature;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.ValueSet;
@@ -14,6 +13,7 @@ import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.oss.phosphor.fosstars.model.value.UnknownValue;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.util.Set;
 import org.apache.http.HttpHeaders;
@@ -42,11 +42,6 @@ public class LgtmDataProvider extends GitHubCachingDataProvider {
    * The number of latest commits to be checked.
    */
   private static final int COMMITS_TO_BE_CHECKED = 20;
-
-  /**
-   * For parsing JSON.
-   */
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * Initializes a data provider.
@@ -79,7 +74,7 @@ public class LgtmDataProvider extends GitHubCachingDataProvider {
       HttpGet httpGetRequest = new HttpGet(url);
       httpGetRequest.addHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType());
       try (CloseableHttpResponse httpResponse = client.execute(httpGetRequest)) {
-        return MAPPER.readTree(httpResponse.getEntity().getContent());
+        return Json.mapper().readTree(httpResponse.getEntity().getContent());
       }
     }
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/experimental/graphql/GitHubAdvisories.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/experimental/graphql/GitHubAdvisories.java
@@ -1,11 +1,11 @@
 package com.sap.oss.phosphor.fosstars.data.github.experimental.graphql;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.data.github.experimental.graphql.data.Advisory;
 import com.sap.oss.phosphor.fosstars.data.github.experimental.graphql.data.GitHubAdvisoryEntry;
 import com.sap.oss.phosphor.fosstars.data.github.experimental.graphql.data.Identifier;
 import com.sap.oss.phosphor.fosstars.data.github.experimental.graphql.data.Node;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManager;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -50,11 +50,6 @@ public class GitHubAdvisories {
    * First n advisories per page.
    */
   private static final int FIRST_N_ADVISORIES = 100;
-
-  /**
-   * An {@link ObjectMapper} for serialization and deserialization.
-   */
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * The token to access GitHub API.
@@ -139,7 +134,8 @@ public class GitHubAdvisories {
     try (CloseableHttpClient client = httpClient()) {
       HttpPost httpPostRequest = buildRequest(gitHubToken, jsonEntity);
       try (CloseableHttpResponse response = client.execute(httpPostRequest)) {
-        return MAPPER.readValue(response.getEntity().getContent(), GitHubAdvisoryEntry.class);
+        return Json.mapper().readValue(
+            response.getEntity().getContent(), GitHubAdvisoryEntry.class);
       }
     }
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/json/AbstractJsonStorage.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/json/AbstractJsonStorage.java
@@ -1,6 +1,6 @@
 package com.sap.oss.phosphor.fosstars.data.json;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,11 +11,6 @@ import java.net.URL;
  * This is a base class for all storage classes in this package.
  */
 class AbstractJsonStorage {
-
-  /**
-   * An ObjectMapper for serialization and deserialization.
-   */
-  static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * Checks if a URL is valid and uses HTTPS.
@@ -49,7 +44,7 @@ class AbstractJsonStorage {
     T storage;
 
     if (file.exists()) {
-      storage = MAPPER.readValue(file, clazz);
+      storage = Json.mapper().readValue(file, clazz);
     } else {
       storage = loadFromResource(path, clazz);
     }
@@ -74,7 +69,7 @@ class AbstractJsonStorage {
     InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
     if (is != null) {
       try {
-        return MAPPER.readValue(is, clazz);
+        return Json.mapper().readValue(is, clazz);
       } finally {
         is.close();
       }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorage.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/json/UnpatchedVulnerabilitiesStorage.java
@@ -8,6 +8,7 @@ import com.sap.oss.phosphor.fosstars.model.value.CVSS;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerability;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerability.Resolution;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -136,7 +137,7 @@ public class UnpatchedVulnerabilitiesStorage extends AbstractJsonStorage {
    * @throws IOException If something went wrong.
    */
   public void store(String path) throws IOException {
-    Files.write(Paths.get(path), MAPPER.writerWithDefaultPrettyPrinter().writeValueAsBytes(this));
+    Files.write(Paths.get(path), Json.toBytes(this));
   }
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/RatingRepository.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/RatingRepository.java
@@ -1,6 +1,5 @@
 package com.sap.oss.phosphor.fosstars.model;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.other.MakeImmutable;
 import com.sap.oss.phosphor.fosstars.model.rating.example.SecurityRatingExample;
 import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
@@ -8,6 +7,7 @@ import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating.Threshol
 import com.sap.oss.phosphor.fosstars.model.score.oss.OssSecurityScore;
 import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore;
 import com.sap.oss.phosphor.fosstars.model.weight.ScoreWeights;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,11 +44,6 @@ public class RatingRepository {
    * A logger.
    */
   private static final Logger LOGGER = LogManager.getLogger(RatingRepository.class);
-
-  /**
-   * An ObjectMapper for serialization and deserialization ratings to JSON.
-   */
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * Singleton.
@@ -157,7 +152,7 @@ public class RatingRepository {
    * @throws IOException If something went wrong.
    */
   private void store(Rating rating, Path path) throws IOException {
-    Files.write(path, MAPPER.writerWithDefaultPrettyPrinter().writeValueAsBytes(rating));
+    Files.write(path, Json.toBytes(rating));
   }
 
   /**
@@ -179,7 +174,7 @@ public class RatingRepository {
    * @throws IOException If something went wrong.
    */
   private void store(Score score, Path path) throws IOException {
-    Files.write(path, MAPPER.writerWithDefaultPrettyPrinter().writeValueAsBytes(score));
+    Files.write(path, Json.toBytes(score));
   }
 
   /**
@@ -201,13 +196,13 @@ public class RatingRepository {
 
     File file = Paths.get(path.replace('/', File.separatorChar)).toFile();
     if (file.exists()) {
-      return MAPPER.readValue(file, clazz);
+      return Json.mapper().readValue(file, clazz);
     }
 
     InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
     if (is != null) {
       try {
-        return MAPPER.readValue(is, clazz);
+        return Json.mapper().readValue(is, clazz);
       } finally {
         is.close();
       }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/oss/VulnerabilitiesInProject.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/oss/VulnerabilitiesInProject.java
@@ -9,6 +9,7 @@ import com.sap.oss.phosphor.fosstars.model.feature.AbstractFeature;
 import com.sap.oss.phosphor.fosstars.model.value.UnknownValue;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import com.sap.oss.phosphor.fosstars.model.value.VulnerabilitiesValue;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 
 public class VulnerabilitiesInProject extends AbstractFeature<Vulnerabilities> {
@@ -16,7 +17,7 @@ public class VulnerabilitiesInProject extends AbstractFeature<Vulnerabilities> {
   /**
    * For deserialization.
    */
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = Json.newMapper();
 
   static {
     MAPPER.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/oss/VulnerabilitiesInProject.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/oss/VulnerabilitiesInProject.java
@@ -17,7 +17,7 @@ public class VulnerabilitiesInProject extends AbstractFeature<Vulnerabilities> {
   /**
    * For deserialization.
    */
-  private static final ObjectMapper MAPPER = Json.newMapper();
+  private static final ObjectMapper MAPPER = Json.mapper();
 
   static {
     MAPPER.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/TestVectors.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/TestVectors.java
@@ -3,10 +3,8 @@ package com.sap.oss.phosphor.fosstars.model.qa;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.sap.oss.phosphor.fosstars.model.Value;
+import com.sap.oss.phosphor.fosstars.util.Yaml;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -29,23 +27,6 @@ public class TestVectors implements Iterable<TestVector> {
    * No default values.
    */
   private static final Set<Value<?>> NO_DEFAULTS = Collections.emptySet();
-
-  /**
-   * A factory for parsing YAML.
-   */
-  private static final YAMLFactory YAML_FACTORY;
-
-  /**
-   * For serialization and deserialization in YAML.
-   */
-  static final ObjectMapper YAML_OBJECT_MAPPER;
-
-  static {
-    YAML_FACTORY = new YAMLFactory();
-    YAML_FACTORY.disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID);
-    YAML_OBJECT_MAPPER = new ObjectMapper(YAML_FACTORY);
-    YAML_OBJECT_MAPPER.findAndRegisterModules();
-  }
 
   /**
    * A list of test vectors.
@@ -206,7 +187,7 @@ public class TestVectors implements Iterable<TestVector> {
    */
   public static TestVectors loadFromYaml(InputStream is) throws IOException {
     Objects.requireNonNull(is, "Input stream can't be null!");
-    return YAML_OBJECT_MAPPER.readValue(is, TestVectors.class);
+    return Yaml.read(is, TestVectors.class);
   }
 
   /**
@@ -217,7 +198,7 @@ public class TestVectors implements Iterable<TestVector> {
    */
   public void storeToYaml(Path filename) throws IOException {
     Objects.requireNonNull(filename, "Filename can't be null!");
-    Files.write(filename, YAML_OBJECT_MAPPER.writeValueAsBytes(this));
+    Files.write(filename, Yaml.toBytes(this));
   }
 
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/tuning/AbstractTuning.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/tuning/AbstractTuning.java
@@ -1,6 +1,5 @@
 package com.sap.oss.phosphor.fosstars.model.tuning;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Tunable;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.qa.TestVectorResult;
@@ -15,11 +14,6 @@ import org.apache.logging.log4j.Logger;
  * This is a base class for tuning procedures.
  */
 public abstract class AbstractTuning {
-
-  /**
-   * An ObjectMapper for serialization and deserialization ratings to JSON.
-   */
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * A logger.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/weight/ScoreWeights.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/weight/ScoreWeights.java
@@ -4,14 +4,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.sap.oss.phosphor.fosstars.model.Score;
 import com.sap.oss.phosphor.fosstars.model.Tunable;
 import com.sap.oss.phosphor.fosstars.model.Weight;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -27,25 +24,6 @@ import java.util.Set;
  * A collection of weights for scores.
  */
 public class ScoreWeights implements Tunable {
-
-  /**
-   * A factory for parsing YAML.
-   */
-  static final YAMLFactory YAML_FACTORY;
-
-  /**
-   * For serialization and deserialization in YAML.
-   */
-  static final ObjectMapper YAML_OBJECT_MAPPER;
-
-  static {
-    YAML_FACTORY = new YAMLFactory();
-    YAML_FACTORY.disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID);
-    YAML_OBJECT_MAPPER = new ObjectMapper(YAML_FACTORY);
-    YAML_OBJECT_MAPPER.findAndRegisterModules();
-  }
-
-  private static final ObjectMapper JSON_OBJECT_MAPPER = new ObjectMapper();
 
   /**
    * The default weight for sub-scores.
@@ -178,7 +156,7 @@ public class ScoreWeights implements Tunable {
    * This method exists to make Jackson happy.
    */
   @JsonGetter("values")
-  private Map<Class, Weight> values() {
+  private Map<Class<?>, Weight> values() {
     return new HashMap<>(values);
   }
 
@@ -225,25 +203,12 @@ public class ScoreWeights implements Tunable {
   }
 
   /**
-   * Loads weights from YAML.
-   *
-   * @param is An input stream with data.
-   * @return The weights.
-   * @throws IOException If something went wrong.
-   */
-  public static ScoreWeights loadWeightsFromYaml(InputStream is) throws IOException {
-    return YAML_OBJECT_MAPPER.readValue(is, ScoreWeights.class);
-  }
-
-  /**
    * Stores the weights to a JSON file.
    *
    * @param file The file.
    * @throws IOException If something went wrong.
    */
   public void storeToJson(String file) throws IOException {
-    Files.write(
-        Paths.get(file),
-        JSON_OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsBytes(this));
+    Files.write(Paths.get(file), Json.toBytes(this));
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/nvd/NVD.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/nvd/NVD.java
@@ -1,12 +1,11 @@
 package com.sap.oss.phosphor.fosstars.nvd;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.nvd.data.CVE;
 import com.sap.oss.phosphor.fosstars.nvd.data.CveMetaData;
 import com.sap.oss.phosphor.fosstars.nvd.data.NvdEntry;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -55,16 +54,6 @@ public class NVD {
    * The version of NVD feed to be used.
    */
   private static final String NVD_FEED_VERSION = "1.1";
-
-  /**
-   * An {@link ObjectMapper} for serialization and deserialization.
-   */
-  private static final ObjectMapper MAPPER = new ObjectMapper();
-
-  /**
-   * A factory for parsing JSON.
-   */
-  private static final JsonFactory JSON_FACTORY = MAPPER.getFactory();
 
   /**
    * The location where the data from the NVD is stored.
@@ -245,7 +234,7 @@ public class NVD {
    */
   public void parse() throws IOException {
     for (String file : jsonFiles()) {
-      try (JsonParser parser = JSON_FACTORY.createParser(open(file))) {
+      try (JsonParser parser = Json.mapper().getFactory().createParser(open(file))) {
         while (!parser.isClosed()) {
           if (!JsonToken.FIELD_NAME.equals(parser.nextToken())) {
             continue;
@@ -259,7 +248,7 @@ public class NVD {
           throw new IllegalArgumentException("Hmm ... Looks like 'CVE_Items' is not an array!");
         }
 
-        for (NvdEntry entry : MAPPER.readValue(parser, NvdEntry[].class)) {
+        for (NvdEntry entry : Json.mapper().readValue(parser, NvdEntry[].class)) {
 
           // if one of the following null-checks becomes true,
           // that would mean the there is an entry in NVD without a CVE id

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/AbstractReporter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/AbstractReporter.java
@@ -1,10 +1,10 @@
 package com.sap.oss.phosphor.fosstars.tool.github;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.OpenSourceProject;
 import com.sap.oss.phosphor.fosstars.tool.Reporter;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -25,11 +25,6 @@ abstract class AbstractReporter<T extends OpenSourceProject> implements Reporter
    * A logger.
    */
   protected final Logger logger = LogManager.getLogger(getClass());
-
-  /**
-   * For serialization.
-   */
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * A type reference of a list of {@link GitHubProject}s for deserialization.
@@ -83,7 +78,7 @@ abstract class AbstractReporter<T extends OpenSourceProject> implements Reporter
       return Collections.emptyList();
     }
     try (InputStream is = Files.newInputStream(path)) {
-      return MAPPER.readValue(is, LIST_OF_GITHUB_PROJECTS_TYPE);
+      return Json.mapper().readValue(is, LIST_OF_GITHUB_PROJECTS_TYPE);
     }
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/GitHubProjectCache.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/GitHubProjectCache.java
@@ -3,9 +3,9 @@ package com.sap.oss.phosphor.fosstars.tool.github;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.RatingValue;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -21,11 +21,6 @@ import java.util.Optional;
  * This is a cache of {@link GitHubProject}s.
  */
 class GitHubProjectCache {
-
-  /**
-   * For serialization and deserialization.
-   */
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * The default lifetime of a cache entry in days.
@@ -157,7 +152,7 @@ class GitHubProjectCache {
    * @throws IOException If something went wrong.
    */
   static GitHubProjectCache load(InputStream is) throws IOException {
-    return MAPPER.readValue(is, GitHubProjectCache.class);
+    return Json.read(is, GitHubProjectCache.class);
   }
 
   /**
@@ -177,8 +172,6 @@ class GitHubProjectCache {
    * @throws IOException If something went wrong.
    */
   void store(Path filename) throws IOException {
-    Files.write(
-        filename,
-        MAPPER.writerWithDefaultPrettyPrinter().writeValueAsBytes(this));
+    Files.write(filename, Json.toBytes(this));
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/GitHubProjectFinder.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/GitHubProjectFinder.java
@@ -2,10 +2,9 @@ package com.sap.oss.phosphor.fosstars.tool.github;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubOrganization;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.util.Yaml;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -273,11 +272,6 @@ public class GitHubProjectFinder {
   static class ConfigParser {
 
     /**
-     * A factory for parsing YAML.
-     */
-    private static final YAMLFactory YAML_FACTORY = new YAMLFactory();
-
-    /**
      * Parse a configuration stored in a file.
      *
      * @param filename The file name.
@@ -299,8 +293,7 @@ public class GitHubProjectFinder {
      */
     Config parse(InputStream is) throws IOException {
       Objects.requireNonNull(is, "Input stream can't be null!");
-      ObjectMapper mapper = new ObjectMapper(YAML_FACTORY);
-      return mapper.readValue(is, Config.class);
+      return Yaml.read(is, Config.class);
     }
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/MavenScmFinder.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/MavenScmFinder.java
@@ -4,8 +4,8 @@ import static com.sap.oss.phosphor.fosstars.maven.MavenUtils.readModel;
 import static com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject.isOnGitHub;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -22,11 +22,6 @@ import org.apache.maven.model.Scm;
  * The class takes GAV coordinates of an artifact and looks for a URL to its SCM.
  */
 public class MavenScmFinder {
-
-  /**
-   * For parsing JSON.
-   */
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * A template of a request to the Maven Search API.
@@ -200,7 +195,7 @@ public class MavenScmFinder {
         .replace("{ARTIFACT_ID}", artifactId);
     URL url = new URL(urlString);
 
-    JsonNode node = MAPPER.readTree(url);
+    JsonNode node = Json.mapper().readTree(url);
 
     if (!node.has("response")) {
       throw new IOException("Oh no! The response doesn't have a response filed!");

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/MergedJsonReporter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/MergedJsonReporter.java
@@ -1,7 +1,7 @@
 package com.sap.oss.phosphor.fosstars.tool.github;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -13,11 +13,6 @@ import java.util.Objects;
  * This reporter takes a number of projects and merge them in to a JSON file.
  */
 public class MergedJsonReporter extends AbstractReporter<GitHubProject> {
-
-  /**
-   * Serializer and deserializer.
-   */
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * A path to an output file.
@@ -44,8 +39,6 @@ public class MergedJsonReporter extends AbstractReporter<GitHubProject> {
 
     logger.info("Storing info about projects to {}", filename);
     allProjects.sort(Comparator.comparing(project -> project.scm().toString()));
-    Files.write(
-        Paths.get(filename),
-        MAPPER.writerWithDefaultPrettyPrinter().writeValueAsBytes(allProjects));
+    Files.write(Paths.get(filename), Json.toBytes(allProjects));
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/SecurityRatingCalculator.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/SecurityRatingCalculator.java
@@ -544,7 +544,7 @@ public class SecurityRatingCalculator {
    * @throws IOException If something went wrong.
    */
   static Config config(InputStream is) throws IOException {
-    ObjectMapper mapper = Yaml.newMapper();
+    ObjectMapper mapper = Yaml.mapper();
     mapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
     return mapper.readValue(is, Config.class);
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/SecurityRatingCalculator.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/SecurityRatingCalculator.java
@@ -5,7 +5,6 @@ import static com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject.isOn
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.sap.oss.phosphor.fosstars.advice.Advisor;
 import com.sap.oss.phosphor.fosstars.advice.oss.github.OssSecurityGithubAdvisor;
 import com.sap.oss.phosphor.fosstars.data.NoUserCallback;
@@ -21,6 +20,8 @@ import com.sap.oss.phosphor.fosstars.tool.YesNoQuestion.Answer;
 import com.sap.oss.phosphor.fosstars.tool.format.Formatter;
 import com.sap.oss.phosphor.fosstars.tool.format.MarkdownFormatter;
 import com.sap.oss.phosphor.fosstars.tool.format.PrettyPrinter;
+import com.sap.oss.phosphor.fosstars.util.Json;
+import com.sap.oss.phosphor.fosstars.util.Yaml;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -439,11 +440,7 @@ public class SecurityRatingCalculator {
     if (commandLine.hasOption("raw-rating-file")) {
       String file = commandLine.getOptionValue("raw-rating-file");
       LOGGER.info("Storing a raw rating to {}", file);
-      Files.write(
-          Paths.get(file),
-          new ObjectMapper()
-              .writerWithDefaultPrettyPrinter()
-              .writeValueAsBytes(project.ratingValue().get()));
+      Files.write(Paths.get(file), Json.toBytes(project.ratingValue().get()));
     }
   }
 
@@ -547,8 +544,7 @@ public class SecurityRatingCalculator {
    * @throws IOException If something went wrong.
    */
   static Config config(InputStream is) throws IOException {
-    YAMLFactory factory = new YAMLFactory();
-    ObjectMapper mapper = new ObjectMapper(factory);
+    ObjectMapper mapper = Yaml.newMapper();
     mapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
     return mapper.readValue(is, Config.class);
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/util/Deserialization.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/util/Deserialization.java
@@ -1,0 +1,55 @@
+package com.sap.oss.phosphor.fosstars.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator.Builder;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The class holds common functionality for JSON and YAML serialization/deserialization.
+ */
+public abstract class Deserialization {
+
+  /**
+   * A type reference for deserialization to a Map.
+   */
+  static final TypeReference<Map<String,Object>> MAP_TYPE_REFERENCE
+      = new TypeReference<Map<String, Object>>() {};
+
+  /**
+   * A list of types that are allowed for deserialization by default.
+   */
+  private static final List<String> DEFAULT_ALLOWED_SUB_TYPES = Arrays.asList(
+      "com.sap.oss.phosphor.fosstars");
+
+  /**
+   * A list of classes that are allowed for deserialization.
+   */
+  private static final List<String> ALLOWED_SUB_TYPES = new ArrayList<>(DEFAULT_ALLOWED_SUB_TYPES);
+
+  /**
+   * Allows deserialization of a specified packages or classes.
+   *
+   * @param patterns The packages or classes.
+   */
+  public static void allow(String... patterns) {
+    Objects.requireNonNull(patterns, "Oh no! Patterns are null!");
+    ALLOWED_SUB_TYPES.addAll(Arrays.asList(patterns));
+  }
+
+  /**
+   * Creates a validator for deserialization.
+   *
+   * @return A validator for deserialization.
+   */
+  static PolymorphicTypeValidator validator() {
+    Builder builder = BasicPolymorphicTypeValidator.builder();
+    ALLOWED_SUB_TYPES.forEach(builder::allowIfSubType);
+    return builder.build();
+  }
+}

--- a/src/main/java/com/sap/oss/phosphor/fosstars/util/Json.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/util/Json.java
@@ -3,46 +3,36 @@ package com.sap.oss.phosphor.fosstars.util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Objects;
 
 /**
- * This is a helper class that offers methods for serialization and deserialization using YAML.
+ * This is a helper class that offers methods for serialization and deserialization using JSON.
  */
-public class Yaml {
+public class Json {
 
   /**
-   * A factory for parsing YAML.
-   */
-  private static final YAMLFactory YAML_FACTORY;
-
-  /**
-   * For serialization and deserialization in YAML.
+   * For serialization and deserialization in JSON.
    */
   private static final ObjectMapper OBJECT_MAPPER;
 
   /**
    * A type reference for deserialization to a Map.
    */
-  private static final TypeReference<Map<String,Object>> MAP_TYPE_REFERENCE
+  private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE
       = new TypeReference<Map<String, Object>>() {};
 
   static {
-    YAML_FACTORY = new YAMLFactory();
-    YAML_FACTORY.disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID);
-    OBJECT_MAPPER = new ObjectMapper(YAML_FACTORY);
-    OBJECT_MAPPER.findAndRegisterModules();
+    OBJECT_MAPPER = new ObjectMapper();
   }
 
   /**
-   * Reads YAML from an input stream and parses it ot a map.
+   * Reads JSON from an input stream and parses it ot a map.
    *
    * @param is The input stream to process.
-   * @return A map with the parsed YAML.
+   * @return A map with the parsed JSON.
    * @throws IOException If something went wrong.
    */
   public static Map<String, Object> readMap(InputStream is) throws IOException {
@@ -88,20 +78,20 @@ public class Yaml {
   }
 
   /**
-   * Returns a shared {@link ObjectMapper} for YAML.
+   * Returns a shared {@link ObjectMapper} for JSON.
    *
-   * @return A shared {@link ObjectMapper} for YAML.
+   * @return A shared {@link ObjectMapper} for JSON.
    */
   public static ObjectMapper mapper() {
     return OBJECT_MAPPER;
   }
 
   /**
-   * Creates a new {@link ObjectMapper} for YAML.
+   * Creates a new {@link ObjectMapper} for JSON.
    *
-   * @return A new {@link ObjectMapper} for YAML.
+   * @return A new {@link ObjectMapper} for JSON.
    */
   public static ObjectMapper newMapper() {
-    return new ObjectMapper(YAML_FACTORY);
+    return new ObjectMapper();
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/util/Json.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/util/Json.java
@@ -1,43 +1,16 @@
 package com.sap.oss.phosphor.fosstars.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Map;
 import java.util.Objects;
 
 /**
  * This is a helper class that offers methods for serialization and deserialization using JSON.
  */
-public class Json {
-
-  /**
-   * For serialization and deserialization in JSON.
-   */
-  private static final ObjectMapper OBJECT_MAPPER;
-
-  /**
-   * A type reference for deserialization to a Map.
-   */
-  private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE
-      = new TypeReference<Map<String, Object>>() {};
-
-  static {
-    OBJECT_MAPPER = new ObjectMapper();
-  }
-
-  /**
-   * Reads JSON from an input stream and parses it ot a map.
-   *
-   * @param is The input stream to process.
-   * @return A map with the parsed JSON.
-   * @throws IOException If something went wrong.
-   */
-  public static Map<String, Object> readMap(InputStream is) throws IOException {
-    return OBJECT_MAPPER.readValue(is, MAP_TYPE_REFERENCE);
-  }
+public class Json extends Deserialization {
 
   /**
    * Deserializes an instance of a specified type.
@@ -49,7 +22,9 @@ public class Json {
    * @throws IOException If deserialization failed.
    */
   public static <T> T read(InputStream is, Class<T> clazz) throws IOException {
-    return OBJECT_MAPPER.readValue(is, clazz);
+    Objects.requireNonNull(is, "Oh no! Input stream is null!");
+    Objects.requireNonNull(clazz, "Oh no! Class is null!");
+    return mapper().readValue(is, clazz);
   }
 
   /**
@@ -62,7 +37,9 @@ public class Json {
    * @throws IOException If deserialization failed.
    */
   public static <T> T read(byte[] bytes, Class<T> clazz) throws IOException {
-    return OBJECT_MAPPER.readValue(bytes, clazz);
+    Objects.requireNonNull(bytes, "Oh no! Bytes is null!");
+    Objects.requireNonNull(clazz, "Oh no! Class is null!");
+    return mapper().readValue(bytes, clazz);
   }
 
   /**
@@ -74,7 +51,7 @@ public class Json {
    */
   public static byte[] toBytes(Object object) throws JsonProcessingException {
     Objects.requireNonNull(object, "Oh no! Object is null!");
-    return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsBytes(object);
+    return mapper().writerWithDefaultPrettyPrinter().writeValueAsBytes(object);
   }
 
   /**
@@ -83,15 +60,6 @@ public class Json {
    * @return A shared {@link ObjectMapper} for JSON.
    */
   public static ObjectMapper mapper() {
-    return OBJECT_MAPPER;
-  }
-
-  /**
-   * Creates a new {@link ObjectMapper} for JSON.
-   *
-   * @return A new {@link ObjectMapper} for JSON.
-   */
-  public static ObjectMapper newMapper() {
-    return new ObjectMapper();
+    return JsonMapper.builder().polymorphicTypeValidator(validator()).build();
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/util/Yaml.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/util/Yaml.java
@@ -1,8 +1,8 @@
 package com.sap.oss.phosphor.fosstars.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import java.io.IOException;
@@ -13,29 +13,16 @@ import java.util.Objects;
 /**
  * This is a helper class that offers methods for serialization and deserialization using YAML.
  */
-public class Yaml {
+public class Yaml extends Deserialization {
 
   /**
    * A factory for parsing YAML.
    */
   private static final YAMLFactory YAML_FACTORY;
 
-  /**
-   * For serialization and deserialization in YAML.
-   */
-  private static final ObjectMapper OBJECT_MAPPER;
-
-  /**
-   * A type reference for deserialization to a Map.
-   */
-  private static final TypeReference<Map<String,Object>> MAP_TYPE_REFERENCE
-      = new TypeReference<Map<String, Object>>() {};
-
   static {
     YAML_FACTORY = new YAMLFactory();
     YAML_FACTORY.disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID);
-    OBJECT_MAPPER = new ObjectMapper(YAML_FACTORY);
-    OBJECT_MAPPER.findAndRegisterModules();
   }
 
   /**
@@ -46,7 +33,8 @@ public class Yaml {
    * @throws IOException If something went wrong.
    */
   public static Map<String, Object> readMap(InputStream is) throws IOException {
-    return OBJECT_MAPPER.readValue(is, MAP_TYPE_REFERENCE);
+    Objects.requireNonNull(is, "Oh no! Input stream is null!");
+    return mapper().readValue(is, MAP_TYPE_REFERENCE);
   }
 
   /**
@@ -59,7 +47,8 @@ public class Yaml {
    * @throws IOException If deserialization failed.
    */
   public static <T> T read(InputStream is, Class<T> clazz) throws IOException {
-    return OBJECT_MAPPER.readValue(is, clazz);
+    Objects.requireNonNull(is, "Oh no! Input stream is null!");
+    return mapper().readValue(is, clazz);
   }
 
   /**
@@ -72,7 +61,9 @@ public class Yaml {
    * @throws IOException If deserialization failed.
    */
   public static <T> T read(byte[] bytes, Class<T> clazz) throws IOException {
-    return OBJECT_MAPPER.readValue(bytes, clazz);
+    Objects.requireNonNull(bytes, "Oh no! Bytes is null!");
+    Objects.requireNonNull(clazz, "Oh no! Class is null!");
+    return mapper().readValue(bytes, clazz);
   }
 
   /**
@@ -84,7 +75,7 @@ public class Yaml {
    */
   public static byte[] toBytes(Object object) throws JsonProcessingException {
     Objects.requireNonNull(object, "Oh no! Object is null!");
-    return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsBytes(object);
+    return mapper().writerWithDefaultPrettyPrinter().writeValueAsBytes(object);
   }
 
   /**
@@ -93,15 +84,9 @@ public class Yaml {
    * @return A shared {@link ObjectMapper} for YAML.
    */
   public static ObjectMapper mapper() {
-    return OBJECT_MAPPER;
-  }
-
-  /**
-   * Creates a new {@link ObjectMapper} for YAML.
-   *
-   * @return A new {@link ObjectMapper} for YAML.
-   */
-  public static ObjectMapper newMapper() {
-    return new ObjectMapper(YAML_FACTORY);
+    ObjectMapper mapper = JsonMapper.builder(YAML_FACTORY)
+        .polymorphicTypeValidator(validator()).build();
+    mapper.findAndRegisterModules();
+    return mapper;
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/LocalRepositoryInfoTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/LocalRepositoryInfoTest.java
@@ -2,7 +2,7 @@ package com.sap.oss.phosphor.fosstars.data.github;
 
 import static org.junit.Assert.assertEquals;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -13,11 +13,10 @@ public class LocalRepositoryInfoTest {
 
   @Test
   public void testSerialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
     LocalRepositoryInfo info = new LocalRepositoryInfo(
         Paths.get("."), new Date(), new URL("https://scm/org/test"));
-    LocalRepositoryInfo clone = mapper.readValue(
-        mapper.writeValueAsBytes(info), LocalRepositoryInfo.class);
+    LocalRepositoryInfo clone = Json.mapper().readValue(
+        Json.toBytes(info), LocalRepositoryInfo.class);
     assertEquals(info.updated(), clone.updated());
     assertEquals(info.path().toAbsolutePath(), clone.path().toAbsolutePath());
     assertEquals(info.url(), clone.url());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/DoubleFeatureTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/DoubleFeatureTest.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Value;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -14,13 +14,12 @@ public class DoubleFeatureTest {
 
   @Test
   public void serializeAndDeserialize() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
     DoubleFeature feature = new DoubleFeature("test");
-    byte[] bytes = mapper.writeValueAsBytes(feature);
+    byte[] bytes = Json.toBytes(feature);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
 
-    DoubleFeature clone = mapper.readValue(bytes, DoubleFeature.class);
+    DoubleFeature clone = Json.mapper().readValue(bytes, DoubleFeature.class);
     assertNotNull(clone);
     assertEquals(feature, clone);
     assertEquals(feature.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/EnumFeatureTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/EnumFeatureTest.java
@@ -6,8 +6,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.value.EnumValue;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -66,14 +66,12 @@ public class EnumFeatureTest {
 
   @Test
   public void testSerializeAndDeserialize() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
-
     EnumFeature<TestEnum> feature = new EnumFeature<>(TestEnum.class, "feature");
-    byte[] bytes = mapper.writeValueAsBytes(feature);
+    byte[] bytes = Json.toBytes(feature);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
 
-    Object clone = mapper.readValue(bytes, EnumFeature.class);
+    Object clone = Json.read(bytes, EnumFeature.class);
     assertNotNull(clone);
     assertEquals(feature, clone);
     assertEquals(feature.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/LgtmGradeFeatureTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/LgtmGradeFeatureTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -12,14 +12,12 @@ public class LgtmGradeFeatureTest {
 
   @Test
   public void serializeAndDeserialize() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
-
     LgtmGradeFeature feature = new LgtmGradeFeature("feature");
-    byte[] bytes = mapper.writeValueAsBytes(feature);
+    byte[] bytes = Json.toBytes(feature);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
 
-    Object clone = mapper.readValue(bytes, LgtmGradeFeature.class);
+    Object clone = Json.read(bytes, LgtmGradeFeature.class);
     assertNotNull(clone);
     assertEquals(feature, clone);
     assertEquals(feature.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/oss/LanguagesFeatureTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/oss/LanguagesFeatureTest.java
@@ -3,7 +3,7 @@ package com.sap.oss.phosphor.fosstars.model.feature.oss;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -11,10 +11,8 @@ public class LanguagesFeatureTest {
 
   @Test
   public void serializationAndDeserialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
     LanguagesFeature feature = new LanguagesFeature("test");
-    LanguagesFeature clone = mapper.readValue(
-        mapper.writeValueAsBytes(feature), LanguagesFeature.class);
+    LanguagesFeature clone = Json.read(Json.toBytes(feature), LanguagesFeature.class);
     assertEquals(feature, clone);
     assertTrue(feature.equals(clone) && clone.equals(feature));
     assertEquals(feature.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/oss/PackageManagersFeatureTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/oss/PackageManagersFeatureTest.java
@@ -3,18 +3,16 @@ package com.sap.oss.phosphor.fosstars.model.feature.oss;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
 public class PackageManagersFeatureTest {
 
   @Test
-  public void serializationAndDeserialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
+  public void testSerializationAndDeserialization() throws IOException {
     PackageManagersFeature feature = new PackageManagersFeature("test");
-    PackageManagersFeature clone = mapper.readValue(
-        mapper.writeValueAsBytes(feature), PackageManagersFeature.class);
+    PackageManagersFeature clone = Json.read(Json.toBytes(feature), PackageManagersFeature.class);
     assertEquals(feature, clone);
     assertTrue(feature.equals(clone) && clone.equals(feature));
     assertEquals(feature.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/ScoreTestVectorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/ScoreTestVectorTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.sap.oss.phosphor.fosstars.model.Interval;
@@ -12,6 +11,7 @@ import com.sap.oss.phosphor.fosstars.model.Score;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.math.DoubleInterval;
 import com.sap.oss.phosphor.fosstars.model.score.example.ExampleScores;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -62,13 +62,12 @@ public class ScoreTestVectorTest {
 
     YAMLFactory factory = new YAMLFactory();
     factory.disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID);
-    ObjectMapper mapper = new ObjectMapper(factory);
 
-    byte[] bytes = mapper.writeValueAsBytes(vector);
+    byte[] bytes = Json.toBytes(vector);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
 
-    ScoreTestVector clone = mapper.readValue(bytes, ScoreTestVector.class);
+    ScoreTestVector clone = Json.read(bytes, ScoreTestVector.class);
     assertEquals(vector, clone);
     assertEquals(vector.hashCode(), clone.hashCode());
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/StandardTestVectorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/StandardTestVectorTest.java
@@ -9,9 +9,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.sap.oss.phosphor.fosstars.model.Interval;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.feature.example.ExampleFeatures;
@@ -19,6 +16,8 @@ import com.sap.oss.phosphor.fosstars.model.math.DoubleInterval;
 import com.sap.oss.phosphor.fosstars.model.rating.example.SecurityRatingExample.SecurityLabelExample;
 import com.sap.oss.phosphor.fosstars.model.value.BooleanValue;
 import com.sap.oss.phosphor.fosstars.model.value.IntegerValue;
+import com.sap.oss.phosphor.fosstars.util.Json;
+import com.sap.oss.phosphor.fosstars.util.Yaml;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -172,13 +171,10 @@ public class StandardTestVectorTest {
     StandardTestVector vector = new StandardTestVector(
         values, expectedScore, SecurityLabelExample.OKAY, "test");
 
-    YAMLFactory factory = new YAMLFactory();
-    factory.disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID);
-    ObjectMapper mapper = new ObjectMapper(factory);
-    byte[] bytes = mapper.writeValueAsBytes(vector);
+    byte[] bytes = Yaml.toBytes(vector);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
-    StandardTestVector clone = mapper.readValue(bytes, StandardTestVector.class);
+    StandardTestVector clone = Yaml.read(bytes, StandardTestVector.class);
     assertEquals(vector, clone);
     assertEquals(vector.hashCode(), clone.hashCode());
   }
@@ -191,11 +187,10 @@ public class StandardTestVectorTest {
     StandardTestVector vector = new StandardTestVector(
         values, expectedScore, SecurityLabelExample.OKAY, "test");
 
-    ObjectMapper mapper = new ObjectMapper();
-    byte[] bytes = mapper.writeValueAsBytes(vector);
+    byte[] bytes = Json.toBytes(vector);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
-    StandardTestVector clone = mapper.readValue(bytes, StandardTestVector.class);
+    StandardTestVector clone = Json.read(bytes, StandardTestVector.class);
     assertEquals(vector, clone);
     assertEquals(vector.hashCode(), clone.hashCode());
   }
@@ -207,11 +202,10 @@ public class StandardTestVectorTest {
     StandardTestVector vector = new StandardTestVector(
         values, null, SecurityLabelExample.OKAY, "test", false, true);
 
-    ObjectMapper mapper = new ObjectMapper();
-    byte[] bytes = mapper.writeValueAsBytes(vector);
+    byte[] bytes = Json.toBytes(vector);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
-    StandardTestVector clone = mapper.readValue(bytes, StandardTestVector.class);
+    StandardTestVector clone = Json.read(bytes, StandardTestVector.class);
     assertEquals(vector, clone);
     assertEquals(vector.hashCode(), clone.hashCode());
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/TestVectorsTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/TestVectorsTest.java
@@ -5,11 +5,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.feature.example.ExampleFeatures;
 import com.sap.oss.phosphor.fosstars.model.math.DoubleInterval;
 import com.sap.oss.phosphor.fosstars.model.rating.example.SecurityRatingExample.SecurityLabelExample;
 import com.sap.oss.phosphor.fosstars.model.value.IntegerValue;
+import com.sap.oss.phosphor.fosstars.util.Json;
+import com.sap.oss.phosphor.fosstars.util.Yaml;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -70,18 +71,16 @@ public class TestVectorsTest {
 
   @Test
   public void testSerializationJson() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
-    TestVectors clone = mapper.readValue(
-        mapper.writeValueAsBytes(VECTORS), TestVectors.class);
+    TestVectors clone = Json.read(Json.toBytes(VECTORS), TestVectors.class);
     assertTrue(VECTORS.equals(clone) && clone.equals(VECTORS));
     assertEquals(VECTORS.hashCode(), clone.hashCode());
   }
 
   @Test
   public void testSerializationYaml() throws IOException {
-    byte[] bytes = TestVectors.YAML_OBJECT_MAPPER.writeValueAsBytes(VECTORS);
+    byte[] bytes = Yaml.toBytes(VECTORS);
     System.out.println(new String(bytes));
-    TestVectors clone = TestVectors.YAML_OBJECT_MAPPER.readValue(bytes, TestVectors.class);
+    TestVectors clone = Yaml.read(bytes, TestVectors.class);
     assertTrue(VECTORS.equals(clone) && clone.equals(VECTORS));
     assertEquals(VECTORS.hashCode(), clone.hashCode());
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/rating/NotApplicableLabelTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/rating/NotApplicableLabelTest.java
@@ -4,24 +4,24 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
 public class NotApplicableLabelTest {
 
   @Test
-  public void name() {
+  public void testName() {
     assertFalse(new NotApplicableLabel().name().isEmpty());
   }
 
   @Test
-  public void isNotApplicable() {
+  public void testIsNotApplicable() {
     assertTrue(new NotApplicableLabel().isNotApplicable());
   }
 
   @Test
-  public void equalsAndHashCode() {
+  public void testEqualsAndHashCode() {
     NotApplicableLabel one = new NotApplicableLabel();
     NotApplicableLabel two = new NotApplicableLabel();
     assertEquals(one, one);
@@ -30,11 +30,10 @@ public class NotApplicableLabelTest {
   }
 
   @Test
-  public void serializationAndDeserialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
+  public void testSerializationAndDeserialization() throws IOException {
     NotApplicableLabel label = new NotApplicableLabel();
-    NotApplicableLabel clone = mapper.readValue(
-        mapper.writeValueAsBytes(label), NotApplicableLabel.class);
+    NotApplicableLabel clone = Json.read(
+        Json.toBytes(label), NotApplicableLabel.class);
     assertEquals(label, clone);
   }
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/rating/example/SecurityRatingExampleTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/rating/example/SecurityRatingExampleTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Feature;
 import com.sap.oss.phosphor.fosstars.model.Parameter;
 import com.sap.oss.phosphor.fosstars.model.Rating;
@@ -22,6 +21,7 @@ import com.sap.oss.phosphor.fosstars.model.other.MakeImmutable;
 import com.sap.oss.phosphor.fosstars.model.value.BooleanValue;
 import com.sap.oss.phosphor.fosstars.model.value.IntegerValue;
 import com.sap.oss.phosphor.fosstars.model.value.RatingValue;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -31,10 +31,8 @@ public class SecurityRatingExampleTest {
 
   @Test
   public void testSerializeAndDeserialize() throws IOException  {
-    ObjectMapper mapper = new ObjectMapper();
     SecurityRatingExample rating = new SecurityRatingExample();
-    SecurityRatingExample clone = mapper.readValue(
-        mapper.writeValueAsBytes(rating), SecurityRatingExample.class);
+    SecurityRatingExample clone = Json.read(Json.toBytes(rating), SecurityRatingExample.class);
     assertEquals(rating, clone);
   }
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/WeightedCompositeScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/WeightedCompositeScoreTest.java
@@ -11,7 +11,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Confidence;
 import com.sap.oss.phosphor.fosstars.model.Feature;
 import com.sap.oss.phosphor.fosstars.model.Parameter;
@@ -22,6 +21,7 @@ import com.sap.oss.phosphor.fosstars.model.feature.DoubleFeature;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
 import com.sap.oss.phosphor.fosstars.model.weight.MutableWeight;
 import com.sap.oss.phosphor.fosstars.model.weight.ScoreWeights;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
@@ -339,14 +339,12 @@ public class WeightedCompositeScoreTest {
 
   @Test
   public void testSerializationAndDeserialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
     WeightedScoreImpl score = new WeightedScoreImpl(
         setOf(SECURITY_TESTING_SCORE_EXAMPLE, PROJECT_ACTIVITY_SCORE_EXAMPLE),
         ScoreWeights.createFor(SECURITY_TESTING_SCORE_EXAMPLE, PROJECT_ACTIVITY_SCORE_EXAMPLE));
     score.weights().set(SECURITY_TESTING_SCORE_EXAMPLE, new MutableWeight(0.1));
     score.weights().set(PROJECT_ACTIVITY_SCORE_EXAMPLE, new MutableWeight(0.7));
-    WeightedScoreImpl clone = mapper.readValue(
-        mapper.writeValueAsBytes(score), WeightedScoreImpl.class
+    WeightedScoreImpl clone = Json.read(Json.toBytes(score), WeightedScoreImpl.class
     );
     assertEquals(score, clone);
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
@@ -42,7 +42,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Confidence;
 import com.sap.oss.phosphor.fosstars.model.Score;
 import com.sap.oss.phosphor.fosstars.model.Value;
@@ -52,6 +51,7 @@ import com.sap.oss.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.util.Date;
 import java.util.Set;
@@ -62,18 +62,17 @@ public class OssSecurityScoreTest {
   private static final double DELTA = 0.01;
 
   @Test
-  public void serializeAndDeserialize() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
+  public void testSerializeAndDeserialize() throws IOException {
     OssSecurityScore score = new OssSecurityScore();
-    byte[] bytes = mapper.writeValueAsBytes(score);
+    byte[] bytes = Json.toBytes(score);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
-    OssSecurityScore clone = mapper.readValue(bytes, OssSecurityScore.class);
+    OssSecurityScore clone = Json.read(bytes, OssSecurityScore.class);
     assertEquals(score, clone);
   }
 
   @Test
-  public void calculateForAllUnknown() {
+  public void testCalculateForAllUnknown() {
     Score score = new OssSecurityScore();
     ScoreValue scoreValue = score.calculate(Utils.allUnknown(score.allFeatures()));
     assertEquals(Score.MIN, scoreValue.get(), 0.01);
@@ -82,7 +81,7 @@ public class OssSecurityScoreTest {
   }
 
   @Test
-  public void calculate() {
+  public void testCalculate() {
     Score score = new OssSecurityScore();
     Set<Value<?>> values = setOf(
         SUPPORTED_BY_COMPANY.value(false),
@@ -126,7 +125,7 @@ public class OssSecurityScoreTest {
 
   private static void checkUsedValues(ScoreValue scoreValue) {
     assertEquals(scoreValue.score().subScores().size(), scoreValue.usedValues().size());
-    for (Value value : scoreValue.usedValues()) {
+    for (Value<?> value : scoreValue.usedValues()) {
       boolean found = false;
       for (Score subScore : scoreValue.score().subScores()) {
         if (value.feature().getClass() == subScore.getClass()) {

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/StaticAnalysisScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/StaticAnalysisScoreTest.java
@@ -14,11 +14,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Confidence;
 import com.sap.oss.phosphor.fosstars.model.Score;
 import com.sap.oss.phosphor.fosstars.model.value.Languages;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -157,10 +157,8 @@ public class StaticAnalysisScoreTest {
 
   @Test
   public void testSerialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
     StaticAnalysisScore score = new StaticAnalysisScore();
-    StaticAnalysisScore clone = mapper.readValue(
-        mapper.writeValueAsBytes(score), StaticAnalysisScore.class);
+    StaticAnalysisScore clone = Json.read(Json.toBytes(score), StaticAnalysisScore.class);
     assertEquals(score, clone);
   }
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/subject/oss/GitHubOrganizationTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/subject/oss/GitHubOrganizationTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -25,11 +25,10 @@ public class GitHubOrganizationTest {
   @Test
   public void testSerialization() throws IOException {
     GitHubOrganization org = new GitHubOrganization("test");
-    ObjectMapper mapper = new ObjectMapper();
-    byte[] bytes = mapper.writeValueAsBytes(org);
+    byte[] bytes = Json.toBytes(org);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
-    GitHubOrganization clone = mapper.readValue(bytes, GitHubOrganization.class);
+    GitHubOrganization clone = Json.read(bytes, GitHubOrganization.class);
     assertNotNull(clone);
     assertEquals(org, clone);
     assertEquals(org.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/subject/oss/GitHubProjectTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/subject/oss/GitHubProjectTest.java
@@ -5,11 +5,11 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.rating.example.SecurityRatingExample.SecurityLabelExample;
 import com.sap.oss.phosphor.fosstars.model.score.example.ExampleScores;
 import com.sap.oss.phosphor.fosstars.model.value.RatingValue;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -23,11 +23,10 @@ public class GitHubProjectTest {
         new RatingValue(
             new ScoreValue(ExampleScores.SECURITY_SCORE_EXAMPLE),
             SecurityLabelExample.OKAY));
-    ObjectMapper mapper = new ObjectMapper();
-    byte[] bytes = mapper.writeValueAsBytes(project);
+    byte[] bytes = Json.toBytes(project);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
-    GitHubProject clone = mapper.readValue(bytes, GitHubProject.class);
+    GitHubProject clone = Json.read(bytes, GitHubProject.class);
     assertNotNull(clone);
     assertEquals(project, clone);
     assertEquals(project.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/BooleanValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/BooleanValueTest.java
@@ -4,22 +4,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.feature.BooleanFeature;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
 public class BooleanValueTest {
 
   @Test
-  public void serialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
+  public void testSerialization() throws IOException {
     BooleanValue booleanValue = new BooleanValue(new BooleanFeature("test"), true);
-    byte[] bytes = mapper.writeValueAsBytes(booleanValue);
+    byte[] bytes = Json.toBytes(booleanValue);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
 
-    BooleanValue clone = mapper.readValue(bytes, BooleanValue.class);
+    BooleanValue clone = Json.read(bytes, BooleanValue.class);
     assertNotNull(clone);
     assertEquals(booleanValue, clone);
     assertEquals(booleanValue.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/DateValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/DateValueTest.java
@@ -6,10 +6,10 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.feature.DateFeature;
 import com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.util.Date;
 import org.junit.Test;
@@ -17,7 +17,7 @@ import org.junit.Test;
 public class DateValueTest {
 
   @Test
-  public void get() {
+  public void testGet() {
     Value<Date> one = new DateValue(OssFeatures.PROJECT_START_DATE, new Date(1));
     assertFalse(one.isUnknown());
     assertNotNull(one.get());
@@ -26,7 +26,7 @@ public class DateValueTest {
   }
 
   @Test
-  public void equals() {
+  public void testEquals() {
     final Value<Date> one = new DateValue(OssFeatures.PROJECT_START_DATE, new Date(1));
     final Value<Date> two = new DateValue(OssFeatures.PROJECT_START_DATE, new Date(1));
     final Value<Date> three = new DateValue(OssFeatures.PROJECT_START_DATE, new Date(2));
@@ -49,14 +49,13 @@ public class DateValueTest {
   }
 
   @Test
-  public void serialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
+  public void testSerialization() throws IOException {
     DateValue dateValue = new DateValue(new DateFeature("test"), new Date());
-    byte[] bytes = mapper.writeValueAsBytes(dateValue);
+    byte[] bytes = Json.toBytes(dateValue);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
 
-    DateValue clone = mapper.readValue(bytes, DateValue.class);
+    DateValue clone = Json.read(bytes, DateValue.class);
     assertNotNull(clone);
     assertEquals(dateValue, clone);
     assertEquals(dateValue.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/DoubleValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/DoubleValueTest.java
@@ -4,22 +4,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.feature.DoubleFeature;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
 public class DoubleValueTest {
 
   @Test
-  public void serialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
+  public void testSerialization() throws IOException {
     DoubleValue value = new DoubleValue(new DoubleFeature("test"), 10.1);
-    byte[] bytes = mapper.writeValueAsBytes(value);
+    byte[] bytes = Json.toBytes(value);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
 
-    DoubleValue clone = mapper.readValue(bytes, DoubleValue.class);
+    DoubleValue clone = Json.read(bytes, DoubleValue.class);
     assertNotNull(clone);
     assertEquals(value, clone);
     assertEquals(value.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/EnumValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/EnumValueTest.java
@@ -6,9 +6,9 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.feature.EnumFeature;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -29,7 +29,7 @@ public class EnumValueTest {
 
   @Test
   public void testUnknown() {
-    Value value = new EnumFeature<>(TestEnum.class, "test").unknown();
+    Value<?> value = new EnumFeature<>(TestEnum.class, "test").unknown();
     assertNotNull(value);
     assertTrue(value.isUnknown());
   }
@@ -57,15 +57,13 @@ public class EnumValueTest {
 
   @Test
   public void testSerializeAndDeserialize() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
-
     EnumFeature<TestEnum> feature = new EnumFeature<>(TestEnum.class, "feature");
-    EnumValue a = feature.value(TestEnum.A);
-    byte[] bytes = mapper.writeValueAsBytes(a);
+    EnumValue<TestEnum> a = feature.value(TestEnum.A);
+    byte[] bytes = Json.toBytes(a);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
 
-    Object clone = mapper.readValue(bytes, EnumValue.class);
+    Object clone = Json.read(bytes, EnumValue.class);
     assertNotNull(clone);
     assertEquals(a, clone);
     assertEquals(a.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/IntegerValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/IntegerValueTest.java
@@ -4,22 +4,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.feature.PositiveIntegerFeature;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
 public class IntegerValueTest {
 
   @Test
-  public void serialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
+  public void testSerialization() throws IOException {
     IntegerValue integerValue = new IntegerValue(new PositiveIntegerFeature("test"), 10);
-    byte[] bytes = mapper.writeValueAsBytes(integerValue);
+    byte[] bytes = Json.toBytes(integerValue);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
 
-    IntegerValue clone = mapper.readValue(bytes, IntegerValue.class);
+    IntegerValue clone = Json.read(bytes, IntegerValue.class);
     assertNotNull(clone);
     assertEquals(integerValue, clone);
     assertEquals(integerValue.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/LanguagesTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/LanguagesTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.util.Iterator;
 import org.junit.Test;
@@ -44,9 +44,8 @@ public class LanguagesTest {
 
   @Test
   public void testSerialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
     Languages languages = Languages.of(JAVA, C, OTHER);
-    Languages clone = mapper.readValue(mapper.writeValueAsBytes(languages), Languages.class);
+    Languages clone = Json.read(Json.toBytes(languages), Languages.class);
     assertEquals(languages, clone);
   }
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/LanguagesValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/LanguagesValueTest.java
@@ -3,8 +3,8 @@ package com.sap.oss.phosphor.fosstars.model.value;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.feature.oss.LanguagesFeature;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -12,10 +12,9 @@ public class LanguagesValueTest {
 
   @Test
   public void serializationAndDeserialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
     LanguagesFeature feature = new LanguagesFeature("test");
     LanguagesValue value = new LanguagesValue(feature, new Languages(Language.JAVA, Language.C));
-    LanguagesValue clone = mapper.readValue(mapper.writeValueAsBytes(value), LanguagesValue.class);
+    LanguagesValue clone = Json.read(Json.toBytes(value), LanguagesValue.class);
     assertTrue(value.equals(clone) && clone.equals(value));
     assertEquals(value.hashCode(), clone.hashCode());
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/LgtmGradeTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/LgtmGradeTest.java
@@ -4,21 +4,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
 public class LgtmGradeTest {
 
   @Test
-  public void serializeAndDeserialize() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
-
-    byte[] bytes = mapper.writeValueAsBytes(LgtmGrade.E);
+  public void testSerializeAndDeserialize() throws IOException {
+    byte[] bytes = Json.toBytes(LgtmGrade.E);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
 
-    Object clone = mapper.readValue(bytes, LgtmGrade.class);
+    Object clone = Json.read(bytes, LgtmGrade.class);
     assertNotNull(clone);
     assertEquals(LgtmGrade.E, clone);
     assertEquals(LgtmGrade.E.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/LgtmGradeValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/LgtmGradeValueTest.java
@@ -4,24 +4,22 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.feature.LgtmGradeFeature;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
 public class LgtmGradeValueTest {
 
   @Test
-  public void serializeAndDeserialize() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
-
+  public void testSerializeAndDeserialize() throws IOException {
     LgtmGradeFeature feature = new LgtmGradeFeature("feature");
     LgtmGradeValue a = feature.value(LgtmGrade.A_PLUS);
-    byte[] bytes = mapper.writeValueAsBytes(a);
+    byte[] bytes = Json.toBytes(a);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
 
-    Object clone = mapper.readValue(bytes, LgtmGradeValue.class);
+    Object clone = Json.read(bytes, LgtmGradeValue.class);
     assertNotNull(clone);
     assertEquals(a, clone);
     assertEquals(a.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/NotApplicableValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/NotApplicableValueTest.java
@@ -7,54 +7,53 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
 public class NotApplicableValueTest {
 
   @Test
-  public void isUnknown() {
+  public void testIsUnknown() {
     assertFalse(NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).isUnknown());
   }
 
   @Test
-  public void isNotApplicable() {
+  public void testIsNotApplicable() {
     assertTrue(NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).isNotApplicable());
   }
 
   @Test(expected = UnsupportedOperationException.class)
-  public void get() {
+  public void testGet() {
     NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).get();
   }
 
   @Test
-  public void equalsAndHashCode() {
-    NotApplicableValue one = NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
-    NotApplicableValue two = NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
+  public void testEqualsAndHashCode() {
+    NotApplicableValue<Integer> one = NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
+    NotApplicableValue<Integer> two = NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
 
     assertEquals(one, one);
     assertTrue(one.equals(two) && two.equals(one));
     assertEquals(one.hashCode(), two.hashCode());
 
-    NotApplicableValue three = NotApplicableValue.of(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE);
+    NotApplicableValue<Integer> three
+        = NotApplicableValue.of(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE);
     assertNotEquals(one, three);
 
-    UnknownValue four = UnknownValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
+    UnknownValue<Integer> four = UnknownValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
     assertNotEquals(one, four);
   }
 
   @Test
-  public void toStringIsNotEmpty() {
+  public void testToStringIsNotEmpty() {
     assertFalse(NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE).toString().isEmpty());
   }
 
   @Test
-  public void serializationAndDeserialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
-    NotApplicableValue value = NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
-    NotApplicableValue clone = mapper.readValue(
-        mapper.writeValueAsBytes(value), NotApplicableValue.class);
+  public void testSerializationAndDeserialization() throws IOException {
+    NotApplicableValue<Integer> value = NotApplicableValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
+    NotApplicableValue<?> clone = Json.read(Json.toBytes(value), NotApplicableValue.class);
     assertEquals(value, clone);
     assertEquals(value.hashCode(), clone.hashCode());
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/OwaspDependencyCheckCvssThresholdValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/OwaspDependencyCheckCvssThresholdValueTest.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.feature.OwaspDependencyCheckCvssThreshold;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -61,11 +61,9 @@ public class OwaspDependencyCheckCvssThresholdValueTest {
 
   @Test
   public void testSerializationAndDeserialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
-
     OwaspDependencyCheckCvssThresholdValue value = FEATURE.value(5.7);
-    OwaspDependencyCheckCvssThresholdValue clone = mapper.readValue(
-        mapper.writeValueAsBytes(value), OwaspDependencyCheckCvssThresholdValue.class);
+    OwaspDependencyCheckCvssThresholdValue clone = Json.read(
+        Json.toBytes(value), OwaspDependencyCheckCvssThresholdValue.class);
     assertEquals(value, clone);
     assertEquals(value.hashCode(), clone.hashCode());
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/PackageManagersTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/PackageManagersTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.util.List;
 import org.junit.Test;
@@ -46,10 +46,8 @@ public class PackageManagersTest {
 
   @Test
   public void testSerialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
     PackageManagers packageManagers = PackageManagers.from(PIP, MAVEN);
-    PackageManagers clone = mapper.readValue(
-        mapper.writeValueAsBytes(packageManagers), PackageManagers.class);
+    PackageManagers clone = Json.read(Json.toBytes(packageManagers), PackageManagers.class);
     assertEquals(packageManagers, clone);
   }
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/PackageManagersValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/PackageManagersValueTest.java
@@ -3,21 +3,19 @@ package com.sap.oss.phosphor.fosstars.model.value;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.feature.oss.PackageManagersFeature;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
 public class PackageManagersValueTest {
 
   @Test
-  public void serializationAndDeserialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
+  public void testSerializationAndDeserialization() throws IOException {
     PackageManagersFeature feature = new PackageManagersFeature("test");
     PackageManagersValue value = new PackageManagersValue(
         feature, new PackageManagers(PackageManager.MAVEN, PackageManager.OTHER));
-    PackageManagersValue clone = mapper.readValue(
-        mapper.writeValueAsBytes(value), PackageManagersValue.class);
+    PackageManagersValue clone = Json.read(Json.toBytes(value), PackageManagersValue.class);
     assertTrue(value.equals(clone) && clone.equals(value));
     assertEquals(value.hashCode(), clone.hashCode());
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/RatingValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/RatingValueTest.java
@@ -7,8 +7,8 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.rating.example.SecurityRatingExample.SecurityLabelExample;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.util.Collections;
 import org.junit.Test;
@@ -16,7 +16,7 @@ import org.junit.Test;
 public class RatingValueTest {
 
   @Test
-  public void smokeTest() {
+  public void testBasics() {
     ScoreValue scoreValue = new ScoreValue(
         PROJECT_ACTIVITY_SCORE_EXAMPLE, 5.1, 0.8, 9.0, Collections.emptyList());
     RatingValue ratingValue = new RatingValue(scoreValue, SecurityLabelExample.OKAY);
@@ -26,7 +26,7 @@ public class RatingValueTest {
   }
 
   @Test
-  public void equalsAndHashCode() {
+  public void testEqualsAndHashCode() {
     ScoreValue scoreValue = new ScoreValue(
         PROJECT_ACTIVITY_SCORE_EXAMPLE, 5.1, 0.8, 9.0, Collections.emptyList());
     ScoreValue scoreValueClone = new ScoreValue(
@@ -57,15 +57,14 @@ public class RatingValueTest {
   }
 
   @Test
-  public void serializeAndDeserialize() throws IOException {
+  public void testSerializeAndDeserialize() throws IOException {
     ScoreValue scoreValue = new ScoreValue(
         PROJECT_ACTIVITY_SCORE_EXAMPLE, 5.1, 0.8, 9.0, Collections.emptyList());
     RatingValue ratingValue = new RatingValue(scoreValue, SecurityLabelExample.OKAY);
-    ObjectMapper mapper = new ObjectMapper();
-    byte[] bytes = mapper.writeValueAsBytes(ratingValue);
+    byte[] bytes = Json.toBytes(ratingValue);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
-    RatingValue clone = mapper.readValue(bytes, RatingValue.class);
+    RatingValue clone = Json.read(bytes, RatingValue.class);
     assertNotNull(clone);
     assertEquals(ratingValue, clone);
     assertEquals(ratingValue.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ReferenceTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ReferenceTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.net.URL;
 import org.junit.Test;
@@ -12,13 +12,12 @@ import org.junit.Test;
 public class ReferenceTest {
 
   @Test
-  public void serialization() throws IOException {
+  public void testSerialization() throws IOException {
     Reference reference = new Reference("test", new URL("https://blog/post/1"));
-    ObjectMapper mapper = new ObjectMapper();
-    byte[] bytes = mapper.writeValueAsBytes(reference);
+    byte[] bytes = Json.toBytes(reference);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
-    Reference clone = mapper.readValue(bytes, Reference.class);
+    Reference clone = Json.read(bytes, Reference.class);
     assertEquals(reference, clone);
   }
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ScoreValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ScoreValueTest.java
@@ -197,12 +197,11 @@ public class ScoreValueTest {
   public void testSerializeAndDeserializeUnknown() throws IOException {
     ScoreValue value = new ScoreValue(PROJECT_ACTIVITY_SCORE_EXAMPLE).makeUnknown();
 
-    ObjectMapper mapper = new ObjectMapper();
-    byte[] bytes = mapper.writeValueAsBytes(value);
+    byte[] bytes = Json.toBytes(value);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
 
-    ScoreValue clone = mapper.readValue(bytes, ScoreValue.class);
+    ScoreValue clone = Json.read(bytes, ScoreValue.class);
     assertNotNull(clone);
     assertTrue(clone.isUnknown());
     assertEquals(value, clone);

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ScoreValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ScoreValueTest.java
@@ -11,12 +11,12 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Rating;
 import com.sap.oss.phosphor.fosstars.model.RatingRepository;
 import com.sap.oss.phosphor.fosstars.model.Score;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.rating.example.SecurityRatingExample;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -181,14 +181,13 @@ public class ScoreValueTest {
         NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
         NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(3));
 
-    ObjectMapper mapper = new ObjectMapper();
     ScoreValue value = new ScoreValue(
         PROJECT_ACTIVITY_SCORE_EXAMPLE, 5.1, 1.0, 7.2, usedValues);
-    byte[] bytes = mapper.writeValueAsBytes(value);
+    byte[] bytes = Json.toBytes(value);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
 
-    ScoreValue clone = mapper.readValue(bytes, ScoreValue.class);
+    ScoreValue clone = Json.read(bytes, ScoreValue.class);
     assertNotNull(clone);
     assertEquals(value, clone);
     assertEquals(value.hashCode(), clone.hashCode());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/UnknownValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/UnknownValueTest.java
@@ -4,8 +4,8 @@ import static com.sap.oss.phosphor.fosstars.model.feature.example.ExampleFeature
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Value;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -29,10 +29,8 @@ public class UnknownValueTest {
 
   @Test
   public void testSerializationAndDeserialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
     UnknownValue<Integer> value = UnknownValue.of(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
-    UnknownValue<Integer> clone = mapper.readValue(
-        mapper.writeValueAsBytes(value), UnknownValue.class);
+    UnknownValue<?> clone = Json.read(Json.toBytes(value), UnknownValue.class);
     assertEquals(value, clone);
     assertEquals(value.hashCode(), clone.hashCode());
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ValueHashSetTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ValueHashSetTest.java
@@ -11,9 +11,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.ValueSet;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.util.Set;
 import org.junit.Test;
@@ -36,7 +36,7 @@ public class ValueHashSetTest {
   }
 
   @Test
-  public void testHas() {
+  public void testHasValue() {
     ValueSet values = ValueHashSet.empty();
     values.update(NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(10));
     assertEquals(1, values.size());
@@ -91,13 +91,12 @@ public class ValueHashSetTest {
     values.update(NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(10));
     values.update(HAS_SECURITY_TEAM.value(true));
 
-    ObjectMapper mapper = new ObjectMapper();
-    byte[] bytes = mapper.writeValueAsBytes(values);
+    byte[] bytes = Json.toBytes(values);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
     System.out.println(new String(bytes));
 
-    ValueSet clone = mapper.readValue(bytes, ValueSet.class);
+    ValueSet clone = Json.read(bytes, ValueSet.class);
     assertEquals(values, clone);
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/VulnerabilitiesTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/VulnerabilitiesTest.java
@@ -6,9 +6,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerability.Resolution;
+import com.sap.oss.phosphor.fosstars.util.Json;
+import com.sap.oss.phosphor.fosstars.util.Yaml;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -19,17 +19,13 @@ import org.junit.Test;
 public class VulnerabilitiesTest {
 
   @Test
-  public void jsonSerializationAndDeserialization() throws IOException {
-    serializationAndDeserialization(new ObjectMapper(), vulnerabilities());
+  public void tstJsonSerializationAndDeserialization() throws IOException {
+    serializationAndDeserialization(Json.mapper(), vulnerabilities());
   }
 
   @Test
-  public void yamlSerializationAndDeserialization() throws IOException {
-    YAMLFactory factory = new YAMLFactory();
-    factory.disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID);
-    ObjectMapper mapper = new ObjectMapper(factory);
-    mapper.findAndRegisterModules();
-    serializationAndDeserialization(mapper, vulnerabilities());
+  public void testYamlSerializationAndDeserialization() throws IOException {
+    serializationAndDeserialization(Yaml.mapper(), vulnerabilities());
   }
 
   private static void serializationAndDeserialization(

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/VulnerabilitiesValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/VulnerabilitiesValueTest.java
@@ -5,27 +5,26 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
 public class VulnerabilitiesValueTest {
 
   @Test
-  public void serialization() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
+  public void testSerialization() throws IOException {
     VulnerabilitiesValue vulnerabilityValue =
         new VulnerabilitiesValue(
             new Vulnerabilities(
                 newVulnerability("https://bugtracker/1").make(),
                 newVulnerability("https://bugtracker/2").make()));
-    byte[] bytes = mapper.writeValueAsBytes(vulnerabilityValue);
+    byte[] bytes = Json.toBytes(vulnerabilityValue);
     assertNotNull(bytes);
     assertTrue(bytes.length > 0);
     String content = new String(bytes);
     assertTrue(content.contains("https://bugtracker/1"));
     assertTrue(content.contains("https://bugtracker/2"));
-    VulnerabilitiesValue clone = mapper.readValue(bytes, VulnerabilitiesValue.class);
+    VulnerabilitiesValue clone = Json.read(bytes, VulnerabilitiesValue.class);
     assertEquals(vulnerabilityValue, clone);
     assertEquals(vulnerabilityValue.hashCode(), clone.hashCode());
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/weight/ImmutableWeightTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/weight/ImmutableWeightTest.java
@@ -3,35 +3,35 @@ package com.sap.oss.phosphor.fosstars.model.weight;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
 public class ImmutableWeightTest {
 
   @Test
-  public void good() {
+  public void testGood() {
     assertEquals(0.45, new ImmutableWeight(0.45).value(), 0.0);
     assertEquals(1, new ImmutableWeight(1).value(), 0.0);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void zero() {
+  public void testZero() {
     new ImmutableWeight(0);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void negative() {
+  public void testNegative() {
     new ImmutableWeight(-1);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void tooBig() {
+  public void testTooBig() {
     new ImmutableWeight(2);
   }
 
   @Test(expected = UnsupportedOperationException.class)
-  public void update() {
+  public void testUpdate() {
     ImmutableWeight weight = new ImmutableWeight(0.5);
     assertTrue(weight.isImmutable());
     assertEquals(0.5, weight.value(), 0.001);
@@ -39,16 +39,14 @@ public class ImmutableWeightTest {
   }
 
   @Test
-  public void serializeAndDeserialize() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
+  public void testSerializeAndDeserialize() throws IOException {
     ImmutableWeight weight = new ImmutableWeight(0.5);
-    byte[] bytes = mapper.writeValueAsBytes(weight);
-    ImmutableWeight clone = mapper.readValue(bytes, ImmutableWeight.class);
+    ImmutableWeight clone = Json.read(Json.toBytes(weight), ImmutableWeight.class);
     assertEquals(weight, clone);
   }
 
   @Test
-  public void boundaries() {
+  public void testBoundaries() {
     MutableWeight weight = new MutableWeight(0.5);
     assertTrue(weight.boundaries().contains(weight.value()));
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/weight/MutableWeightTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/weight/MutableWeightTest.java
@@ -5,35 +5,35 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;
 
 public class MutableWeightTest {
 
   @Test
-  public void good() {
+  public void testGood() {
     assertEquals(0.45, new MutableWeight(0.45).value(), 0.0);
     assertEquals(1, new MutableWeight(1).value(), 0.0);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void zero() {
+  public void testZero() {
     new MutableWeight(0);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void negative() {
+  public void testNegative() {
     new MutableWeight(-1);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void tooBig() {
+  public void testTooBig() {
     new MutableWeight(2);
   }
 
   @Test
-  public void update() {
+  public void testUpdate() {
     MutableWeight weight = new MutableWeight(0.5);
     assertFalse(weight.isImmutable());
     assertEquals(0.5, weight.value(), 0.001);
@@ -43,16 +43,14 @@ public class MutableWeightTest {
   }
 
   @Test
-  public void serializeAndDeserialize() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
+  public void testSerializeAndDeserialize() throws IOException {
     MutableWeight weight = new MutableWeight(0.5);
-    byte[] bytes = mapper.writeValueAsBytes(weight);
-    MutableWeight clone = mapper.readValue(bytes, MutableWeight.class);
+    MutableWeight clone = Json.read(Json.toBytes(weight), MutableWeight.class);
     assertEquals(weight, clone);
   }
 
   @Test
-  public void boundaries() {
+  public void testBoundaries() {
     MutableWeight weight = new MutableWeight(0.5);
     assertTrue(weight.boundaries().contains(weight.value()));
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/weight/ScoreWeightsTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/weight/ScoreWeightsTest.java
@@ -5,6 +5,7 @@ import static com.sap.oss.phosphor.fosstars.model.score.example.ExampleScores.SE
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.sap.oss.phosphor.fosstars.util.Yaml;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -46,9 +47,7 @@ public class ScoreWeightsTest {
     weights.set(PROJECT_ACTIVITY_SCORE_EXAMPLE, new MutableWeight(0.2));
     weights.set(SECURITY_TESTING_SCORE_EXAMPLE, new MutableWeight(0.7));
 
-    ScoreWeights clone = ScoreWeights.YAML_OBJECT_MAPPER.readValue(
-        ScoreWeights.YAML_OBJECT_MAPPER.writeValueAsBytes(weights),
-        ScoreWeights.class);
+    ScoreWeights clone = Yaml.read(Yaml.toBytes(weights), ScoreWeights.class);
     assertTrue(weights.equals(clone) && clone.equals(weights));
     assertEquals(weights.hashCode(), clone.hashCode());
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/util/SafeDeserializationTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/util/SafeDeserializationTest.java
@@ -1,0 +1,36 @@
+package com.sap.oss.phosphor.fosstars.util;
+
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import com.sap.oss.phosphor.test.AnotherData;
+import com.sap.oss.phosphor.test.Entity;
+import java.io.IOException;
+import org.junit.Test;
+
+public class SafeDeserializationTest {
+
+  @Test
+  public void testWithProhibitedClass() throws IOException {
+    Entity entity = new Entity(new AnotherData());
+
+    try {
+      Json.mapper().readValue(Json.toBytes(entity), Entity.class);
+      fail("Deserialization should fail");
+    } catch (InvalidTypeIdException e) {
+      // ok
+    }
+
+    try {
+      Yaml.mapper().readValue(Json.toBytes(entity), Entity.class);
+      fail("Deserialization should fail");
+    } catch (InvalidTypeIdException e) {
+      // ok
+    }
+
+    Deserialization.allow(AnotherData.class.getCanonicalName());
+    Json.mapper().readValue(Json.toBytes(entity), Entity.class);
+    Yaml.mapper().readValue(Json.toBytes(entity), Entity.class);
+  }
+
+}

--- a/src/test/java/com/sap/oss/phosphor/test/AnotherData.java
+++ b/src/test/java/com/sap/oss/phosphor/test/AnotherData.java
@@ -1,0 +1,6 @@
+package com.sap.oss.phosphor.test;
+
+public class AnotherData {
+
+  public String string;
+}

--- a/src/test/java/com/sap/oss/phosphor/test/Data.java
+++ b/src/test/java/com/sap/oss/phosphor/test/Data.java
@@ -1,0 +1,5 @@
+package com.sap.oss.phosphor.test;
+
+public interface Data {
+
+}

--- a/src/test/java/com/sap/oss/phosphor/test/DoubleData.java
+++ b/src/test/java/com/sap/oss/phosphor/test/DoubleData.java
@@ -1,0 +1,6 @@
+package com.sap.oss.phosphor.test;
+
+public class DoubleData implements Data {
+
+  public double number;
+}

--- a/src/test/java/com/sap/oss/phosphor/test/Entity.java
+++ b/src/test/java/com/sap/oss/phosphor/test/Entity.java
@@ -1,0 +1,21 @@
+package com.sap.oss.phosphor.test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
+public class Entity {
+
+  @JsonTypeInfo(use = Id.CLASS)
+  private final Object data;
+
+  @JsonCreator
+  public Entity(@JsonProperty("data") Object data) {
+    this.data = data;
+  }
+
+  public Object getData() {
+    return data;
+  }
+}

--- a/src/test/java/com/sap/oss/phosphor/test/IntegerData.java
+++ b/src/test/java/com/sap/oss/phosphor/test/IntegerData.java
@@ -1,0 +1,6 @@
+package com.sap.oss.phosphor.test;
+
+public class IntegerData implements Data {
+
+  public int number;
+}


### PR DESCRIPTION
Here is a list of main updates:

- Added `Deserialization` class that holds settings serialization/deserialization and creates a validator for polymorphic deserialization.
- Added `Json` class that holds an `ObjectMapper` for JSON.
- Updated `Json` and `Yaml` classes to set a validator for returned `ObjectMapper`s.
- Added new methods to `Yaml` class.
- Replaced creating `ObjectMapper`s with calls to `Json` and `Yaml` classes.
- Fixed minor issues with Java generics.
- Added `SafeDeserializationTest`.
- Updated other tests

Fixes #381 