### PR TITLE
Make ValueSet iterable

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/CompositeDataProvider.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/CompositeDataProvider.java
@@ -172,8 +172,8 @@ public class CompositeDataProvider<T> implements DataProvider<T> {
 
     @Override
     public boolean satisfied(ValueSet values) {
-      for (Feature feature : features) {
-        Optional<Value<?>> something = values.of(feature);
+      for (Feature<?> feature : features) {
+        Optional<? extends Value<?>> something = values.of(feature);
         if (!something.isPresent()) {
           return false;
         }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/StandardValueCache.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/StandardValueCache.java
@@ -90,7 +90,7 @@ public class StandardValueCache implements Cache<String, ValueSet> {
     }
 
     ValueSet result = new ValueHashSet();
-    for (Value<?> value : set.toArray()) {
+    for (Value<?> value : set) {
       unwrapExpiring(value).ifPresent(result::update);
     }
 
@@ -129,7 +129,7 @@ public class StandardValueCache implements Cache<String, ValueSet> {
 
   @Override
   public void put(String key, ValueSet set, Date expiration) {
-    for (Value<?> value : set.toArray()) {
+    for (Value<?> value : set) {
       put(key, value, expiration);
     }
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/InfoAboutVulnerabilities.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/InfoAboutVulnerabilities.java
@@ -63,7 +63,7 @@ public class InfoAboutVulnerabilities
       ValueSet subset = new ValueHashSet();
       provider.set(callback).set(cache).update(project, subset);
 
-      for (Value<?> value : subset.toArray()) {
+      for (Value<?> value : subset) {
         if (value.isUnknown()) {
           continue;
         }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/ValueSet.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/ValueSet.java
@@ -13,7 +13,7 @@ import java.util.Set;
     @JsonSubTypes.Type(value = ValueHashSet.class, name = "ValueHashSet")
 })
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
-public interface ValueSet {
+public interface ValueSet extends Iterable<Value<?>> {
 
   /**
    * Checks if the set of values contains a value of a particular feature.
@@ -49,13 +49,6 @@ public interface ValueSet {
   ValueSet update(Set<Value<?>> values);
 
   /**
-   * Converts the set to an array of values.
-   *
-   * @return An array of values.
-   */
-  Value[] toArray();
-
-  /**
    * Get a number of values in the value set.
    *
    * @return A number of values in the set.
@@ -85,4 +78,11 @@ public interface ValueSet {
    * @return True if the set contains all the specified features, false otherwise.
    */
   boolean containsAll(Set<Feature<?>> features);
+
+  /**
+   * Converts a value set to a regular {@link Set}.
+   *
+   * @return A set with values.
+   */
+  Set<Value<?>> toSet();
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/AbstractScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/AbstractScore.java
@@ -96,7 +96,7 @@ public abstract class AbstractScore implements Score {
   @Override
   public ScoreValue calculate(ValueSet values) {
     Objects.requireNonNull(values, "Hey! Value set can't be null!");
-    return calculate(values.toArray());
+    return calculate(values.toSet());
   }
 
   @Override

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/ValueHashSet.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/ValueHashSet.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -132,7 +133,7 @@ public class ValueHashSet implements ValueSet {
   @Override
   public ValueSet update(ValueSet values) {
     Objects.requireNonNull(values, "Oh no! Values is null!");
-    for (Value<?> value : values.toArray()) {
+    for (Value<?> value : values) {
       update(value);
     }
     return this;
@@ -145,21 +146,6 @@ public class ValueHashSet implements ValueSet {
   }
 
   @Override
-  public Value[] toArray() {
-    Value[] array = new Value[featureToValue.size()];
-    int i = 0;
-    for (Value value : featureToValue.values()) {
-      array[i] = value;
-      i++;
-    }
-    return array;
-  }
-
-  /**
-   * Converts a value set to a regular {@link Set}.
-   *
-   * @return A set with values.
-   */
   public Set<Value<?>> toSet() {
     return new HashSet<>(featureToValue.values());
   }
@@ -204,6 +190,11 @@ public class ValueHashSet implements ValueSet {
   public boolean containsAll(Set<Feature<?>> features) {
     Objects.requireNonNull(features, "Oh no! Features is null");
     return featureToValue.keySet().containsAll(features);
+  }
+
+  @Override
+  public Iterator<Value<?>> iterator() {
+    return toSet().iterator();
   }
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/SingleSecurityRatingCalculator.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/SingleSecurityRatingCalculator.java
@@ -160,7 +160,7 @@ class SingleSecurityRatingCalculator {
     }
 
     LOGGER.info("Here is what we know about the project:");
-    Arrays.stream(values.toArray())
+    values.toSet().stream()
         .sorted(Comparator.comparing(value -> value.feature().name()))
         .forEach(value -> LOGGER.info("   {}: {}", value.feature(), value));
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/CompositeDataProviderTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/CompositeDataProviderTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 
 public class CompositeDataProviderTest {
 
-  private static class DataProviderImpl implements DataProvider {
+  private static class DataProviderImpl implements DataProvider<Object> {
 
     private final String featureName;
 
@@ -27,7 +27,7 @@ public class CompositeDataProviderTest {
     }
 
     @Override
-    public DataProvider update(Object object, ValueSet values) {
+    public DataProvider<Object> update(Object object, ValueSet values) {
       values.update(new BooleanValue(new BooleanFeature(featureName), true));
       return this;
     }
@@ -38,25 +38,25 @@ public class CompositeDataProviderTest {
     }
 
     @Override
-    public ValueCache cache() {
+    public ValueCache<Object> cache() {
       return null;
     }
 
     @Override
-    public DataProvider set(UserCallback callback) {
+    public DataProvider<Object> set(UserCallback callback) {
       this.callback = callback;
       return this;
     }
 
     @Override
-    public DataProvider set(ValueCache cache) {
+    public DataProvider<Object> set(ValueCache<Object> cache) {
       return null;
     }
   }
 
   @Test
-  public void testAllProvidersCalled() throws IOException {
-    CompositeDataProvider compositeDataProvider = new CompositeDataProvider(
+  public void testThatAllProvidersCalled() throws IOException {
+    CompositeDataProvider<Object> compositeDataProvider = new CompositeDataProvider<>(
         new DataProviderImpl("feature 1"),
         new DataProviderImpl("feature 2"),
         new DataProviderImpl("feature 3")
@@ -80,7 +80,7 @@ public class CompositeDataProviderTest {
     compositeDataProvider.update(new Object(), values);
 
     assertEquals(3, values.size());
-    for (Value value : values.toArray()) {
+    for (Value<?> value : values) {
       BooleanValue booleanValue = (BooleanValue) value;
       assertFalse(booleanValue.isUnknown());
       assertTrue(booleanValue.feature().name().startsWith("feature "));
@@ -89,11 +89,11 @@ public class CompositeDataProviderTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void noInteractiveProviders() {
-    new CompositeDataProvider(
-        new DataProvider() {
+  public void testWithNoInteractiveProviders() {
+    new CompositeDataProvider<>(
+        new DataProvider<Object>() {
           @Override
-          public DataProvider update(Object object, ValueSet values) {
+          public DataProvider<Object> update(Object object, ValueSet values) {
             throw new UnsupportedOperationException("This should not be called!");
           }
 
@@ -103,17 +103,17 @@ public class CompositeDataProviderTest {
           }
 
           @Override
-          public ValueCache cache() {
+          public ValueCache<Object> cache() {
             throw new UnsupportedOperationException("This should not be called!");
           }
 
           @Override
-          public DataProvider set(UserCallback callback) {
+          public DataProvider<Object> set(UserCallback callback) {
             throw new UnsupportedOperationException("This should not be called!");
           }
 
           @Override
-          public DataProvider set(ValueCache cache) {
+          public DataProvider<Object> set(ValueCache<Object> cache) {
             throw new UnsupportedOperationException("This should not be called!");
           }
         }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ValueHashSetTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ValueHashSetTest.java
@@ -15,56 +15,57 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.ValueSet;
 import java.io.IOException;
+import java.util.Set;
 import org.junit.Test;
 
 public class ValueHashSetTest {
 
   @Test
-  public void createEmptyValueHashSet() {
-    assertEquals(0, ValueHashSet.empty().toArray().length);
+  public void testCreateEmptyValueHashSet() {
+    assertEquals(0, ValueHashSet.empty().size());
   }
 
   @Test
-  public void createNotEmptyValueHashSet() {
+  public void testCreateNotEmptyValueHashSet() {
     ValueSet values = new ValueHashSet(
         NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(10),
         NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS.value(5));
-    assertEquals(2, values.toArray().length);
+    assertEquals(2, values.size());
     assertTrue(values.has(NUMBER_OF_COMMITS_LAST_THREE_MONTHS));
     assertTrue(values.has(NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS));
   }
 
   @Test
-  public void has() {
+  public void testHas() {
     ValueSet values = ValueHashSet.empty();
     values.update(NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(10));
-    assertEquals(1, values.toArray().length);
+    assertEquals(1, values.size());
     assertTrue(values.has(NUMBER_OF_COMMITS_LAST_THREE_MONTHS));
   }
 
   @Test
-  public void update() {
+  public void testUpdate() {
     ValueSet values = ValueHashSet.empty();
     values.update(NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(10));
-    assertEquals(1, values.toArray().length);
-    assertEquals(NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(10), values.toArray()[0]);
+    assertEquals(1, values.size());
+    assertEquals(NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(10), values.iterator().next());
     values.update(NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(20));
-    assertEquals(1, values.toArray().length);
-    assertEquals(NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(20), values.toArray()[0]);
+    assertEquals(1, values.size());
+    assertEquals(NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(20), values.iterator().next());
   }
 
   @Test
-  public void toArray() {
+  public void testToSet() {
     ValueSet values = ValueHashSet.empty();
     values.update(NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(10));
     values.update(NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS.value(5));
-    Value[] array = values.toArray();
-    assertNotNull(array);
-    assertEquals(2, array.length);
+    Set<Value<?>> set = values.toSet();
+    assertNotNull(set);
+    assertEquals(2, set.size());
   }
 
   @Test
-  public void unknown() {
+  public void testUnknown() {
     ValueSet values = ValueHashSet.unknown(NUMBER_OF_WATCHERS_ON_GITHUB, NUMBER_OF_GITHUB_STARS,
         NUMBER_OF_COLLABORATORS);
     assertEquals(3, values.size());
@@ -85,7 +86,7 @@ public class ValueHashSetTest {
   }
 
   @Test
-  public void serializationAndDeserialization() throws IOException {
+  public void testSerializationAndDeserialization() throws IOException {
     ValueSet values = ValueHashSet.empty();
     values.update(NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(10));
     values.update(HAS_SECURITY_TEAM.value(true));


### PR DESCRIPTION
Here is a list of updates:

- Removed `ValueSet.toArray()` method.
- Added `ValueSet.toSet()` method.
- Updated `ValueSet` to implement `Iterable`.
- Fixed warnings for Java generics.
- Updated tests.

Fixes #418