### PR TITLE
Disable signing with JGit in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea
-fosstars-model.iml
+*.iml
 target
 .attach_pid*
 .fosstars

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/FuzzedInOssFuzzTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/FuzzedInOssFuzzTest.java
@@ -13,10 +13,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Date;
 import org.apache.commons.io.FileUtils;
+import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.junit.Test;
 
 public class FuzzedInOssFuzzTest extends TestGitHubDataFetcherHolder {
@@ -37,8 +39,13 @@ public class FuzzedInOssFuzzTest extends TestGitHubDataFetcherHolder {
       Files.write(dockerFilePath, content.getBytes());
 
       git.add().addFilepattern("projects/project/Dockerfile").call();
-      git.commit()
-          .setMessage("Added Dockerfile")
+      CommitCommand commit = git.commit();
+      commit.setCredentialsProvider(
+              new UsernamePasswordCredentialsProvider("fuzzer", "don't tell anyone"));
+      commit.setMessage("Added Dockerfile")
+          .setSign(false)
+          .setAuthor("Mr. Fuzzer", "fuzzer@test.com")
+          .setCommitter("Mr. Fuzzer", "fuzzer@test.com")
           .call();
 
       LocalRepository localRepository = new LocalRepository(

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/LocalRepositoryTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/LocalRepositoryTest.java
@@ -16,10 +16,12 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.junit.Test;
 
 public class LocalRepositoryTest {
@@ -38,8 +40,13 @@ public class LocalRepositoryTest {
       Path path = new File(repository.getDirectory().getParent(), filename).toPath();
       Files.write(path, content.getBytes());
       git.add().addFilepattern(filename).call();
-      git.commit()
-          .setMessage("Added " + filename)
+      CommitCommand commit = git.commit();
+      commit.setCredentialsProvider(
+              new UsernamePasswordCredentialsProvider("test", "don't tell anyone"));
+      commit.setMessage("Added " + filename)
+          .setSign(false)
+          .setAuthor("Mr. Test", "test@test.com")
+          .setCommitter("Mr. Test", "test@test.com")
           .call();
 
       LocalRepository localRepository = new LocalRepository(
@@ -72,8 +79,11 @@ public class LocalRepositoryTest {
           Paths.get(repository.getDirectory().getParent()).resolve("file"),
           "test".getBytes());
       git.add().addFilepattern("README.md").call();
-      git.commit()
-          .setMessage("Old commit")
+      CommitCommand commit = git.commit();
+      commit.setCredentialsProvider(
+              new UsernamePasswordCredentialsProvider("mr.white", "don't tell anyone"));
+      commit.setMessage("Old commit")
+          .setSign(false)
           .setAuthor("Mr. White", "mr.white@test.com")
           .setCommitter("Mr. White", "mr.white@test.com")
           .call();
@@ -85,8 +95,11 @@ public class LocalRepositoryTest {
           Paths.get(repository.getDirectory().getParent()).resolve("file"),
           "test".getBytes());
       git.add().addFilepattern("SECURITY.md").call();
-      git.commit()
-          .setMessage("Latest commit")
+      commit = git.commit();
+      commit.setCredentialsProvider(
+              new UsernamePasswordCredentialsProvider("mr.black", "don't tell anyone"));
+      commit.setMessage("Latest commit")
+          .setSign(false)
           .setAuthor("Mr. Black", "mr.black@test.com")
           .setCommitter("Mr. Black", "mr.black@test.com")
           .call();


### PR DESCRIPTION
Here is a list of updates:

- Disabled signing for commits in `FuzzedInOssFuzzTest`.
- Disabled signing for commits in `LocalRepositoryTest`.

Fixes #429