### PR TITLE
Fix warnings for Java generics

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/AbstractOssAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/AbstractOssAdvisor.java
@@ -72,7 +72,7 @@ public abstract class AbstractOssAdvisor implements Advisor {
    * @return A list of advices.
    */
   protected abstract List<Advice> adviseFor(
-      Subject subject, List<Value> usedValues, OssAdviceContext context);
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context);
 
   /**
    * Returns advices for a boolean feature from a list of values.
@@ -84,7 +84,7 @@ public abstract class AbstractOssAdvisor implements Advisor {
    * @return A list of advices.
    */
   protected List<Advice> adviseForBooleanFeature(
-      List<Value> values, Feature<Boolean> feature, Subject subject, OssAdviceContext context) {
+      List<Value<?>> values, Feature<Boolean> feature, Subject subject, OssAdviceContext context) {
 
     return findValue(values, feature)
         .filter(AbstractOssAdvisor::knownFalseValue)

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/CodeqlAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/CodeqlAdvisor.java
@@ -28,7 +28,7 @@ public class CodeqlAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviseFor(
-      Subject subject, List<Value> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
 
     return Stream.of(USES_LGTM_CHECKS, USES_CODEQL_CHECKS, RUNS_CODEQL_SCANS)
         .map(feature -> adviseForBooleanFeature(usedValues, feature, subject, context))

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/FindSecBugsAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/FindSecBugsAdvisor.java
@@ -25,7 +25,7 @@ public class FindSecBugsAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviseFor(
-      Subject subject, List<Value> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
 
     return adviseForBooleanFeature(usedValues, USES_FIND_SEC_BUGS, subject, context);
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/FuzzingAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/FuzzingAdvisor.java
@@ -30,7 +30,7 @@ public class FuzzingAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviseFor(
-      Subject subject, List<Value> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
 
     Optional<ScoreValue> fuzzingScoreValue = findSubScoreValue(subject, FuzzingScore.class);
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/LgtmAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/LgtmAdvisor.java
@@ -30,7 +30,7 @@ public class LgtmAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviseFor(
-      Subject subject, List<Value> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
 
     return findValue(usedValues, WORST_LGTM_GRADE)
         .filter(LgtmAdvisor::isKnown)

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/MemorySafetyAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/MemorySafetyAdvisor.java
@@ -39,7 +39,7 @@ public class MemorySafetyAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviseFor(
-      Subject subject, List<Value> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
 
     Optional<ScoreValue> memorySafetyTestingScoreValue
         = findSubScoreValue(subject, MemorySafetyTestingScore.class);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/SecurityPolicyAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/SecurityPolicyAdvisor.java
@@ -25,7 +25,7 @@ public class SecurityPolicyAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviseFor(
-      Subject subject, List<Value> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
 
     return adviseForBooleanFeature(usedValues, HAS_SECURITY_POLICY, subject, context);
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/AbstractCachingDataProvider.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/AbstractCachingDataProvider.java
@@ -37,21 +37,21 @@ public abstract class AbstractCachingDataProvider<T> extends AbstractDataProvide
       throws IOException {
 
     // get a list of features which are supported by the data provider
-    Set<Feature> features = supportedFeatures();
+    Set<Feature<?>> features = supportedFeatures();
 
     // look for values for the supported features in the cache
     // unknown values don't count
-    Set<Value> cachedValues = new HashSet<>();
+    Set<Value<?>> cachedValues = new HashSet<>();
     for (Feature feature : features) {
-      Optional<Value> something = cache.get(object, feature);
-      Value value = something.orElse(UnknownValue.of(feature));
+      Optional<Value<?>> something = cache.get(object, feature);
+      Value<?> value = something.orElse(UnknownValue.of(feature));
       if (!value.isUnknown()) {
         cachedValues.add(value);
       }
     }
 
     // put the cached values to the resulting set of values
-    for (Value value : cachedValues) {
+    for (Value<?> value : cachedValues) {
       values.update(value);
     }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/AbstractDataProvider.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/AbstractDataProvider.java
@@ -56,7 +56,7 @@ public abstract class AbstractDataProvider<T> implements DataProvider<T> {
    *
    * @return A set of features that the provider can fill out.
    */
-  protected abstract Set<Feature> supportedFeatures();
+  protected abstract Set<Feature<?>> supportedFeatures();
 
   /**
    * Gathers data about an object and updates a specified set of values.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/CompositeDataProvider.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/CompositeDataProvider.java
@@ -97,7 +97,7 @@ public class CompositeDataProvider<T> implements DataProvider<T> {
   @Override
   public CompositeDataProvider<T> set(UserCallback callback) {
     Objects.requireNonNull(callback, "Callback can't be null!");
-    for (DataProvider provider : providers) {
+    for (DataProvider<?> provider : providers) {
       provider.set(callback);
     }
     return this;
@@ -118,7 +118,7 @@ public class CompositeDataProvider<T> implements DataProvider<T> {
    * @param features The features.
    * @return This data provider.
    */
-  public CompositeDataProvider<T> stopWhenFilledOut(Feature... features) {
+  public CompositeDataProvider<T> stopWhenFilledOut(Feature<?>... features) {
     stopCondition(new AllFeaturesFilledOut(features));
     return this;
   }
@@ -155,14 +155,14 @@ public class CompositeDataProvider<T> implements DataProvider<T> {
     /**
      * A list of features.
      */
-    private final List<Feature> features = new ArrayList<>();
+    private final List<Feature<?>> features = new ArrayList<>();
 
     /**
      * Initializes a stop condition with a number of features.
      *
      * @param features The features. It can't be null or empty.
      */
-    AllFeaturesFilledOut(Feature... features) {
+    AllFeaturesFilledOut(Feature<?>... features) {
       Objects.requireNonNull(features, "Features can't be null!");
       if (features.length == 0) {
         throw new IllegalArgumentException("No features provided!");
@@ -173,7 +173,7 @@ public class CompositeDataProvider<T> implements DataProvider<T> {
     @Override
     public boolean satisfied(ValueSet values) {
       for (Feature feature : features) {
-        Optional<Value> something = values.of(feature);
+        Optional<Value<?>> something = values.of(feature);
         if (!something.isPresent()) {
           return false;
         }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/NoValueCache.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/NoValueCache.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 /**
  * This is a dummy cache which stores nothing.
  */
-public class NoValueCache<T> implements ValueCache<T> {
+public class NoValueCache<K> implements ValueCache<K> {
 
   /**
    * Creates an instance of {@link NoValueCache}.
@@ -22,22 +22,22 @@ public class NoValueCache<T> implements ValueCache<T> {
   }
 
   @Override
-  public Optional<Value> get(T key, Feature feature) {
+  public <T> Optional<Value<T>> get(K key, Feature<T> feature) {
     return Optional.empty();
   }
 
   @Override
-  public Optional<ValueSet> get(T key) {
+  public Optional<ValueSet> get(K key) {
     return Optional.empty();
   }
 
   @Override
-  public void put(T key, ValueSet value) {
+  public void put(K key, ValueSet value) {
     // do nothing
   }
 
   @Override
-  public void put(T key, ValueSet value, Date expiration) {
+  public void put(K key, ValueSet value, Date expiration) {
     // do nothing
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/ValueCache.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/ValueCache.java
@@ -18,7 +18,8 @@ public interface ValueCache<K> extends Cache<K, ValueSet> {
    *
    * @param key The key.
    * @param feature The feature.
+   * @param <T> Type of data held by the feature.
    * @return An {@link Optional} with the value if the cache has it.
    */
-  Optional<Value> get(K key, Feature feature);
+  <T> Optional<Value<T>> get(K key, Feature<T> feature);
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/CachedSingleFeatureGitHubDataProvider.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/CachedSingleFeatureGitHubDataProvider.java
@@ -11,8 +11,10 @@ import java.util.Set;
 
 /**
  * This is a base class for data providers that fill out a single feature for a project on GitHub.
+ *
+ * @param <F> Type of data held by the feature.
  */
-public abstract class CachedSingleFeatureGitHubDataProvider extends GitHubCachingDataProvider {
+public abstract class CachedSingleFeatureGitHubDataProvider<F> extends GitHubCachingDataProvider {
 
   /**
    * Initializes a data provider.
@@ -29,7 +31,7 @@ public abstract class CachedSingleFeatureGitHubDataProvider extends GitHubCachin
   }
 
   @Override
-  protected final Set<Feature> supportedFeatures() {
+  protected final Set<Feature<?>> supportedFeatures() {
     return Collections.singleton(supportedFeature());
   }
 
@@ -38,7 +40,7 @@ public abstract class CachedSingleFeatureGitHubDataProvider extends GitHubCachin
    *
    * @return A feature that the provider can fill out.
    */
-  protected abstract Feature supportedFeature();
+  protected abstract Feature<F> supportedFeature();
 
   /**
    * Fetch a feature value for a project.
@@ -47,5 +49,5 @@ public abstract class CachedSingleFeatureGitHubDataProvider extends GitHubCachin
    * @return The value.
    * @throws IOException If something went wrong.
    */
-  protected abstract Value fetchValueFor(GitHubProject project) throws IOException;
+  protected abstract Value<F> fetchValueFor(GitHubProject project) throws IOException;
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/CodeqlDataProvider.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/CodeqlDataProvider.java
@@ -61,7 +61,7 @@ public class CodeqlDataProvider extends GitHubCachingDataProvider {
   }
 
   @Override
-  protected Set<Feature> supportedFeatures() {
+  protected Set<Feature<?>> supportedFeatures() {
     return setOf(RUNS_CODEQL_SCANS, USES_CODEQL_CHECKS);
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/FirstCommit.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/FirstCommit.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 /**
  * This data provider returns a date of the first commit.
  */
-public class FirstCommit extends CachedSingleFeatureGitHubDataProvider {
+public class FirstCommit extends CachedSingleFeatureGitHubDataProvider<Date> {
 
   /**
    * Initializes a data provider.
@@ -24,12 +24,12 @@ public class FirstCommit extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Date> supportedFeature() {
     return FIRST_COMMIT_DATE;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Date> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out when the first commit was done ...");
     return firstCommitDate(project);
   }
@@ -41,7 +41,7 @@ public class FirstCommit extends CachedSingleFeatureGitHubDataProvider {
    * @throws IOException If something went wrong.
    */
   private Value<Date> firstCommitDate(GitHubProject project) throws IOException {
-    Optional<Commit> firstCommit = fetcher.localRepositoryFor(project).firstCommit();
+    Optional<Commit> firstCommit = GitHubDataFetcher.localRepositoryFor(project).firstCommit();
     if (firstCommit.isPresent()) {
       return FIRST_COMMIT_DATE.value(firstCommit.get().date());
     }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/FuzzedInOssFuzz.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/FuzzedInOssFuzz.java
@@ -19,7 +19,7 @@ import org.apache.commons.io.IOUtils;
  * This data provider check if an open-source project is included to the OSS-Fuzz project.
  * It fills out the {@link OssFeatures#FUZZED_IN_OSS_FUZZ} feature.
  */
-public class FuzzedInOssFuzz extends CachedSingleFeatureGitHubDataProvider {
+public class FuzzedInOssFuzz extends CachedSingleFeatureGitHubDataProvider<Boolean> {
 
   /**
    * OSS-Fuzz project on GitHub.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/GitHubDataCache.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/GitHubDataCache.java
@@ -88,7 +88,7 @@ public class GitHubDataCache<T> implements Cache<GitHubProject, T> {
     if (o instanceof GitHubDataCache == false) {
       return false;
     }
-    GitHubDataCache<T> cache = (GitHubDataCache) o;
+    GitHubDataCache<T> cache = (GitHubDataCache<T>) o;
     return Objects.equals(entries, cache.entries);
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/HasBugBountyProgram.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/HasBugBountyProgram.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 /**
  * This data provider tries to figure out if a project has a bug bounty program.
  */
-public class HasBugBountyProgram extends CachedSingleFeatureGitHubDataProvider {
+public class HasBugBountyProgram extends CachedSingleFeatureGitHubDataProvider<Boolean> {
 
   /**
    * Where info about bug bounty programs are stored.
@@ -30,12 +30,12 @@ public class HasBugBountyProgram extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Boolean> supportedFeature() {
     return HAS_BUG_BOUNTY_PROGRAM;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Boolean> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project has a bug bounty program ...");
     return HAS_BUG_BOUNTY_PROGRAM.value(bugBounties.existsFor(project));
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/HasCompanySupport.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/HasCompanySupport.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 /**
  * This data provider check if an open-source project is supported by a company.
  */
-public class HasCompanySupport extends CachedSingleFeatureGitHubDataProvider {
+public class HasCompanySupport extends CachedSingleFeatureGitHubDataProvider<Boolean> {
 
   /**
    * Where the info about open-source projects is stored.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/HasSecurityPolicy.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/HasSecurityPolicy.java
@@ -12,7 +12,7 @@ import java.io.IOException;
  * This data provider check if an open-source project has a security policy which describes how
  * vulnerabilities should be reported and fixed.
  */
-public class HasSecurityPolicy extends CachedSingleFeatureGitHubDataProvider {
+public class HasSecurityPolicy extends CachedSingleFeatureGitHubDataProvider<Boolean> {
 
   /**
    * A minimal number of characters in a security policy to consider it valid.
@@ -42,12 +42,12 @@ public class HasSecurityPolicy extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Boolean> supportedFeature() {
     return HAS_SECURITY_POLICY;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Boolean> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project has a security policy ...");
     return hasSecurityPolicy(project);
   }
@@ -59,7 +59,7 @@ public class HasSecurityPolicy extends CachedSingleFeatureGitHubDataProvider {
    * @throws IOException If something went wrong.
    */
   private Value<Boolean> hasSecurityPolicy(GitHubProject project) throws IOException {
-    LocalRepository repository = fetcher.localRepositoryFor(project);
+    LocalRepository repository = GitHubDataFetcher.localRepositoryFor(project);
     for (String path : POLICY_LOCATIONS) {
       if (isPolicy(repository, path)) {
         return HAS_SECURITY_POLICY.value(true);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/HasSecurityTeam.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/HasSecurityTeam.java
@@ -14,7 +14,7 @@ import java.io.IOException;
  * project belongs to an organization which provides a security team such as Apache Software
  * Foundation. Next, it tries to ask a user if {@link UserCallback} is available.
  */
-public class HasSecurityTeam extends CachedSingleFeatureGitHubDataProvider {
+public class HasSecurityTeam extends CachedSingleFeatureGitHubDataProvider<Boolean> {
 
   /**
    * Where info about security teams are stored.
@@ -33,12 +33,12 @@ public class HasSecurityTeam extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Boolean> supportedFeature() {
     return HAS_SECURITY_TEAM;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Boolean> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project has a security team ...");
     return HAS_SECURITY_TEAM.value(securityTeam.existsFor(project.scm()));
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/InfoAboutVulnerabilities.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/InfoAboutVulnerabilities.java
@@ -26,12 +26,13 @@ import java.util.Objects;
  * The data provider cache a value for
  * the {@link com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures#VULNERABILITIES} feature.
  */
-public class InfoAboutVulnerabilities extends CachedSingleFeatureGitHubDataProvider {
+public class InfoAboutVulnerabilities
+    extends CachedSingleFeatureGitHubDataProvider<Vulnerabilities> {
 
   /**
    * A list of underlying data providers.
    */
-  private List<DataProvider<GitHubProject>> providers;
+  private final List<DataProvider<GitHubProject>> providers;
 
   /**
    * Initializes a data provider.
@@ -49,12 +50,12 @@ public class InfoAboutVulnerabilities extends CachedSingleFeatureGitHubDataProvi
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Vulnerabilities> supportedFeature() {
     return VULNERABILITIES;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Vulnerabilities> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Looking for vulnerabilities in the project ...");
 
     Vulnerabilities allVulnerabilities = new Vulnerabilities();
@@ -62,7 +63,7 @@ public class InfoAboutVulnerabilities extends CachedSingleFeatureGitHubDataProvi
       ValueSet subset = new ValueHashSet();
       provider.set(callback).set(cache).update(project, subset);
 
-      for (Value value : subset.toArray()) {
+      for (Value<?> value : subset.toArray()) {
         if (value.isUnknown()) {
           continue;
         }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/IsApache.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/IsApache.java
@@ -11,7 +11,7 @@ import java.io.IOException;
  * The data provider tries to figure out if an open-source project belongs to the Apache Software
  * Foundation.
  */
-public class IsApache extends CachedSingleFeatureGitHubDataProvider {
+public class IsApache extends CachedSingleFeatureGitHubDataProvider<Boolean> {
 
   /**
    * Initializes a data provider.
@@ -23,12 +23,12 @@ public class IsApache extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Boolean> supportedFeature() {
     return IS_APACHE;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Boolean> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project belongs to the Apache Software Foundation ...");
     return IS_APACHE.value("apache".equalsIgnoreCase(project.organization().name()));
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/IsEclipse.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/IsEclipse.java
@@ -11,7 +11,7 @@ import java.io.IOException;
  * The data provider tries to figure out if an open-source project belongs to the Eclipse Software
  * Foundation.
  */
-public class IsEclipse extends CachedSingleFeatureGitHubDataProvider {
+public class IsEclipse extends CachedSingleFeatureGitHubDataProvider<Boolean> {
 
   private static final String[] KNOWN_ECLIPSE_ORGANISATIONS = { "eclipse", "eclipse-ee4j" };
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/LgtmDataProvider.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/LgtmDataProvider.java
@@ -58,7 +58,7 @@ public class LgtmDataProvider extends GitHubCachingDataProvider {
   }
 
   @Override
-  protected Set<Feature> supportedFeatures() {
+  protected Set<Feature<?>> supportedFeatures() {
     return setOf(USES_LGTM_CHECKS, WORST_LGTM_GRADE);
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/NumberOfCommits.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/NumberOfCommits.java
@@ -13,7 +13,7 @@ import java.util.Date;
 /**
  * This data provider returns a number of commits last 3 months.
  */
-public class NumberOfCommits extends CachedSingleFeatureGitHubDataProvider {
+public class NumberOfCommits extends CachedSingleFeatureGitHubDataProvider<Integer> {
 
   /**
    * ~3 months.
@@ -30,16 +30,16 @@ public class NumberOfCommits extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Integer> supportedFeature() {
     return NUMBER_OF_COMMITS_LAST_THREE_MONTHS;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Integer> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Counting how many commits have been done in the last three months ...");
 
     Date date = Date.from(Instant.now().minus(THREE_MONTHS));
     return NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(
-        fetcher.localRepositoryFor(project).commitsAfter(date).size());
+        GitHubDataFetcher.localRepositoryFor(project).commitsAfter(date).size());
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/NumberOfContributors.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/NumberOfContributors.java
@@ -17,7 +17,7 @@ import java.util.Set;
  * is an author of a commit or a person who committed the commit. The provider iterates over all
  * commits which have been made for lat 3 months, and collect unique login names of contributors.
  */
-public class NumberOfContributors extends CachedSingleFeatureGitHubDataProvider {
+public class NumberOfContributors extends CachedSingleFeatureGitHubDataProvider<Integer> {
 
   /**
    * Period of time to be checked.
@@ -34,17 +34,17 @@ public class NumberOfContributors extends CachedSingleFeatureGitHubDataProvider 
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Integer> supportedFeature() {
     return NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Integer> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Counting how many people contributed to the project in the last three months ...");
 
     Date date = Date.from(Instant.now().minus(THREE_MONTHS));
     Set<String> contributors = new HashSet<>();
-    for (Commit commit : fetcher.localRepositoryFor(project).commitsAfter(date)) {
+    for (Commit commit : GitHubDataFetcher.localRepositoryFor(project).commitsAfter(date)) {
       contributors.add(commit.authorName());
       contributors.add(commit.committerName());
     }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/NumberOfStars.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/NumberOfStars.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 /**
  * This data provider returns a number of stars for a project.
  */
-public class NumberOfStars extends CachedSingleFeatureGitHubDataProvider {
+public class NumberOfStars extends CachedSingleFeatureGitHubDataProvider<Integer> {
 
   /**
    * Initializes a data provider.
@@ -22,7 +22,7 @@ public class NumberOfStars extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Integer> supportedFeature() {
     return NUMBER_OF_GITHUB_STARS;
   }
 
@@ -34,7 +34,7 @@ public class NumberOfStars extends CachedSingleFeatureGitHubDataProvider {
    * @throws IOException If something went wrong.
    */
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Integer> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Counting how many stars the project has ...");
     return NUMBER_OF_GITHUB_STARS.value(
         fetcher.repositoryFor(project).getStargazersCount());

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/NumberOfWatchers.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/NumberOfWatchers.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 /**
  * This data provider returns a number of watchers for a project.
  */
-public class NumberOfWatchers extends CachedSingleFeatureGitHubDataProvider {
+public class NumberOfWatchers extends CachedSingleFeatureGitHubDataProvider<Integer> {
 
   /**
    * Initializes a data provider.
@@ -22,7 +22,7 @@ public class NumberOfWatchers extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Integer> supportedFeature() {
     return NUMBER_OF_WATCHERS_ON_GITHUB;
   }
 
@@ -34,7 +34,7 @@ public class NumberOfWatchers extends CachedSingleFeatureGitHubDataProvider {
    * @throws IOException If something went wrong.
    */
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Integer> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Counting how many watchers the project has ...");
     return NUMBER_OF_WATCHERS_ON_GITHUB.value(
         fetcher.repositoryFor(project).getSubscribersCount());

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/OwaspSecurityLibraries.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/OwaspSecurityLibraries.java
@@ -56,7 +56,7 @@ public class OwaspSecurityLibraries extends GitHubCachingDataProvider {
   }
 
   @Override
-  protected Set<Feature> supportedFeatures() {
+  protected Set<Feature<?>> supportedFeatures() {
     return setOf(USES_OWASP_ESAPI, USES_OWASP_JAVA_ENCODER, USES_OWASP_JAVA_HTML_SANITIZER);
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/PackageManagement.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/PackageManagement.java
@@ -40,7 +40,7 @@ import java.util.function.Predicate;
 /**
  * This data provider returns package managers which are used in a project.
  */
-public class PackageManagement extends CachedSingleFeatureGitHubDataProvider {
+public class PackageManagement extends CachedSingleFeatureGitHubDataProvider<PackageManagers> {
 
   /**
    * A minimal number of characters in a config to consider it valid.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/ProgrammingLanguages.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/ProgrammingLanguages.java
@@ -16,7 +16,7 @@ import org.kohsuke.github.GHRepository;
  * This data provider returns a number of languages that are used
  * in an open-source project.
  */
-public class ProgrammingLanguages extends CachedSingleFeatureGitHubDataProvider {
+public class ProgrammingLanguages extends CachedSingleFeatureGitHubDataProvider<Languages> {
 
   /**
    * Initializes a data provider.
@@ -28,12 +28,12 @@ public class ProgrammingLanguages extends CachedSingleFeatureGitHubDataProvider 
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Languages> supportedFeature() {
     return LANGUAGES;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Languages> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Looking for programming languages that are used in the project...");
     return languagesOf(project);
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/ProjectStarted.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/ProjectStarted.java
@@ -13,7 +13,7 @@ import java.util.Optional;
  * This data provider estimates a date when a project was created by the date when the repository
  * was created.
  */
-public class ProjectStarted extends CachedSingleFeatureGitHubDataProvider {
+public class ProjectStarted extends CachedSingleFeatureGitHubDataProvider<Date> {
 
   /**
    * Initializes a data provider.
@@ -25,15 +25,15 @@ public class ProjectStarted extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Date> supportedFeature() {
     return PROJECT_START_DATE;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Date> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out when the project started ...");
 
-    Optional<Commit> firstCommit = fetcher.localRepositoryFor(project).firstCommit();
+    Optional<Commit> firstCommit = GitHubDataFetcher.localRepositoryFor(project).firstCommit();
     Date firstCommitDate = firstCommit.map(Commit::date).orElse(null);
     Date repositoryCreated = fetcher.repositoryFor(project).getCreatedAt();
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/SignsJarArtifacts.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/SignsJarArtifacts.java
@@ -23,7 +23,7 @@ import org.apache.maven.model.Plugin;
  * <a href="http://maven.apache.org/plugins/maven-gpg-plugin/">Maven GPG plugin</a>.</p>
  * <p>The provider fills out the {@link OssFeatures#SIGNS_ARTIFACTS} feature.</p>
  */
-public class SignsJarArtifacts extends CachedSingleFeatureGitHubDataProvider {
+public class SignsJarArtifacts extends CachedSingleFeatureGitHubDataProvider<Boolean> {
 
   /**
    * Initializes a data provider.
@@ -35,14 +35,14 @@ public class SignsJarArtifacts extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Boolean> supportedFeature() {
     return SIGNS_ARTIFACTS;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Boolean> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project signs jar files ...");
-    LocalRepository repository = fetcher.localRepositoryFor(project);
+    LocalRepository repository = GitHubDataFetcher.localRepositoryFor(project);
     boolean answer = checkMaven(repository);
     return SIGNS_ARTIFACTS.value(answer);
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UnpatchedVulnerabilities.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UnpatchedVulnerabilities.java
@@ -20,7 +20,8 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * This data provider tries to figure out if an open-source project has unpatched vulnerabilities.
  */
-public class UnpatchedVulnerabilities extends CachedSingleFeatureGitHubDataProvider {
+public class UnpatchedVulnerabilities
+    extends CachedSingleFeatureGitHubDataProvider<Vulnerabilities> {
 
   /**
    * The flag shows if the provider should look for unpatched vulnerabilities in NVD.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesDependabot.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesDependabot.java
@@ -21,7 +21,7 @@ import java.util.Optional;
  * Next, the provider searches for commits from Dependabot in the commit history.
  * If the commits are found, then the provider also reports that the project uses Dependabot.</p>
  */
-public class UsesDependabot extends CachedSingleFeatureGitHubDataProvider {
+public class UsesDependabot extends CachedSingleFeatureGitHubDataProvider<Boolean> {
 
   /**
    * A list of locations of a Dependabot configuration file in a repository.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesFindSecBugs.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesFindSecBugs.java
@@ -24,7 +24,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
  *
  * <p>The provider fills out the {@link OssFeatures#USES_FIND_SEC_BUGS} feature.</p>
  */
-public class UsesFindSecBugs extends CachedSingleFeatureGitHubDataProvider {
+public class UsesFindSecBugs extends CachedSingleFeatureGitHubDataProvider<Boolean> {
 
   /**
    * Initializes a data provider.
@@ -36,12 +36,12 @@ public class UsesFindSecBugs extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Boolean> supportedFeature() {
     return USES_FIND_SEC_BUGS;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Boolean> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project uses FindSecBugs ...");
     LocalRepository repository = GitHubDataFetcher.localRepositoryFor(project);
     boolean answer = checkMaven(repository);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesGithubForDevelopment.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesGithubForDevelopment.java
@@ -20,7 +20,7 @@ import org.kohsuke.github.GHRepository;
 /**
  * This data provider tries to figure out if a project uses GitHub for development.
  */
-public class UsesGithubForDevelopment extends CachedSingleFeatureGitHubDataProvider {
+public class UsesGithubForDevelopment extends CachedSingleFeatureGitHubDataProvider<Boolean> {
 
   /**
    * This threshold shows how many checks have to be passed to say that a project uses GitHub

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesNoHttpTool.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesNoHttpTool.java
@@ -25,7 +25,7 @@ import org.apache.maven.model.Plugin;
  * The provider fills out the
  * {@link com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures#USES_NOHTTP} feature.
  */
-public class UsesNoHttpTool extends CachedSingleFeatureGitHubDataProvider {
+public class UsesNoHttpTool extends CachedSingleFeatureGitHubDataProvider<Boolean> {
 
   /**
    * Initializes a data provider.
@@ -37,15 +37,15 @@ public class UsesNoHttpTool extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Boolean> supportedFeature() {
     return USES_NOHTTP;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Boolean> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project uses nohttp ...");
 
-    LocalRepository repository = fetcher.localRepositoryFor(project);
+    LocalRepository repository = GitHubDataFetcher.localRepositoryFor(project);
     return USES_NOHTTP.value(checkMaven(repository) || checkGradle(repository));
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesOwaspDependencyCheck.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesOwaspDependencyCheck.java
@@ -67,7 +67,7 @@ public class UsesOwaspDependencyCheck extends GitHubCachingDataProvider {
   }
 
   @Override
-  protected Set<Feature> supportedFeatures() {
+  protected Set<Feature<?>> supportedFeatures() {
     return setOf(
         OWASP_DEPENDENCY_CHECK_USAGE, 
         OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesSanitizers.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesSanitizers.java
@@ -68,7 +68,7 @@ public class UsesSanitizers extends GitHubCachingDataProvider {
   }
 
   @Override
-  protected Set<Feature> supportedFeatures() {
+  protected Set<Feature<?>> supportedFeatures() {
     return setOf(USES_ADDRESS_SANITIZER, USES_MEMORY_SANITIZER, USES_UNDEFINED_BEHAVIOR_SANITIZER);
   }
 
@@ -83,7 +83,7 @@ public class UsesSanitizers extends GitHubCachingDataProvider {
     values.update(USES_MEMORY_SANITIZER.value(false));
     values.update(USES_UNDEFINED_BEHAVIOR_SANITIZER.value(false));
 
-    LocalRepository repository = fetcher.localRepositoryFor(project);
+    LocalRepository repository = GitHubDataFetcher.localRepositoryFor(project);
 
     List<Path> files = repository.files(
         path -> Files.isRegularFile(path) && maybeBuildConfig(path));

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesSignedCommits.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UsesSignedCommits.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
  * a density ratio compared against a percentage threshold
  * ({@link #SIGNED_COMMIT_PERCENTAGE_THRESHOLD}).
  */
-public class UsesSignedCommits extends CachedSingleFeatureGitHubDataProvider {
+public class UsesSignedCommits extends CachedSingleFeatureGitHubDataProvider<Boolean> {
 
   /**
    * A period of time when the provider should look for signed commits.
@@ -40,12 +40,12 @@ public class UsesSignedCommits extends CachedSingleFeatureGitHubDataProvider {
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Boolean> supportedFeature() {
     return USES_SIGNED_COMMITS;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Boolean> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Figuring out if the project uses signed commits ...");
     return usesSignedCommits(project);
   }
@@ -78,7 +78,8 @@ public class UsesSignedCommits extends CachedSingleFeatureGitHubDataProvider {
    * @throws IOException caused during REST call to GitHub API.
    */  
   private boolean askGithub(GitHubProject project) throws IOException {
-    List<Commit> yearCommits = fetcher.localRepositoryFor(project).commitsWithin(ONE_YEAR);
+    List<Commit> yearCommits
+        = GitHubDataFetcher.localRepositoryFor(project).commitsWithin(ONE_YEAR);
     int counter = yearCommits.size();
 
     List<Commit> signedCommits = yearCommits.stream()

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/VulnerabilitiesFromNvd.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/VulnerabilitiesFromNvd.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 /**
  * This data provider looks for vulnerabilities in NVD.
  */
-public class VulnerabilitiesFromNvd extends CachedSingleFeatureGitHubDataProvider {
+public class VulnerabilitiesFromNvd extends CachedSingleFeatureGitHubDataProvider<Vulnerabilities> {
 
   /**
    * A feature that hold info about vulnerabilities in the NVD.
@@ -42,12 +42,12 @@ public class VulnerabilitiesFromNvd extends CachedSingleFeatureGitHubDataProvide
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Vulnerabilities> supportedFeature() {
     return VULNERABILITIES_IN_NVD;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Vulnerabilities> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Looking for vulnerabilities in NVD ...");
 
     Vulnerabilities vulnerabilities = new Vulnerabilities();

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/experimental/VulnerabilitiesFromGitHubAdvisories.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/experimental/VulnerabilitiesFromGitHubAdvisories.java
@@ -34,7 +34,8 @@ import org.kohsuke.github.GHRepository;
  * This data provider looks for vulnerabilities in {@link GitHubAdvisories} which are not present in
  * {@link com.sap.oss.phosphor.fosstars.nvd.NVD}.
  */
-public class VulnerabilitiesFromGitHubAdvisories extends CachedSingleFeatureGitHubDataProvider {
+public class VulnerabilitiesFromGitHubAdvisories
+    extends CachedSingleFeatureGitHubDataProvider<Vulnerabilities> {
 
   /**
    * A feature that holds info about vulnerabilities in the GitHub Advisory Database.
@@ -60,12 +61,12 @@ public class VulnerabilitiesFromGitHubAdvisories extends CachedSingleFeatureGitH
   }
 
   @Override
-  protected Feature supportedFeature() {
+  protected Feature<Vulnerabilities> supportedFeature() {
     return VULNERABILITIES_IN_ADVISORIES;
   }
 
   @Override
-  protected Value fetchValueFor(GitHubProject project) throws IOException {
+  protected Value<Vulnerabilities> fetchValueFor(GitHubProject project) throws IOException {
     logger.info("Looking for vulnerabilities from GitHub Advisory ...");
 
     Vulnerabilities vulnerabilities = new Vulnerabilities();

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/interactive/AskAboutSecurityTeam.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/interactive/AskAboutSecurityTeam.java
@@ -41,7 +41,7 @@ public class AskAboutSecurityTeam<T> extends AbstractInteractiveDataProvider<T> 
   }
 
   @Override
-  protected Set<Feature> supportedFeatures() {
+  protected Set<Feature<?>> supportedFeatures() {
     return Collections.singleton(HAS_SECURITY_TEAM);
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/interactive/AskAboutUnpatchedVulnerabilities.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/interactive/AskAboutUnpatchedVulnerabilities.java
@@ -58,7 +58,7 @@ public class AskAboutUnpatchedVulnerabilities<T> extends AbstractInteractiveData
   }
 
   @Override
-  protected Set<Feature> supportedFeatures() {
+  protected Set<Feature<?>> supportedFeatures() {
     return Collections.singleton(VULNERABILITIES);
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/Confidence.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/Confidence.java
@@ -80,7 +80,7 @@ public interface Confidence {
    * @param values The features values.
    * @return The confidence level.
    */
-  static double make(List<Value> values) {
+  static double make(List<Value<?>> values) {
     Objects.requireNonNull(values, "Hey! Values can't be null!");
 
     if (values.size() == 0) {
@@ -90,7 +90,7 @@ public interface Confidence {
     double weightSum = 0.0;
     double weightedConfidenceSum = 0.0;
 
-    for (Value value : values) {
+    for (Value<?> value : values) {
       if (value.isUnknown()) {
         // if value is unknown, then confidence is min and weight is 1.0
         weightSum += 1.0;
@@ -118,7 +118,7 @@ public interface Confidence {
    * @return The confidence level
    * @see #make(List)
    */
-  static double make(Value... values) {
+  static double make(Value<?>... values) {
     Objects.requireNonNull(values, "Hey! Values can't be null!");
     return make(Arrays.asList(values));
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/Rating.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/Rating.java
@@ -39,7 +39,7 @@ public interface Rating {
    * @param values A set of values.
    * @return A rating value.
    */
-  RatingValue calculate(Set<Value> values);
+  RatingValue calculate(Set<Value<?>> values);
 
   /**
    * Takes a number of feature values and calculates a score.
@@ -47,7 +47,7 @@ public interface Rating {
    * @param values A number of values.
    * @return A rating value.
    */
-  RatingValue calculate(Value... values);
+  RatingValue calculate(Value<?>... values);
 
   /**
    * Takes a set of feature values and calculates a score.
@@ -62,7 +62,7 @@ public interface Rating {
    *
    * @return A number of features.
    */
-  Set<Feature> allFeatures();
+  Set<Feature<?>> allFeatures();
 
   /**
    * Accept a visitor.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/RatingRepository.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/RatingRepository.java
@@ -58,7 +58,7 @@ public class RatingRepository {
   /**
    * A mapping from a version to a rating.
    */
-  private final Map<Class, Rating> ratings = new HashMap<>();
+  private final Map<Class<? extends Rating>, Rating> ratings = new HashMap<>();
 
   /**
    * This constructor loads all available ratings.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/Score.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/Score.java
@@ -102,14 +102,14 @@ public interface Score extends Feature<Double> {
    *
    * @return A set of features which the score uses directly.
    */
-  Set<Feature> features();
+  Set<Feature<?>> features();
 
   /**
    * Returns all features which are used by the score.
    *
    * @return A number of features.
    */
-  Set<Feature> allFeatures();
+  Set<Feature<?>> allFeatures();
 
   /**
    * Get sub-scores which the score directly uses.
@@ -126,7 +126,7 @@ public interface Score extends Feature<Double> {
    * @throws IllegalArgumentException If the provided values don't contain required features
    *                                  which are used by the score.
    */
-  ScoreValue calculate(Set<Value> values);
+  ScoreValue calculate(Set<Value<?>> values);
 
   /**
    * Takes a number of values and calculates a score.
@@ -136,7 +136,7 @@ public interface Score extends Feature<Double> {
    * @throws IllegalArgumentException If the provided values don't contain required features
    *                                  which are used by the score.
    */
-  ScoreValue calculate(Value... values);
+  ScoreValue calculate(Value<?>... values);
 
   /**
    * Takes an instance of {@link ValueSet} and calculates a score.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/ValueSet.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/ValueSet.java
@@ -30,7 +30,7 @@ public interface ValueSet {
    * @param values Values to be updated.
    * @return This ValueSet.
    */
-  ValueSet update(Value... values);
+  ValueSet update(Value<?>... values);
 
   /**
    * Updates a number of values in the set.
@@ -46,7 +46,7 @@ public interface ValueSet {
    * @param values The new values.
    * @return This ValueSet.
    */
-  ValueSet update(Set<Value> values);
+  ValueSet update(Set<Value<?>> values);
 
   /**
    * Converts the set to an array of values.
@@ -84,5 +84,5 @@ public interface ValueSet {
    * @param features A Set of features.
    * @return True if the set contains all the specified features, false otherwise.
    */
-  boolean containsAll(Set<Feature> features);
+  boolean containsAll(Set<Feature<?>> features);
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/Visitor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/Visitor.java
@@ -31,7 +31,7 @@ public interface Visitor {
    *
    * @param feature The feature to be visited.
    */
-  void visit(Feature feature);
+  void visit(Feature<?> feature);
 
   /**
    * Visit a {@link Parameter}.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/other/ImmutabilityChecker.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/other/ImmutabilityChecker.java
@@ -34,7 +34,7 @@ public class ImmutabilityChecker implements Visitor {
   }
 
   @Override
-  public void visit(Feature feature) {
+  public void visit(Feature<?> feature) {
     checkImmutability(feature);
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/other/MakeImmutable.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/other/MakeImmutable.java
@@ -23,7 +23,7 @@ public class MakeImmutable implements Visitor {
   }
 
   @Override
-  public void visit(Feature feature) {
+  public void visit(Feature<?> feature) {
     tryToMakeImmutable(feature);
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/other/Utils.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/other/Utils.java
@@ -51,10 +51,10 @@ public class Utils {
    * @param feature A feature.
    * @return True if the specified set of values contains the feature, false otherwise.
    */
-  public static boolean contains(Set<Value> values, Feature feature) {
+  public static boolean contains(Set<Value<?>> values, Feature<?> feature) {
     Objects.requireNonNull(values, "Give me a set of values but not a null please!");
     Objects.requireNonNull(feature, "Give me a feature but not a null please!");
-    for (Value value : values) {
+    for (Value<?> value : values) {
       if (value.feature().equals(feature)) {
         return true;
       }
@@ -68,7 +68,7 @@ public class Utils {
    * @param features An array of features.
    * @return A set of unknown values for the specified features.
    */
-  public static Set<Value> allUnknown(Feature... features) {
+  public static Set<Value<?>> allUnknown(Feature<?>... features) {
     return allUnknown(Arrays.asList(features));
   }
 
@@ -78,10 +78,10 @@ public class Utils {
    * @param features A collection of features.
    * @return A set of unknown values for the specified features.
    */
-  public static Set<Value> allUnknown(Collection<Feature> features) {
+  public static Set<Value<?>> allUnknown(Collection<Feature<?>> features) {
     Objects.requireNonNull(features, "Hey! Give me features but not a null!");
-    Set<Value> values = new HashSet<>();
-    for (Feature feature : features) {
+    Set<Value<?>> values = new HashSet<>();
+    for (Feature<?> feature : features) {
       values.add(UnknownValue.of(feature));
     }
     return values;
@@ -95,7 +95,7 @@ public class Utils {
    * @param <T> A type of the data in the value.
    * @return An {@link Optional} with the value.
    */
-  public static <T> Optional<Value<T>> findValue(Set<Value> values, Feature<T> feature) {
+  public static <T> Optional<Value<T>> findValue(Set<Value<?>> values, Feature<T> feature) {
     return findValue(values.toArray(new Value[0]), feature);
   }
 
@@ -107,16 +107,16 @@ public class Utils {
    * @param <T> A type of the data in the value.
    * @return An {@link Optional} with the value.
    */
-  public static <T> Optional<Value<T>> findValue(List<Value> values, Feature<T> feature) {
+  public static <T> Optional<Value<T>> findValue(List<Value<?>> values, Feature<T> feature) {
     return findValue(values.toArray(new Value[0]), feature);
   }
 
-  private static <T> Optional<Value<T>> findValue(Value[] values, Feature<T> feature) {
+  private static <T> Optional<Value<T>> findValue(Value<?>[] values, Feature<T> feature) {
     Objects.requireNonNull(feature, "Oh no! Feature can't be null!");
     Objects.requireNonNull(values, "Oh no! Feature values can't be null!");
-    for (Value value : values) {
+    for (Value<?> value : values) {
       if (feature.equals(value.feature())) {
-        return Optional.of(value);
+        return Optional.of((Value<T>) value);
       }
     }
 
@@ -134,7 +134,9 @@ public class Utils {
    * @throws IllegalArgumentException with the specified error message
    *                                  if no value was found for the specified feature.
    */
-  public static <T> Value<T> findValue(Set<Value> values, Feature<T> feature, String errorMessage) {
+  public static <T> Value<T> findValue(
+      Set<Value<?>> values, Feature<T> feature, String errorMessage) {
+
     return findValue(values.toArray(new Value[0]), feature, errorMessage);
   }
 
@@ -149,7 +151,7 @@ public class Utils {
    * @throws IllegalArgumentException with the specified error message
    *                                  if no value was found for the specified feature.
    */
-  public static <T> Value<T> findValue(Value[] values, Feature<T> feature, String errorMessage) {
+  public static <T> Value<T> findValue(Value<?>[] values, Feature<T> feature, String errorMessage) {
     Optional<Value<T>> value = findValue(values, feature);
     if (!value.isPresent()) {
       throw new IllegalArgumentException(errorMessage);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/RatingVerification.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/RatingVerification.java
@@ -13,7 +13,7 @@ public class RatingVerification extends AbstractVerification {
   /**
    * A rating to be verified.
    */
-  private Rating rating;
+  private final Rating rating;
 
   /**
    * Initializes a {@link RatingVerification} for a {@link Rating}.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/ScoreTestVector.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/ScoreTestVector.java
@@ -59,18 +59,18 @@ public class ScoreTestVector extends AbstractTestVector {
   }
 
   @Override
-  public Set<Value> values() {
+  public Set<Value<?>> values() {
     throw new UnsupportedOperationException("I need a score to create values!");
   }
 
   @Override
-  public Set<Value> valuesFor(Score score) {
+  public Set<Value<?>> valuesFor(Score score) {
     Objects.requireNonNull(score, "Oh no! Score is null!");
 
-    Set<Value> result = new HashSet<>();
+    Set<Value<?>> result = new HashSet<>();
     for (Map.Entry<Class<? extends Score>, Double> entry : values.entrySet()) {
       Score subScore = subScore(score, entry.getKey());
-      Value value = subScore.value(entry.getValue());
+      Value<?> value = subScore.value(entry.getValue());
       result.add(value);
     }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/ScoreVerification.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/ScoreVerification.java
@@ -13,7 +13,7 @@ public class ScoreVerification extends AbstractVerification {
   /**
    * A score to be verified.
    */
-  private Score score;
+  private final Score score;
 
   /**
    * Initializes a {@link ScoreVerification} for a {@link Score}.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/StandardTestVector.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/StandardTestVector.java
@@ -19,7 +19,7 @@ public class StandardTestVector extends AbstractTestVector {
   /**
    * A set of feature values.
    */
-  private final Set<Value> values;
+  private final Set<Value<?>> values;
 
   /**
    * Initializes a new {@link StandardTestVector}.
@@ -30,7 +30,7 @@ public class StandardTestVector extends AbstractTestVector {
    * @param alias A alias of the test vector.
    */
   public StandardTestVector(
-      Set<Value> values, Interval expectedScore, Label expectedLabel, String alias) {
+      Set<Value<?>> values, Interval expectedScore, Label expectedLabel, String alias) {
 
     this(values, expectedScore, expectedLabel, alias, false, false);
   }
@@ -49,7 +49,7 @@ public class StandardTestVector extends AbstractTestVector {
    */
   @JsonCreator
   public StandardTestVector(
-      @JsonProperty("values") Set<Value> values,
+      @JsonProperty("values") Set<Value<?>> values,
       @JsonProperty("expectedScore") Interval expectedScore,
       @JsonProperty("expectedLabel") Label expectedLabel,
       @JsonProperty("alias") String alias,
@@ -73,12 +73,12 @@ public class StandardTestVector extends AbstractTestVector {
 
   @Override
   @JsonGetter("values")
-  public final Set<Value> values() {
+  public final Set<Value<?>> values() {
     return Collections.unmodifiableSet(values);
   }
 
   @Override
-  public Set<Value> valuesFor(Score score) {
+  public Set<Value<?>> valuesFor(Score score) {
     return values();
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/TestVector.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/TestVector.java
@@ -30,7 +30,7 @@ public interface TestVector {
    *
    * @return The values.
    */
-  Set<Value> values();
+  Set<Value<?>> values();
 
   /**
    * Returns the values resolved for a specified score.
@@ -38,7 +38,7 @@ public interface TestVector {
    * @param score The score.
    * @return The values.
    */
-  Set<Value> valuesFor(Score score);
+  Set<Value<?>> valuesFor(Score score);
 
   /**
    * Returns an expected interval for a score value.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/TestVectorBuilder.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/TestVectorBuilder.java
@@ -19,7 +19,7 @@ public class TestVectorBuilder {
   /**
    * A set of feature values.
    */
-  private final Set<Value> values = new HashSet<>();
+  private final Set<Value<?>> values = new HashSet<>();
 
   /**
    * An interval for an expected score.
@@ -134,9 +134,9 @@ public class TestVectorBuilder {
    * @param values A set of values to be set.
    * @return This instance of TestVectorBuilder.
    */
-  public TestVectorBuilder set(Set<Value> values) {
+  public TestVectorBuilder set(Set<Value<?>> values) {
     Objects.requireNonNull(values, "Hey! You have to give me a set of values but not a null!");
-    for (Value value : values) {
+    for (Value<?> value : values) {
       set(value);
     }
     return this;
@@ -148,7 +148,7 @@ public class TestVectorBuilder {
    * @param value A value to be set.
    * @return This instance of TestVectorBuilder.
    */
-  public TestVectorBuilder set(Value value) {
+  public TestVectorBuilder set(Value<?> value) {
     Objects.requireNonNull(value, "Hey! You have to give me a feature value but not null");
     boolean added = values.add(value);
     if (!added) {

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/TestVectorWithDefaults.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/TestVectorWithDefaults.java
@@ -22,7 +22,7 @@ public class TestVectorWithDefaults implements TestVector {
   /**
    * A set of default values.
    */
-  private final Set<Value> defaults;
+  private final Set<Value<?>> defaults;
 
   /**
    * Initializes a new wrapper.
@@ -30,7 +30,7 @@ public class TestVectorWithDefaults implements TestVector {
    * @param vector A test vector to be wrapped.
    * @param defaults A set of default values.
    */
-  TestVectorWithDefaults(TestVector vector, Set<Value> defaults) {
+  TestVectorWithDefaults(TestVector vector, Set<Value<?>> defaults) {
     Objects.requireNonNull(vector, "Hey! Vector can't be null!");
     Objects.requireNonNull(defaults, "Hey! Defaults can't be null!");
     this.vector = vector;
@@ -47,13 +47,13 @@ public class TestVectorWithDefaults implements TestVector {
   }
 
   @Override
-  public Set<Value> values() {
+  public Set<Value<?>> values() {
     ValueHashSet values = new ValueHashSet(vector.values());
     return extendedWithDefaults(values);
   }
 
   @Override
-  public Set<Value> valuesFor(Score score) {
+  public Set<Value<?>> valuesFor(Score score) {
     ValueHashSet values = new ValueHashSet(vector.valuesFor(score));
     return extendedWithDefaults(values);
   }
@@ -64,8 +64,8 @@ public class TestVectorWithDefaults implements TestVector {
    * @param values The value set to be extended.
    * @return An extended set of values.
    */
-  private Set<Value> extendedWithDefaults(ValueHashSet values) {
-    for (Value defaultValue : defaults) {
+  private Set<Value<?>> extendedWithDefaults(ValueHashSet values) {
+    for (Value<?> defaultValue : defaults) {
       if (!values.has(defaultValue.feature())) {
         values.update(defaultValue);
       }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/TestVectors.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/TestVectors.java
@@ -28,7 +28,7 @@ public class TestVectors implements Iterable<TestVector> {
   /**
    * No default values.
    */
-  private static final Set<Value> NO_DEFAULTS = Collections.emptySet();
+  private static final Set<Value<?>> NO_DEFAULTS = Collections.emptySet();
 
   /**
    * A factory for parsing YAML.
@@ -55,7 +55,7 @@ public class TestVectors implements Iterable<TestVector> {
   /**
    * A set of default values.
    */
-  private final Set<Value> defaults;
+  private final Set<Value<?>> defaults;
 
   /**
    * Initializes a new collection of test vectors.
@@ -74,7 +74,7 @@ public class TestVectors implements Iterable<TestVector> {
    */
   public TestVectors(
       @JsonProperty("elements") List<TestVector> vectors,
-      @JsonProperty("defaults") Set<Value> defaults) {
+      @JsonProperty("defaults") Set<Value<?>> defaults) {
 
     Objects.requireNonNull(vectors, "Hey! Vectors can't be null!");
     Objects.requireNonNull(defaults, "Hey! Defaults can't be null!");
@@ -144,7 +144,7 @@ public class TestVectors implements Iterable<TestVector> {
    * This getter is to make Jackson happy.
    */
   @JsonGetter("defaults")
-  private Set<Value> defaults() {
+  private Set<Value<?>> defaults() {
     return new HashSet<>(defaults);
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/rating/AbstractRating.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/rating/AbstractRating.java
@@ -42,12 +42,12 @@ public abstract class AbstractRating implements Rating {
   }
 
   @Override
-  public final RatingValue calculate(Set<Value> values) {
+  public final RatingValue calculate(Set<Value<?>> values) {
     return calculate(score.calculate(values));
   }
 
   @Override
-  public RatingValue calculate(Value... values) {
+  public RatingValue calculate(Value<?>... values) {
     return calculate(score.calculate(values));
   }
 
@@ -84,7 +84,7 @@ public abstract class AbstractRating implements Rating {
   }
 
   @Override
-  public Set<Feature> allFeatures() {
+  public Set<Feature<?>> allFeatures() {
     return score.allFeatures();
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/rating/example/SecurityRatingExampleVerification.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/rating/example/SecurityRatingExampleVerification.java
@@ -54,7 +54,7 @@ public class SecurityRatingExampleVerification extends RatingVerification {
       boolean securityReviewDone, boolean staticAnalysisDone,
       Interval expectedScore, Label expectedLabel) {
 
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(numberOfCommits));
     values.add(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(numberOfContributors));
     values.add(SECURITY_REVIEW_DONE_EXAMPLE.value(securityReviewDone));

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/AbstractScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/AbstractScore.java
@@ -88,7 +88,7 @@ public abstract class AbstractScore implements Score {
   }
 
   @Override
-  public ScoreValue calculate(Set<Value> values) {
+  public ScoreValue calculate(Set<Value<?>> values) {
     Objects.requireNonNull(values, "Hey! Values can't be null!");
     return calculate(values.toArray(new Value[0]));
   }
@@ -121,7 +121,7 @@ public abstract class AbstractScore implements Score {
   }
 
   @Override
-  public Set<Feature> allFeatures() {
+  public Set<Feature<?>> allFeatures() {
     return fillOutFeatures(this, new HashSet<>());
   }
 
@@ -170,7 +170,7 @@ public abstract class AbstractScore implements Score {
    * @param allFeatures A set of features to be filled out.
    * @return The specified set of features.
    */
-  private static Set<Feature> fillOutFeatures(Score score, Set<Feature> allFeatures) {
+  private static Set<Feature<?>> fillOutFeatures(Score score, Set<Feature<?>> allFeatures) {
     allFeatures.addAll(score.features());
     for (Score subScore : score.subScores()) {
       fillOutFeatures(subScore, allFeatures);
@@ -186,7 +186,7 @@ public abstract class AbstractScore implements Score {
    * @param usedValues The values which were used to produce the score value.
    * @return A new {@link ScoreValue}.
    */
-  protected ScoreValue scoreValue(double value, Value... usedValues) {
+  protected ScoreValue scoreValue(double value, Value<?>... usedValues) {
     return new ScoreValue(
         this,
         Score.adjust(value),
@@ -203,7 +203,7 @@ public abstract class AbstractScore implements Score {
    * @param usedValues The values which were used to produce the score value.
    * @return A new {@link ScoreValue}.
    */
-  protected ScoreValue scoreValue(double value, List<Value> usedValues) {
+  protected ScoreValue scoreValue(double value, List<Value<?>> usedValues) {
     return new ScoreValue(
         this,
         Score.adjust(value),
@@ -221,13 +221,13 @@ public abstract class AbstractScore implements Score {
    * @return A value for the specified feature if it's in the list.
    * @throws IllegalArgumentException If a value was not found.
    */
-  protected <T> Value<T> find(Feature<T> feature, Value... values) {
+  protected <T> Value<T> find(Feature<T> feature, Value<?>... values) {
     Objects.requireNonNull(values, "Oh no! Feature values can't be null!");
     Objects.requireNonNull(feature, "Oh no! Feature can't be null!");
 
-    for (Value value : values) {
+    for (Value<?> value : values) {
       if (feature.equals(value.feature())) {
-        return value;
+        return (Value<T>) value;
       }
     }
 
@@ -243,7 +243,7 @@ public abstract class AbstractScore implements Score {
    * @return The calculated score value.
    * @see #calculateIfNecessary(Score, ValueSet)
    */
-  protected static ScoreValue calculateIfNecessary(Score score, Value... values) {
+  protected static ScoreValue calculateIfNecessary(Score score, Value<?>... values) {
     return calculateIfNecessary(score, ValueHashSet.from(values));
   }
 
@@ -283,14 +283,14 @@ public abstract class AbstractScore implements Score {
    * @return True if all values are unknown, false otherwise.
    * @throws IllegalArgumentException If values are empty.
    */
-  protected static boolean allUnknown(Value... values) {
+  protected static boolean allUnknown(Value<?>... values) {
     Objects.requireNonNull(values, "Oh no! Values is null!");
 
     if (values.length == 0) {
       throw new IllegalStateException("Oh no! Values is empty!");
     }
 
-    for (Value value : values) {
+    for (Value<?> value : values) {
       if (!value.isUnknown()) {
         return false;
       }
@@ -306,14 +306,14 @@ public abstract class AbstractScore implements Score {
    * @return True if all values are N/A, false otherwise.
    * @throws IllegalArgumentException If values are empty.
    */
-  protected static boolean allNotApplicable(Value... values) {
+  protected static boolean allNotApplicable(Value<?>... values) {
     Objects.requireNonNull(values, "Oh no! Values is null!");
 
     if (values.length == 0) {
       throw new IllegalStateException("Oh no! Values is empty!");
     }
 
-    for (Value value : values) {
+    for (Value<?> value : values) {
       if (!value.isNotApplicable()) {
         return false;
       }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/AverageCompositeScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/AverageCompositeScore.java
@@ -63,7 +63,7 @@ public class AverageCompositeScore extends AbstractScore {
    * @return An empty set of features.
    */
   @Override
-  public Set<Feature> features() {
+  public Set<Feature<?>> features() {
     return Collections.emptySet();
   }
 
@@ -80,7 +80,7 @@ public class AverageCompositeScore extends AbstractScore {
    * @return An overall score.
    */
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     ValueHashSet valueSet = new ValueHashSet(values);
     ScoreValue scoreValue = new ScoreValue(this);
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/FeatureBasedScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/FeatureBasedScore.java
@@ -19,7 +19,7 @@ public abstract class FeatureBasedScore extends AbstractScore {
   /**
    * A set of features which are used in the score.
    */
-  private final Set<Feature> features;
+  private final Set<Feature<?>> features;
 
   /**
    * Initializes a feature-based score with an empty description.
@@ -27,7 +27,7 @@ public abstract class FeatureBasedScore extends AbstractScore {
    * @param name A name of the score.
    * @param features A number of features which are used in the score.
    */
-  public FeatureBasedScore(String name, Feature... features) {
+  public FeatureBasedScore(String name, Feature<?>... features) {
     this(name, EMPTY_DESCRIPTION, setOf(features));
   }
 
@@ -38,7 +38,7 @@ public abstract class FeatureBasedScore extends AbstractScore {
    * @param description A description of the score (may be empty).
    * @param features A number of features which are used in the score.
    */
-  public FeatureBasedScore(String name, String description, Feature... features) {
+  public FeatureBasedScore(String name, String description, Feature<?>... features) {
     this(name, description, setOf(features));
   }
 
@@ -49,9 +49,9 @@ public abstract class FeatureBasedScore extends AbstractScore {
    * @param description A description of the score (may be empty).
    * @param features A set of features which are used in the score.
    */
-  public FeatureBasedScore(String name, String description, Set<Feature> features) {
+  public FeatureBasedScore(String name, String description, Set<Feature<?>> features) {
     super(name, description);
-    for (Feature feature : features) {
+    for (Feature<?> feature : features) {
       if (feature instanceof Score) {
         throw new IllegalArgumentException("Hey! I cannot work with scores!");
       }
@@ -61,7 +61,7 @@ public abstract class FeatureBasedScore extends AbstractScore {
 
   @Override
   @JsonIgnore
-  public final Set<Feature> features() {
+  public final Set<Feature<?>> features() {
     return new HashSet<>(features);
   }
 
@@ -74,7 +74,7 @@ public abstract class FeatureBasedScore extends AbstractScore {
   @Override
   public void accept(Visitor visitor) {
     super.accept(visitor);
-    for (Feature feature : features) {
+    for (Feature<?> feature : features) {
       feature.accept(visitor);
     }
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/WeightedCompositeScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/WeightedCompositeScore.java
@@ -137,7 +137,7 @@ public class WeightedCompositeScore extends AbstractScore implements Tunable {
    * @return An overall score.
    */
   @Override
-  public final ScoreValue calculate(Value... values) {
+  public final ScoreValue calculate(Value<?>... values) {
     ValueHashSet valueSet = new ValueHashSet(values);
 
     double weightSum = 0.0;
@@ -188,7 +188,7 @@ public class WeightedCompositeScore extends AbstractScore implements Tunable {
    * @return An empty set of features.
    */
   @Override
-  public final Set<Feature> features() {
+  public final Set<Feature<?>> features() {
     return Collections.emptySet();
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/example/ProjectActivityScoreExample.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/example/ProjectActivityScoreExample.java
@@ -46,7 +46,7 @@ public class ProjectActivityScoreExample extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Integer> numberOfCommitsLastMonthValue = findValue(values,
         NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE,
         "Couldn't find number of commits last month!");

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/example/SecurityTestingScoreExample.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/example/SecurityTestingScoreExample.java
@@ -20,7 +20,7 @@ public class SecurityTestingScoreExample extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Boolean> securityReviewDone = findValue(values, SECURITY_REVIEW_DONE_EXAMPLE,
         "Couldn't find security review status!");
     Value<Boolean> staticCodeAnalysisDone = findValue(values, STATIC_CODE_ANALYSIS_DONE_EXAMPLE,

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/CodeqlScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/CodeqlScore.java
@@ -58,7 +58,7 @@ public class CodeqlScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Boolean> usesLgtmChecks = findValue(values, USES_LGTM_CHECKS,
         "Hey! You have to tell me if the project uses LGTM checks!");
     Value<Boolean> usesCodeqlChecks = findValue(values, USES_CODEQL_CHECKS,
@@ -90,15 +90,5 @@ public class CodeqlScore extends FeatureBasedScore {
     }
 
     return scoreValue;
-  }
-
-  /**
-   * Checks if at least one of the specified languages are supported by CodeQL.
-   *
-   * @param languages The languages to be checked.
-   * @return True if at least one of the specified languages are supported by CodeQL.
-   */
-  public static boolean containsSupportedLanguage(Languages languages) {
-    return SUPPORTED_LANGUAGES.containsAnyOf(languages);
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/CommunityCommitmentScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/CommunityCommitmentScore.java
@@ -33,7 +33,7 @@ public class CommunityCommitmentScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Boolean> hasResponsibleCompany = findValue(values, SUPPORTED_BY_COMPANY,
         "Hey! You have to tell me if the project is supported by a company or not!");
     Value<Boolean> isApacheProject = findValue(values, IS_APACHE,

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/DependabotScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/DependabotScore.java
@@ -84,7 +84,7 @@ public class DependabotScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Boolean> usesDependabot = find(USES_DEPENDABOT, values);
     Value<Boolean> usesGithub = find(USES_GITHUB_FOR_DEVELOPMENT, values);
     Value<Languages> languages = find(LANGUAGES, values);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/DependencyScanScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/DependencyScanScore.java
@@ -42,7 +42,7 @@ public class DependencyScanScore extends AbstractScore {
   }
 
   @Override
-  public Set<Feature> features() {
+  public Set<Feature<?>> features() {
     return Collections.emptySet();
   }
 
@@ -52,7 +52,7 @@ public class DependencyScanScore extends AbstractScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Objects.requireNonNull(values, "Oh no! Values is null!");
 
     ScoreValue dependabotScoreValue = calculateIfNecessary(dependabotScore, values);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/FindSecBugsScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/FindSecBugsScore.java
@@ -29,7 +29,7 @@ public class FindSecBugsScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Languages> languages = find(LANGUAGES, values);
     Value<Boolean> usesFindSecBugs = find(USES_FIND_SEC_BUGS, values);
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/FuzzingScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/FuzzingScore.java
@@ -36,7 +36,7 @@ public class FuzzingScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Languages> languages = find(LANGUAGES, values);
     Value<Boolean> fuzzedInOssFuzz = find(FUZZED_IN_OSS_FUZZ, values);
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/LgtmScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/LgtmScore.java
@@ -59,7 +59,7 @@ public class LgtmScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<LgtmGrade> worstLgtmGrade = findValue(values, WORST_LGTM_GRADE,
         "Hey! You have to tell me the worst LGTM grade for the project!");
     Value<Languages> languages = findValue(values, LANGUAGES,

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/MemorySafetyTestingScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/MemorySafetyTestingScore.java
@@ -66,7 +66,7 @@ public class MemorySafetyTestingScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Languages> languages = find(LANGUAGES, values);
     Value<Boolean> usesAddressSanitizer = find(USES_ADDRESS_SANITIZER, values);
     Value<Boolean> usesMemorySanitizer = find(USES_MEMORY_SANITIZER, values);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/NoHttpToolScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/NoHttpToolScore.java
@@ -33,7 +33,7 @@ public class NoHttpToolScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Boolean> usesNoHttp = findValue(values, USES_NOHTTP,
         "Hey! You have to tell me if the project uses nohttp tool!");
     Value<PackageManagers> packageManagers = findValue(values, PACKAGE_MANAGERS,

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/OwaspDependencyScanScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/OwaspDependencyScanScore.java
@@ -37,7 +37,7 @@ public class OwaspDependencyScanScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Double> thresholdValue = find(OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD, values);
     Value<OwaspDependencyCheckUsage> usageValue = find(OWASP_DEPENDENCY_CHECK_USAGE, values);
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectActivityScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectActivityScore.java
@@ -64,7 +64,7 @@ public class ProjectActivityScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Integer> commits = findValue(values, NUMBER_OF_COMMITS_LAST_THREE_MONTHS,
         "Hey! You have to give me a number of commits!");
     Value<Integer> contributors = findValue(values, NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS,

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectPopularityScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectPopularityScore.java
@@ -87,7 +87,7 @@ public class ProjectPopularityScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Integer> n = findValue(values, NUMBER_OF_GITHUB_STARS,
         "Hey! You have to give me a number of stars!");
     Value<Integer> m = findValue(values, NUMBER_OF_WATCHERS_ON_GITHUB,

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectSecurityAwarenessScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectSecurityAwarenessScore.java
@@ -143,7 +143,7 @@ public class ProjectSecurityAwarenessScore extends FeatureBasedScore {
   /**
    * Features that tell if a project uses specific security tools.
    */
-  private static final Feature[] SECURITY_TOOLS_FEATURES = new Feature[] {
+  private static final Feature<?>[] SECURITY_TOOLS_FEATURES = new Feature[] {
       FUZZED_IN_OSS_FUZZ,
       USES_DEPENDABOT,
       USES_NOHTTP, USES_LGTM_CHECKS, USES_FIND_SEC_BUGS,
@@ -163,18 +163,18 @@ public class ProjectSecurityAwarenessScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Boolean> securityPolicy = find(HAS_SECURITY_POLICY, values);
     Value<Boolean> securityTeam = find(HAS_SECURITY_TEAM, values);
     Value<Boolean> signedCommits = find(USES_SIGNED_COMMITS, values);
     Value<Boolean> hasBugBountyProgram = find(HAS_BUG_BOUNTY_PROGRAM, values);
     Value<Boolean> signsArtifacts = find(SIGNS_ARTIFACTS, values);
 
-    List<Value> securityToolsValues = new ArrayList<>();
+    List<Value<?>> securityToolsValues = new ArrayList<>();
     Arrays.stream(SECURITY_TOOLS_FEATURES)
         .forEach(feature -> securityToolsValues.add(find(feature, values)));
 
-    List<Value> usedValues = new ArrayList<>();
+    List<Value<?>> usedValues = new ArrayList<>();
     usedValues.addAll(Arrays.asList(
         securityPolicy, securityTeam, signedCommits, hasBugBountyProgram, signsArtifacts));
     usedValues.addAll(securityToolsValues);
@@ -226,7 +226,7 @@ public class ProjectSecurityAwarenessScore extends FeatureBasedScore {
    * @return True if a value means that one of the security tools is used, false otherwise.
    * @throws IllegalArgumentException In case of an unexpected type of the value.
    */
-  private static boolean usedSecurityTools(Value value) {
+  private static boolean usedSecurityTools(Value<?> value) {
     if (value.isUnknown()) {
       return false;
     }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/UnpatchedVulnerabilitiesScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/UnpatchedVulnerabilitiesScore.java
@@ -54,7 +54,7 @@ public class UnpatchedVulnerabilitiesScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Vulnerabilities> vulnerabilities = findValue(values, VULNERABILITIES,
         "Hey! Give me info about vulnerabilities!");
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/VulnerabilityDiscoveryAndSecurityTestingScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/VulnerabilityDiscoveryAndSecurityTestingScore.java
@@ -105,7 +105,7 @@ public class VulnerabilityDiscoveryAndSecurityTestingScore extends AbstractScore
   }
 
   @Override
-  public Set<Feature> features() {
+  public Set<Feature<?>> features() {
     return setOf(VULNERABILITIES);
   }
 
@@ -115,7 +115,7 @@ public class VulnerabilityDiscoveryAndSecurityTestingScore extends AbstractScore
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Objects.requireNonNull(values, "Oh no! Values is null");
 
     Value<Vulnerabilities> vulnerabilities = findValue(values, VULNERABILITIES,

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScore.java
@@ -62,7 +62,7 @@ public class VulnerabilityLifetimeScore extends FeatureBasedScore {
   }
 
   @Override
-  public ScoreValue calculate(Value... values) {
+  public ScoreValue calculate(Value<?>... values) {
     Value<Vulnerabilities> vulnerabilities = findValue(values, VULNERABILITIES,
         "Hey! Give me info about vulnerabilities!");
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/tuning/AbstractTuning.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/tuning/AbstractTuning.java
@@ -70,7 +70,7 @@ public abstract class AbstractTuning {
         logger.info("    expected label: {}", result.vector.expectedLabel());
         logger.info("    features:");
 
-        for (Value value : result.vector.values()) {
+        for (Value<?> value : result.vector.values()) {
           logger.info("      {}: {}",
               value.feature().name(), value.isUnknown() ? "unknown" : value.get());
         }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/AbstractValue.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/AbstractValue.java
@@ -29,7 +29,7 @@ public abstract class AbstractValue<T> implements Value<T> {
 
   @Override
   @JsonGetter("feature")
-  public final Feature feature() {
+  public final Feature<T> feature() {
     return feature;
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/ExpiringValue.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/ExpiringValue.java
@@ -45,7 +45,7 @@ public class ExpiringValue<T> implements Value<T> {
   }
 
   @Override
-  public Feature feature() {
+  public Feature<T> feature() {
     return value.feature();
   }
 
@@ -118,7 +118,7 @@ public class ExpiringValue<T> implements Value<T> {
    * @return The original feature value.
    */
   @JsonGetter("value")
-  public Value original() {
+  public Value<T> original() {
     return value;
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/LgtmGradeValue.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/LgtmGradeValue.java
@@ -21,7 +21,7 @@ public class LgtmGradeValue extends AbstractValue<LgtmGrade> {
    */
   @JsonCreator
   public LgtmGradeValue(
-      @JsonProperty("feature") Feature feature,
+      @JsonProperty("feature") Feature<LgtmGrade> feature,
       @JsonProperty("value") LgtmGrade value) {
 
     super(feature);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/NotApplicableValue.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/NotApplicableValue.java
@@ -25,7 +25,7 @@ public final class NotApplicableValue<T> extends AbstractValue<T> {
    *
    * @param feature The feature.
    */
-  public NotApplicableValue(@JsonProperty("feature") Feature feature) {
+  public NotApplicableValue(@JsonProperty("feature") Feature<T> feature) {
     super(feature);
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/ValueHashSet.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/ValueHashSet.java
@@ -36,7 +36,7 @@ public class ValueHashSet implements ValueSet {
   /**
    * A mapping from a feature to its value.
    */
-  private final Map<Feature, Value> featureToValue = new HashMap<>();
+  private final Map<Feature<?>, Value<?>> featureToValue = new HashMap<>();
 
   /**
    * Initializes a new {@link ValueHashSet} with a number of values.
@@ -44,7 +44,7 @@ public class ValueHashSet implements ValueSet {
    * @param values The values.
    * @return The new {@link ValueHashSet}.
    */
-  public static ValueHashSet from(Value... values) {
+  public static ValueHashSet from(Value<?>... values) {
     Objects.requireNonNull(values, "Values can't be null!");
     return new ValueHashSet(values);
   }
@@ -61,7 +61,7 @@ public class ValueHashSet implements ValueSet {
    *
    * @param values The values.
    */
-  public ValueHashSet(Set<Value> values) {
+  public ValueHashSet(Set<Value<?>> values) {
     this(Objects.requireNonNull(values, "Values can't be null!").toArray(new Value[0]));
   }
 
@@ -70,9 +70,9 @@ public class ValueHashSet implements ValueSet {
    *
    * @param values The values.
    */
-  public ValueHashSet(Value... values) {
+  public ValueHashSet(Value<?>... values) {
     Objects.requireNonNull(values, "Values can't be null!");
-    for (Value value : values) {
+    for (Value<?> value : values) {
       update(value);
     }
   }
@@ -92,9 +92,9 @@ public class ValueHashSet implements ValueSet {
    * @param features A collection of features.
    * @return An instance of {@link ValueHashSet}.
    */
-  public static ValueHashSet unknown(Collection<Feature> features) {
+  public static ValueHashSet unknown(Collection<Feature<?>> features) {
     ValueHashSet values = empty();
-    for (Feature feature : features) {
+    for (Feature<?> feature : features) {
       if (values.has(feature)) {
         throw new IllegalArgumentException(String.format(
             "Hey! You just gave me a duplicate feature: %s", feature));
@@ -110,7 +110,7 @@ public class ValueHashSet implements ValueSet {
    * @param features A number of features.
    * @return An instance of {@link ValueHashSet}.
    */
-  public static ValueHashSet unknown(Feature... features) {
+  public static ValueHashSet unknown(Feature<?>... features) {
     return unknown(Arrays.asList(features));
   }
 
@@ -121,9 +121,9 @@ public class ValueHashSet implements ValueSet {
   }
 
   @Override
-  public ValueSet update(Value... values) {
+  public ValueSet update(Value<?>... values) {
     Objects.requireNonNull(values, "Oh no! Values is null!");
-    for (Value value : values) {
+    for (Value<?> value : values) {
       featureToValue.put(value.feature(), value);
     }
     return this;
@@ -132,14 +132,14 @@ public class ValueHashSet implements ValueSet {
   @Override
   public ValueSet update(ValueSet values) {
     Objects.requireNonNull(values, "Oh no! Values is null!");
-    for (Value value : values.toArray()) {
+    for (Value<?> value : values.toArray()) {
       update(value);
     }
     return this;
   }
 
   @Override
-  public ValueSet update(Set<Value> values) {
+  public ValueSet update(Set<Value<?>> values) {
     Objects.requireNonNull(values, "Oh no! Values is null!");
     return update(values.toArray(new Value[0]));
   }
@@ -160,7 +160,7 @@ public class ValueHashSet implements ValueSet {
    *
    * @return A set with values.
    */
-  public Set<Value> toSet() {
+  public Set<Value<?>> toSet() {
     return new HashSet<>(featureToValue.values());
   }
 
@@ -171,7 +171,7 @@ public class ValueHashSet implements ValueSet {
 
   @Override
   public <T> Optional<Value<T>> of(Feature<T> feature) {
-    Value<T> value = featureToValue.get(feature);
+    Value<T> value = (Value<T>) featureToValue.get(feature);
     if (value == null) {
       return Optional.empty();
     }
@@ -201,7 +201,7 @@ public class ValueHashSet implements ValueSet {
   }
 
   @Override
-  public boolean containsAll(Set<Feature> features) {
+  public boolean containsAll(Set<Feature<?>> features) {
     Objects.requireNonNull(features, "Oh no! Features is null");
     return featureToValue.keySet().containsAll(features);
   }
@@ -236,9 +236,9 @@ public class ValueHashSet implements ValueSet {
       WritableTypeId typeId = typeSer.typeId(valueHashSet,JsonToken.START_ARRAY);
       typeSer.writeTypePrefix(gen, typeId);
 
-      for (Map.Entry<Feature, Value> entry : valueHashSet.featureToValue.entrySet()) {
-        Feature feature = entry.getKey();
-        Value value = entry.getValue();
+      for (Map.Entry<Feature<?>, Value<?>> entry : valueHashSet.featureToValue.entrySet()) {
+        Feature<?> feature = entry.getKey();
+        Value<?> value = entry.getValue();
         if (!feature.equals(value.feature())) {
           throw new IllegalArgumentException("Feature doesn't match!");
         }
@@ -272,8 +272,8 @@ public class ValueHashSet implements ValueSet {
 
       ValueHashSet valueHashSet = new ValueHashSet();
 
-      Value[] values = jsonParser.getCodec().readValue(jsonParser, Value[].class);
-      for (Value value : values) {
+      Value<?>[] values = jsonParser.getCodec().readValue(jsonParser, Value[].class);
+      for (Value<?> value : values) {
         valueHashSet.update(value);
       }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/weight/ScoreWeights.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/weight/ScoreWeights.java
@@ -201,11 +201,7 @@ public class ScoreWeights implements Tunable {
 
   @Override
   public List<Weight> parameters() {
-    List<Weight> parameters = new ArrayList<>();
-    for (Weight weight : values.values()) {
-      parameters.add(weight);
-    }
-    return parameters;
+    return new ArrayList<>(values.values());
   }
 
   @Override

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/GitHubProjectValueCache.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/GitHubProjectValueCache.java
@@ -38,7 +38,15 @@ public class GitHubProjectValueCache implements ValueCache<GitHubProject> {
     this.cache = Objects.requireNonNull(cache, "Unfortunately cache can't be null");
   }
 
-  public Optional<Value> get(GitHubProject project, Feature feature) {
+  /**
+   * Looks for a feature value for a specified project.
+   *
+   * @param project The project.
+   * @param feature The feature.
+   * @param <T> Type of data.
+   * @return An {@link Optional} with the feature value if it's in the cache.
+   */
+  public <T> Optional<Value<T>> get(GitHubProject project, Feature<T> feature) {
     return cache.get(project.scm().toString(), feature);
   }
 
@@ -47,11 +55,26 @@ public class GitHubProjectValueCache implements ValueCache<GitHubProject> {
     return cache.get(project.scm().toString());
   }
 
-  public void put(GitHubProject project, Value value) {
+  /**
+   * Store a value for a GitHub project.
+   *
+   * @param project The project.
+   * @param value The value.
+   * @param <T> A type of the value.
+   */
+  public <T> void put(GitHubProject project, Value<T> value) {
     cache.put(project.scm().toString(), value);
   }
 
-  public void put(GitHubProject project, Value value, Date expiration) {
+  /**
+   * Store a value with an expiration data for a GitHub project.
+   *
+   * @param project The project.
+   * @param value The value.
+   * @param expiration The expiration date.
+   * @param <T> A type of the value.
+   */
+  public <T> void put(GitHubProject project, Value<T> value, Date expiration) {
     cache.put(project.scm().toString(), value, expiration);
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/MavenScmFinder.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/MavenScmFinder.java
@@ -9,6 +9,7 @@ import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Optional;
@@ -49,7 +50,7 @@ public class MavenScmFinder {
   /**
    * The default charset.
    */
-  private static final Charset CHARSET = Charset.forName("UTF-8");
+  private static final Charset CHARSET = StandardCharsets.UTF_8;
 
   /**
    * Takes GAV coordinates of an artifact and looks for a URL to its SCM.
@@ -152,12 +153,7 @@ public class MavenScmFinder {
       return project;
     }
 
-    project = guessEclipseProjectFor(groupId, artifactId);
-    if (project.isPresent()) {
-      return project;
-    }
-
-    return Optional.empty();
+    return guessEclipseProjectFor(groupId, artifactId);
   }
 
   /**

--- a/src/test/java/com/sap/oss/phosphor/fosstars/TestUtils.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/TestUtils.java
@@ -24,7 +24,7 @@ public class TestUtils {
    * @param score The score.
    * @param values The values.
    */
-  public static void assertScore(double expectedScoreValue, Score score, Set<Value> values) {
+  public static void assertScore(double expectedScoreValue, Score score, Set<Value<?>> values) {
     ScoreValue scoreValue = score.calculate(values);
     assertEquals(expectedScoreValue, scoreValue.get(), DELTA);
     assertEquals(values.size(), scoreValue.usedValues().size());
@@ -41,7 +41,7 @@ public class TestUtils {
    * @param score The score.
    * @param values The values.
    */
-  public static void assertScore(Interval expectedInterval, Score score, Set<Value> values) {
+  public static void assertScore(Interval expectedInterval, Score score, Set<Value<?>> values) {
     ScoreValue scoreValue = score.calculate(values);
     assertTrue(expectedInterval.contains(scoreValue.get()));
     assertTrue(Confidence.INTERVAL.contains(scoreValue.confidence()));

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/AbstractCachingDataProviderTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/AbstractCachingDataProviderTest.java
@@ -99,7 +99,7 @@ public class AbstractCachingDataProviderTest {
     }
 
     @Override
-    protected Set<Feature> supportedFeatures() {
+    protected Set<Feature<?>> supportedFeatures() {
       return Collections.singleton(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
     }
 
@@ -121,7 +121,7 @@ public class AbstractCachingDataProviderTest {
     }
 
     @Override
-    protected Set<Feature> supportedFeatures() {
+    protected Set<Feature<?>> supportedFeatures() {
       return setOf(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, SECURITY_REVIEW_DONE_EXAMPLE);
     }
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/StandardValueCacheTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/StandardValueCacheTest.java
@@ -74,7 +74,7 @@ public class StandardValueCacheTest {
     assertEquals(2, cache.size());
   }
 
-  private static void testPutAndGet(StandardValueCache cache, String key, Value value) {
+  private static <T> void testPutAndGet(StandardValueCache cache, String key, Value<T> value) {
     cache.put(key, value);
 
     Optional<ValueSet> someValueSet = cache.get(key);
@@ -84,7 +84,7 @@ public class StandardValueCacheTest {
     assertTrue(values.of(value.feature()).isPresent());
     assertEquals(value, values.of(value.feature()).get());
 
-    Optional<Value> someValue = cache.get(key, value.feature());
+    Optional<Value<T>> someValue = cache.get(key, value.feature());
     assertTrue(someValue.isPresent());
     assertEquals(value, someValue.get());
   }
@@ -96,7 +96,8 @@ public class StandardValueCacheTest {
     Value<Integer> value = NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(0);
     Date inTwoSecond = new Date(System.currentTimeMillis() + 2 * 1000);
     cache.put("test", value, inTwoSecond);
-    Optional<Value> something = cache.get("test", NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE);
+    Optional<Value<Integer>> something
+        = cache.get("test", NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE);
     assertTrue(something.isPresent());
     Thread.sleep(5000); // sleep for 5 seconds
     something = cache.get("test", NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE);

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/CodeqlDataProviderTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/CodeqlDataProviderTest.java
@@ -37,7 +37,7 @@ public class CodeqlDataProviderTest extends TestGitHubDataFetcherHolder {
 
   @Test
   public void testSupportedFeatures() {
-    Set<Feature> features = new CodeqlDataProvider(fetcher).supportedFeatures();
+    Set<Feature<?>> features = new CodeqlDataProvider(fetcher).supportedFeatures();
     assertEquals(2, features.size());
     assertThat(features, hasItem(RUNS_CODEQL_SCANS));
     assertThat(features, hasItem(USES_CODEQL_CHECKS));

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/UsesOwaspDependencyCheckTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/UsesOwaspDependencyCheckTest.java
@@ -212,7 +212,7 @@ public class UsesOwaspDependencyCheckTest extends TestGitHubDataFetcherHolder {
     ValueSet values = new ValueHashSet();
     provider.update(project, values);
 
-    Set<Feature> features = provider.supportedFeatures();
+    Set<Feature<?>> features = provider.supportedFeatures();
     assertEquals(features.size(), values.size());
     assertTrue(values.containsAll(features));
     return values;

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/RatingVerificationTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/RatingVerificationTest.java
@@ -21,7 +21,7 @@ public class RatingVerificationTest {
   public void successfulVerification() throws VerificationFailedException {
     SecurityRatingExample rating = RatingRepository.INSTANCE.rating(SecurityRatingExample.class);
 
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(0));
     values.add(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(0));
     values.add(SECURITY_REVIEW_DONE_EXAMPLE.value(false));
@@ -39,7 +39,7 @@ public class RatingVerificationTest {
   public void failedVerification() throws VerificationFailedException {
     SecurityRatingExample rating = RatingRepository.INSTANCE.rating(SecurityRatingExample.class);
 
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(0));
     values.add(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(0));
     values.add(SECURITY_REVIEW_DONE_EXAMPLE.value(false));

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/ScoreTestVectorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/ScoreTestVectorTest.java
@@ -43,7 +43,7 @@ public class ScoreTestVectorTest {
     ScoreTestVector vector = new ScoreTestVector(
         values, expectedScore, null, "test", false, false);
 
-    Set<Value> set = vector.valuesFor(ExampleScores.SECURITY_SCORE_EXAMPLE);
+    Set<Value<?>> set = vector.valuesFor(ExampleScores.SECURITY_SCORE_EXAMPLE);
     assertNotNull(set);
     assertEquals(2, set.size());
     assertTrue(set.contains(ExampleScores.PROJECT_ACTIVITY_SCORE_EXAMPLE.value(5.3)));

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/ScoreVerificationTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/ScoreVerificationTest.java
@@ -19,7 +19,7 @@ public class ScoreVerificationTest {
   public void successfulVerification() throws VerificationFailedException {
     SecurityRatingExample rating = RatingRepository.INSTANCE.rating(SecurityRatingExample.class);
 
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(0));
     values.add(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(0));
     values.add(SECURITY_REVIEW_DONE_EXAMPLE.value(false));
@@ -37,7 +37,7 @@ public class ScoreVerificationTest {
   public void failedVerification() throws VerificationFailedException {
     SecurityRatingExample rating = RatingRepository.INSTANCE.rating(SecurityRatingExample.class);
 
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(0));
     values.add(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(0));
     values.add(SECURITY_REVIEW_DONE_EXAMPLE.value(false));

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/StandardTestVectorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/qa/StandardTestVectorTest.java
@@ -34,7 +34,7 @@ public class StandardTestVectorTest {
 
   @Test
   public void smoke() {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 1));
     Interval expectedScore = DoubleInterval.init().from(4.0).to(6.4).closed().make();
     StandardTestVector vector = new StandardTestVector(
@@ -61,21 +61,21 @@ public class StandardTestVectorTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void emptyValues() {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     Interval expectedScore = DoubleInterval.init().from(4.0).to(6.4).closed().make();
     new StandardTestVector(values, expectedScore, SecurityLabelExample.OKAY, "test");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void noExpectedScore() {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 1));
     new StandardTestVector(values, NO_EXPECTED_SCORE, SecurityLabelExample.OKAY, "test");
   }
 
   @Test
   public void notApplicableScore() {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 1));
     new StandardTestVector(
         values, NO_EXPECTED_SCORE, SecurityLabelExample.OKAY, "test", IS_KNOWN, NOT_APPLICABLE);
@@ -83,7 +83,7 @@ public class StandardTestVectorTest {
 
   @Test
   public void noLabel() {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 1));
     Interval expectedScore = DoubleInterval.init().from(4.0).to(6.4).closed().make();
     StandardTestVector vector = new StandardTestVector(
@@ -166,7 +166,7 @@ public class StandardTestVectorTest {
 
   @Test
   public void yamlSerializeAndDeserialize() throws IOException {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 1));
     Interval expectedScore = DoubleInterval.init().from(4.0).to(6.4).closed().make();
     StandardTestVector vector = new StandardTestVector(
@@ -185,7 +185,7 @@ public class StandardTestVectorTest {
 
   @Test
   public void jsonSerializeAndDeserialize() throws IOException {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 1));
     Interval expectedScore = DoubleInterval.init().from(4.0).to(6.4).closed().make();
     StandardTestVector vector = new StandardTestVector(
@@ -202,7 +202,7 @@ public class StandardTestVectorTest {
 
   @Test
   public void jsonSerializeAndDeserializeWithNotApplicableScoreValue() throws IOException {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 1));
     StandardTestVector vector = new StandardTestVector(
         values, null, SecurityLabelExample.OKAY, "test", false, true);

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/rating/example/SecurityRatingExampleTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/rating/example/SecurityRatingExampleTest.java
@@ -40,7 +40,7 @@ public class SecurityRatingExampleTest {
 
   @Test
   public void testCalculate() {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 7));
     values.add(new IntegerValue(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE, 2));
     values.add(new BooleanValue(SECURITY_REVIEW_DONE_EXAMPLE, true));
@@ -64,7 +64,7 @@ public class SecurityRatingExampleTest {
   @Test
   public void testAllFeatures() {
     Rating rating = RatingRepository.INSTANCE.rating(SecurityRatingExample.class);
-    Set<Feature> features = rating.allFeatures();
+    Set<Feature<?>> features = rating.allFeatures();
     assertNotNull(features);
     assertEquals(4, features.size());
     assertTrue(features.contains(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE));

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/rating/oss/OssSecurityRatingTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/rating/oss/OssSecurityRatingTest.java
@@ -29,7 +29,7 @@ public class OssSecurityRatingTest {
   @Test
   public void testCalculate() {
     Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
-    Set<Value> values = Utils.allUnknown(rating.allFeatures());
+    Set<Value<?>> values = Utils.allUnknown(rating.allFeatures());
     RatingValue ratingValue = rating.calculate(values);
     assertTrue(Score.INTERVAL.contains(ratingValue.score()));
     assertEquals(UNCLEAR, ratingValue.label());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/AbstractScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/AbstractScoreTest.java
@@ -39,7 +39,7 @@ public class AbstractScoreTest {
     }
 
     @Override
-    public Set<Feature> features() {
+    public Set<Feature<?>> features() {
       return setOf(
           ExampleFeatures.STATIC_CODE_ANALYSIS_DONE_EXAMPLE,
           ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE);
@@ -51,7 +51,7 @@ public class AbstractScoreTest {
     }
 
     @Override
-    public ScoreValue calculate(Value... values) {
+    public ScoreValue calculate(Value<?>... values) {
       return scoreValue(1.23);
     }
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/AverageCompositeScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/AverageCompositeScoreTest.java
@@ -130,7 +130,7 @@ public class AverageCompositeScoreTest {
     assertFalse(scoreValue.isNotApplicable());
     assertEquals(Confidence.MAX, scoreValue.confidence(), PRECISION);
 
-    List<Value> usedValues = scoreValue.usedValues();
+    List<Value<?>> usedValues = scoreValue.usedValues();
     usedValues.sort(Comparator.comparing(a -> a.feature().name()));
 
     assertEquals(2, usedValues.size());
@@ -163,7 +163,7 @@ public class AverageCompositeScoreTest {
 
     private boolean returnsNotApplicable = false;
 
-    AbstractTestScore(String name, Feature... features) {
+    AbstractTestScore(String name, Feature<?>... features) {
       super(name, features);
     }
 
@@ -173,7 +173,7 @@ public class AverageCompositeScoreTest {
     }
 
     @Override
-    public ScoreValue calculate(Value... values) {
+    public ScoreValue calculate(Value<?>... values) {
       ScoreValue value = calculateImpl(values);
       if (returnsNotApplicable) {
         return value.makeNotApplicable();
@@ -181,7 +181,7 @@ public class AverageCompositeScoreTest {
       return value;
     }
 
-    abstract ScoreValue calculateImpl(Value... values);
+    abstract ScoreValue calculateImpl(Value<?>... values);
 
     @Override
     public int hashCode() {
@@ -205,7 +205,7 @@ public class AverageCompositeScoreTest {
     }
 
     @Override
-    public ScoreValue calculateImpl(Value... values) {
+    public ScoreValue calculateImpl(Value<?>... values) {
       return scoreValue(VALUE, values).confidence(Confidence.MAX);
     }
   }
@@ -221,7 +221,7 @@ public class AverageCompositeScoreTest {
     }
 
     @Override
-    public ScoreValue calculateImpl(Value... values) {
+    public ScoreValue calculateImpl(Value<?>... values) {
       return scoreValue(VALUE, values).confidence(Confidence.MAX);
     }
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/WeightedCompositeScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/WeightedCompositeScoreTest.java
@@ -67,7 +67,7 @@ public class WeightedCompositeScoreTest {
     assertEquals(expectedScore, scoreValue.get(), PRECISION);
     assertEquals(Confidence.MAX, scoreValue.confidence(), PRECISION);
     assertEquals(2, scoreValue.usedValues().size());
-    for (Value value : scoreValue.usedValues()) {
+    for (Value<?> value : scoreValue.usedValues()) {
       if (value.feature() instanceof FirstScore) {
         assertEquals(firstScoreValue, value.get());
         continue;
@@ -288,7 +288,7 @@ public class WeightedCompositeScoreTest {
     assertFalse(scoreValue.isNotApplicable());
     assertEquals(Confidence.MAX, scoreValue.confidence(), PRECISION);
 
-    List<Value> usedValues = scoreValue.usedValues();
+    List<Value<?>> usedValues = scoreValue.usedValues();
     usedValues.sort(Comparator.comparing(a -> a.feature().name()));
 
     assertEquals(2, usedValues.size());
@@ -356,7 +356,7 @@ public class WeightedCompositeScoreTest {
     private boolean returnsNotApplicable = false;
     private boolean returnUnknown = false;
 
-    AbstractTestScore(String name, Feature... features) {
+    AbstractTestScore(String name, Feature<?>... features) {
       super(name, features);
     }
 
@@ -371,7 +371,7 @@ public class WeightedCompositeScoreTest {
     }
 
     @Override
-    public ScoreValue calculate(Value... values) {
+    public ScoreValue calculate(Value<?>... values) {
       if (returnsNotApplicable) {
         return scoreValue(MIN, values)
             .confidence(Confidence.make(values))
@@ -385,7 +385,7 @@ public class WeightedCompositeScoreTest {
       return calculateImpl(values);
     }
 
-    abstract ScoreValue calculateImpl(Value... values);
+    abstract ScoreValue calculateImpl(Value<?>... values);
 
     @Override
     public int hashCode() {
@@ -409,7 +409,7 @@ public class WeightedCompositeScoreTest {
     }
 
     @Override
-    public ScoreValue calculateImpl(Value... values) {
+    public ScoreValue calculateImpl(Value<?>... values) {
       return scoreValue(VALUE, values).confidence(Confidence.MAX);
     }
   }
@@ -425,7 +425,7 @@ public class WeightedCompositeScoreTest {
     }
 
     @Override
-    public ScoreValue calculateImpl(Value... values) {
+    public ScoreValue calculateImpl(Value<?>... values) {
       return scoreValue(VALUE, values).confidence(Confidence.MAX);
     }
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/example/ProjectActivityScoreExampleTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/example/ProjectActivityScoreExampleTest.java
@@ -31,7 +31,7 @@ public class ProjectActivityScoreExampleTest {
 
   @Test
   public void calculate() {
-    Set<Value> values = makeValues(1, 2);
+    Set<Value<?>> values = makeValues(1, 2);
     assertTrue(Score.INTERVAL.contains(PROJECT_ACTIVITY_SCORE_EXAMPLE.calculate(values).get()));
     values = makeValues(0, 0);
     assertTrue(Score.INTERVAL.contains(PROJECT_ACTIVITY_SCORE_EXAMPLE.calculate(values).get()));
@@ -42,7 +42,7 @@ public class ProjectActivityScoreExampleTest {
   @Test(expected = IllegalArgumentException.class)
   public void negativeCommitsNumber() {
     ProjectActivityScoreExample score = PROJECT_ACTIVITY_SCORE_EXAMPLE;
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, -1));
     values.add(new IntegerValue(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE, 11));
     Score.INTERVAL.contains(score.calculate(values).get());
@@ -50,7 +50,7 @@ public class ProjectActivityScoreExampleTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void negativeContributorsNumber() {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 11));
     values.add(new IntegerValue(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE, -1));
     Score.INTERVAL.contains(PROJECT_ACTIVITY_SCORE_EXAMPLE.calculate(values).get());
@@ -58,22 +58,22 @@ public class ProjectActivityScoreExampleTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void noCommitsNumber() {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE, 11));
     Score.INTERVAL.contains(PROJECT_ACTIVITY_SCORE_EXAMPLE.calculate(values).get());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void noContributorsNumber() {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 11));
     Score.INTERVAL.contains(PROJECT_ACTIVITY_SCORE_EXAMPLE.calculate(values).get());
   }
 
-  private static Set<Value> makeValues(
+  private static Set<Value<?>> makeValues(
       int numberOfCommitsLastMonth, int numberOfContributorsLastMonth) {
 
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(numberOfCommitsLastMonth));
     values.add(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(numberOfContributorsLastMonth));
     return values;

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/CommunityCommitmentScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/CommunityCommitmentScoreTest.java
@@ -47,7 +47,7 @@ public class CommunityCommitmentScoreTest {
     assertScore(Score.MAX, COMMUNITY_COMMITMENT, values(true, false, true));
   }
 
-  private static Set<Value> values(boolean company, boolean apache, boolean eclipse) {
+  private static Set<Value<?>> values(boolean company, boolean apache, boolean eclipse) {
     return setOf(
         SUPPORTED_BY_COMPANY.value(company), IS_APACHE.value(apache), IS_ECLIPSE.value(eclipse));
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
@@ -84,7 +84,7 @@ public class OssSecurityScoreTest {
   @Test
   public void calculate() {
     Score score = new OssSecurityScore();
-    Set<Value> values = setOf(
+    Set<Value<?>> values = setOf(
         SUPPORTED_BY_COMPANY.value(false),
         IS_APACHE.value(true),
         IS_ECLIPSE.value(false),

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectActivityScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectActivityScoreTest.java
@@ -111,7 +111,7 @@ public class ProjectActivityScoreTest {
     assertFalse(PROJECT_ACTIVITY.description().isEmpty());
   }
 
-  private static Set<Value> values(int commits, int contributors) {
+  private static Set<Value<?>> values(int commits, int contributors) {
     return setOf(
         NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(commits),
         NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS.value(contributors));

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectPopularityScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectPopularityScoreTest.java
@@ -98,7 +98,7 @@ public class ProjectPopularityScoreTest {
     assertFalse(PROJECT_POPULARITY.description().isEmpty());
   }
 
-  private static Set<Value> values(int stars, int watchers) {
+  private static Set<Value<?>> values(int stars, int watchers) {
     return setOf(
         NUMBER_OF_GITHUB_STARS.value(stars),
         NUMBER_OF_WATCHERS_ON_GITHUB.value(watchers));

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectSecurityAwarenessScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectSecurityAwarenessScoreTest.java
@@ -23,7 +23,7 @@ public class ProjectSecurityAwarenessScoreTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testWithoutEnoughInfo() {
-    Set<Value> values = Utils.allUnknown(PROJECT_SECURITY_AWARENESS_SCORE.allFeatures());
+    Set<Value<?>> values = Utils.allUnknown(PROJECT_SECURITY_AWARENESS_SCORE.allFeatures());
     values.remove(HAS_SECURITY_TEAM.unknown());
     PROJECT_SECURITY_AWARENESS_SCORE.calculate(values);
   }
@@ -36,7 +36,7 @@ public class ProjectSecurityAwarenessScoreTest {
 
   @Test
   public void testCalculate() {
-    Set<Value> values = Utils.allUnknown(PROJECT_SECURITY_AWARENESS_SCORE.allFeatures());
+    Set<Value<?>> values = Utils.allUnknown(PROJECT_SECURITY_AWARENESS_SCORE.allFeatures());
     ScoreValue scoreValue = PROJECT_SECURITY_AWARENESS_SCORE.calculate(values);
     assertFalse(scoreValue.isUnknown());
     assertFalse(scoreValue.isNotApplicable());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/VulnerabilityDiscoveryAndSecurityTestingScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/VulnerabilityDiscoveryAndSecurityTestingScoreTest.java
@@ -26,7 +26,7 @@ public class VulnerabilityDiscoveryAndSecurityTestingScoreTest {
 
   @Test
   public void testCalculate() {
-    Set<Value> values = Utils.allUnknown(SECURITY_TESTING_SCORE.allFeatures());
+    Set<Value<?>> values = Utils.allUnknown(SECURITY_TESTING_SCORE.allFeatures());
     values.add(VULNERABILITIES.value(
         new Vulnerabilities(
             newVulnerability("CVE-1")

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/VulnerabilityLifetimeScoreTest.java
@@ -39,7 +39,7 @@ public class VulnerabilityLifetimeScoreTest {
 
   @Test
   public void calculate() throws ParseException {
-    Set<Value> values = setOf(
+    Set<Value<?>> values = setOf(
         VULNERABILITIES.value(new Vulnerabilities(
             newVulnerability("CVE-2020-001")
                 .description("Test")

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ScoreValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ScoreValueTest.java
@@ -77,7 +77,7 @@ public class ScoreValueTest {
 
   @Test
   public void testUsedValues() {
-    List<Value> usedValues = Arrays.asList(
+    List<Value<?>> usedValues = Arrays.asList(
         NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
         NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(3));
 
@@ -147,7 +147,7 @@ public class ScoreValueTest {
 
   @Test
   public void testEqualsAndHashCode() {
-    List<Value> usedValues = Arrays.asList(
+    List<Value<?>> usedValues = Arrays.asList(
         NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
         NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(3));
 
@@ -177,7 +177,7 @@ public class ScoreValueTest {
 
   @Test
   public void testSerializeAndDeserialize() throws IOException {
-    List<Value> usedValues = Arrays.asList(
+    List<Value<?>> usedValues = Arrays.asList(
         NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE.value(10),
         NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE.value(3));
 
@@ -228,7 +228,7 @@ public class ScoreValueTest {
 
   @Test
   public void testUsedFeatureValues() {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 7));
     values.add(new IntegerValue(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE, 2));
     values.add(new BooleanValue(SECURITY_REVIEW_DONE_EXAMPLE, true));
@@ -243,7 +243,7 @@ public class ScoreValueTest {
 
   @Test
   public void testFindUsedSubScoreValue() {
-    Set<Value> values = new HashSet<>();
+    Set<Value<?>> values = new HashSet<>();
     values.add(new IntegerValue(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, 7));
     values.add(new IntegerValue(NUMBER_OF_CONTRIBUTORS_LAST_MONTH_EXAMPLE, 2));
     values.add(new BooleanValue(SECURITY_REVIEW_DONE_EXAMPLE, true));

--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/MarkdownFormatterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/MarkdownFormatterTest.java
@@ -60,7 +60,7 @@ public class MarkdownFormatterTest {
   private static final OssSecurityRating RATING
       = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
 
-  private static final Set<Value> TEST_VALUES = setOf(
+  private static final Set<Value<?>> TEST_VALUES = setOf(
       SUPPORTED_BY_COMPANY.value(false),
       IS_APACHE.value(true),
       IS_ECLIPSE.value(false),

--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinterTest.java
@@ -67,7 +67,7 @@ public class PrettyPrinterTest {
   private static final OssSecurityRating RATING
       = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
 
-  private static final Set<Value> TEST_VALUES = setOf(
+  private static final Set<Value<?>> TEST_VALUES = setOf(
       SUPPORTED_BY_COMPANY.value(false),
       IS_APACHE.value(true),
       IS_ECLIPSE.value(false),
@@ -121,10 +121,10 @@ public class PrettyPrinterTest {
     assertNotNull(text);
     assertFalse(text.isEmpty());
     System.out.println(text);
-    for (Value value : ratingValue.scoreValue().usedValues()) {
+    for (Value<?> value : ratingValue.scoreValue().usedValues()) {
       assertTrue(text.contains(CommonFormatter.nameOf(value.feature())));
     }
-    for (Feature feature : RATING.allFeatures()) {
+    for (Feature<?> feature : RATING.allFeatures()) {
       assertTrue(String.format("'%s' feature should be there!", feature.name()),
           text.contains(CommonFormatter.nameOf(feature)));
     }


### PR DESCRIPTION
This is a boring changeset that updates multiple classes to use `<?>` or specific types for generic classes. It helps to get rid or many compiler warnings. The changeset also fixes several minor issues and simplifies several methods.

Closes #382