### PR TITLE
More advisors

### DIFF
--- a/advice_npe.patch
+++ b/advice_npe.patch
@@ -1,0 +1,170 @@
+diff --git a/src/main/java/com/sap/oss/phosphor/fosstars/advice/AdviceContentYamlStorage.java b/src/main/java/com/sap/oss/phosphor/fosstars/advice/AdviceContentYamlStorage.java
+index 0e9c1ed6..4c82ae6e 100644
+--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/AdviceContentYamlStorage.java
++++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/AdviceContentYamlStorage.java
+@@ -1,6 +1,7 @@
+ package com.sap.oss.phosphor.fosstars.advice;
+ 
+ import com.fasterxml.jackson.annotation.JsonCreator;
++import com.fasterxml.jackson.annotation.JsonGetter;
+ import com.fasterxml.jackson.annotation.JsonProperty;
+ import com.fasterxml.jackson.core.type.TypeReference;
+ import com.sap.oss.phosphor.fosstars.model.Feature;
+@@ -152,6 +153,23 @@ public class AdviceContentYamlStorage {
+       this.name = name;
+       this.url = url;
+     }
++
++    @Override
++    public boolean equals(Object o) {
++      if (this == o) {
++        return true;
++      }
++      if (o.getClass() != getClass()) {
++        return false;
++      }
++      RawLink rawLink = (RawLink) o;
++      return Objects.equals(name, rawLink.name) && Objects.equals(url, rawLink.url);
++    }
++
++    @Override
++    public int hashCode() {
++      return Objects.hash(name, url);
++    }
+   }
+ 
+   /**
+@@ -183,10 +201,10 @@ public class AdviceContentYamlStorage {
+      */
+     @JsonCreator
+     RawAdviceContent(
+-        @JsonProperty("advice") String advice, @JsonProperty("links") List<RawLink> links) {
++        @JsonProperty("advice") String advice,
++        @JsonProperty(value = "links") List<RawLink> links) {
+ 
+       Objects.requireNonNull(advice, "Oh no! Advice is null!");
+-      Objects.requireNonNull(advice, "Oh no! Links is null!");
+ 
+       advice = advice.trim();
+       if (advice.isEmpty()) {
+@@ -194,7 +212,17 @@ public class AdviceContentYamlStorage {
+       }
+ 
+       this.advice = advice;
+-      this.links = new ArrayList<>(links);
++      this.links = new ArrayList<>(links != null ? links : Collections.emptyList());
++    }
++
++    @JsonGetter("advice")
++    private String advice() {
++      return advice;
++    }
++
++    @JsonGetter("links")
++    private List<RawLink> links() {
++      return new ArrayList<>(links);
+     }
+ 
+     /**
+@@ -273,5 +301,22 @@ public class AdviceContentYamlStorage {
+       return string;
+     }
+ 
++    @Override
++    public boolean equals(Object o) {
++      if (this == o) {
++        return true;
++      }
++      if (o.getClass() != getClass()) {
++        return false;
++      }
++      RawAdviceContent content = (RawAdviceContent) o;
++      return Objects.equals(advice, content.advice)
++          && Objects.equals(links, content.links);
++    }
++
++    @Override
++    public int hashCode() {
++      return Objects.hash(advice, links);
++    }
+   }
+ }
+diff --git a/src/test/java/com/sap/oss/phosphor/fosstars/advice/AdviceContentYamlStorageTest.java b/src/test/java/com/sap/oss/phosphor/fosstars/advice/AdviceContentYamlStorageTest.java
+index 1ebbe273..9a218b6c 100644
+--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/AdviceContentYamlStorageTest.java
++++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/AdviceContentYamlStorageTest.java
+@@ -4,6 +4,7 @@ import static com.sap.oss.phosphor.fosstars.advice.oss.OssAdviceContentYamlStora
+ import static com.sap.oss.phosphor.fosstars.model.feature.example.ExampleFeatures.NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE;
+ import static com.sap.oss.phosphor.fosstars.model.feature.example.ExampleFeatures.SECURITY_REVIEW_DONE_EXAMPLE;
+ import static com.sap.oss.phosphor.fosstars.model.feature.example.ExampleFeatures.STATIC_CODE_ANALYSIS_DONE_EXAMPLE;
++import static java.util.Arrays.asList;
+ import static org.junit.Assert.assertEquals;
+ import static org.junit.Assert.assertFalse;
+ import static org.junit.Assert.assertTrue;
+@@ -13,8 +14,8 @@ import com.sap.oss.phosphor.fosstars.advice.AdviceContentYamlStorage.RawLink;
+ import com.sap.oss.phosphor.fosstars.advice.oss.OssAdviceContentYamlStorage.OssAdviceContext;
+ import com.sap.oss.phosphor.fosstars.model.RatingRepository;
+ import com.sap.oss.phosphor.fosstars.model.rating.example.SecurityRatingExample;
++import com.sap.oss.phosphor.fosstars.util.Yaml;
+ import java.io.IOException;
+-import java.util.Arrays;
+ import java.util.List;
+ import java.util.Set;
+ import org.junit.Test;
+@@ -37,9 +38,13 @@ public class AdviceContentYamlStorageTest {
+     }
+ 
+     advice = storage.adviceFor(STATIC_CODE_ANALYSIS_DONE_EXAMPLE, EMPTY_OSS_CONTEXT);
+-    assertEquals(1, advice.size());
++    assertEquals(3, advice.size());
+     assertFalse(advice.get(0).text().isEmpty());
+     assertFalse(advice.get(0).links().isEmpty());
++    assertFalse(advice.get(1).text().isEmpty());
++    assertTrue(advice.get(1).links().isEmpty());
++    assertFalse(advice.get(2).text().isEmpty());
++    assertTrue(advice.get(2).links().isEmpty());
+ 
+     advice = storage.adviceFor(NUMBER_OF_COMMITS_LAST_MONTH_EXAMPLE, EMPTY_OSS_CONTEXT);
+     assertTrue(advice.isEmpty());
+@@ -49,7 +54,7 @@ public class AdviceContentYamlStorageTest {
+   public void testRawContentVariables() {
+     RawAdviceContent content = new RawAdviceContent(
+         "Test ${FIRST_VARIABLE} variable",
+-        Arrays.asList(
++        asList(
+             new RawLink("First link ${SECOND_VARIABLE}}", "https://test"),
+             new RawLink("Second link", "${THIRD_VARIABLE}}")));
+ 
+@@ -59,4 +64,19 @@ public class AdviceContentYamlStorageTest {
+     assertTrue(variables.contains("SECOND_VARIABLE"));
+     assertTrue(variables.contains("THIRD_VARIABLE"));
+   }
++
++  @Test
++  public void testYamlSerialization() throws IOException {
++    RawAdviceContent fullContent = new RawAdviceContent(
++        "Test",
++        asList(
++            new RawLink("First", "https://test/first"),
++            new RawLink("Second", "https://test/second")));
++    RawAdviceContent clone = Yaml.read(Yaml.toBytes(fullContent), RawAdviceContent.class);
++    assertEquals(fullContent, clone);
++
++    RawAdviceContent noLinks = new RawAdviceContent("No links", null);
++    clone = Yaml.read(Yaml.toBytes(noLinks), RawAdviceContent.class);
++    assertEquals(noLinks, clone);
++  }
+ }
+\ No newline at end of file
+diff --git a/src/test/resources/com/sap/oss/phosphor/fosstars/advice/AdviceContentStorageTest.yml b/src/test/resources/com/sap/oss/phosphor/fosstars/advice/AdviceContentStorageTest.yml
+index 513c07f0..d01ce4d5 100644
+--- a/src/test/resources/com/sap/oss/phosphor/fosstars/advice/AdviceContentStorageTest.yml
++++ b/src/test/resources/com/sap/oss/phosphor/fosstars/advice/AdviceContentStorageTest.yml
+@@ -19,3 +19,6 @@ Static code analysis status (example):
+         url: https://test/5
+       - name: link6
+         url: https://test/6
++  - advice: Advice with empty links
++    links: []
++  - advice: Advice with no links
+\ No newline at end of file

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/AdviceContentYamlStorage.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/AdviceContentYamlStorage.java
@@ -217,7 +217,7 @@ public class AdviceContentYamlStorage {
       }
 
       this.advice = advice;
-      this.links = new ArrayList<>(links != null ? links : Collections.emptyList());
+      this.links = new ArrayList<>(links != null ? links : emptyList());
     }
 
     @JsonGetter("advice")

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/Advisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/Advisor.java
@@ -1,6 +1,7 @@
 package com.sap.oss.phosphor.fosstars.advice;
 
 import com.sap.oss.phosphor.fosstars.model.Subject;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -19,6 +20,7 @@ public interface Advisor {
    *
    * @param subject The subject.
    * @return A list of advice for the subject.
+   * @throws IOException If something went wrong.
    */
-  List<Advice> adviceFor(Subject subject);
+  List<Advice> adviceFor(Subject subject) throws IOException;
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/Advisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/Advisor.java
@@ -20,5 +20,5 @@ public interface Advisor {
    * @param subject The subject.
    * @return A list of advice for the subject.
    */
-  List<Advice> adviseFor(Subject subject);
+  List<Advice> adviceFor(Subject subject);
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/CompositeAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/CompositeAdvisor.java
@@ -1,6 +1,7 @@
 package com.sap.oss.phosphor.fosstars.advice;
 
 import com.sap.oss.phosphor.fosstars.model.Subject;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -32,9 +33,12 @@ public class CompositeAdvisor implements Advisor {
   }
 
   @Override
-  public List<Advice> adviceFor(Subject subject) {
-    return advisors.stream()
-        .map(advisor -> advisor.adviceFor(subject))
-        .collect(ArrayList::new, List::addAll, List::addAll);
+  public List<Advice> adviceFor(Subject subject) throws IOException {
+    List<Advice> advice = new ArrayList<>();
+    for (Advisor advisor : advisors) {
+      advice.addAll(advisor.adviceFor(subject));
+    }
+
+    return advice;
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/CompositeAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/CompositeAdvisor.java
@@ -32,9 +32,9 @@ public class CompositeAdvisor implements Advisor {
   }
 
   @Override
-  public List<Advice> adviseFor(Subject subject) {
+  public List<Advice> adviceFor(Subject subject) {
     return advisors.stream()
-        .map(advisor -> advisor.adviseFor(subject))
+        .map(advisor -> advisor.adviceFor(subject))
         .collect(ArrayList::new, List::addAll, List::addAll);
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/ArtifactVersionAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/ArtifactVersionAdvisor.java
@@ -13,6 +13,7 @@ import com.sap.oss.phosphor.fosstars.model.Subject;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.value.ArtifactVersion;
 import com.sap.oss.phosphor.fosstars.model.value.ArtifactVersions;
+import java.net.MalformedURLException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +36,8 @@ public class ArtifactVersionAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviceFor(
-      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context)
+      throws MalformedURLException {
 
     Optional<Value<String>> versionValue = findValue(usedValues, VERSION);
     Optional<Value<ArtifactVersions>> releasedVersionsValue = findValue(usedValues,

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/CodeqlAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/CodeqlAdvisor.java
@@ -3,19 +3,27 @@ package com.sap.oss.phosphor.fosstars.advice.oss;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.RUNS_CODEQL_SCANS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_CODEQL_CHECKS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_LGTM_CHECKS;
+import static java.util.Arrays.asList;
 
 import com.sap.oss.phosphor.fosstars.advice.Advice;
 import com.sap.oss.phosphor.fosstars.advice.oss.OssAdviceContentYamlStorage.OssAdviceContext;
+import com.sap.oss.phosphor.fosstars.model.Feature;
 import com.sap.oss.phosphor.fosstars.model.Subject;
 import com.sap.oss.phosphor.fosstars.model.Value;
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 /**
  * An advisor for features related to CodeQL.
  */
 public class CodeqlAdvisor extends AbstractOssAdvisor {
+
+  /**
+   * A list of features that the advisor supports.
+   */
+  private static final List<Feature<Boolean>> FEATURES
+      = asList(USES_LGTM_CHECKS, USES_CODEQL_CHECKS, RUNS_CODEQL_SCANS);
 
   /**
    * Create a new advisor.
@@ -28,10 +36,14 @@ public class CodeqlAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviceFor(
-      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context)
+      throws MalformedURLException {
 
-    return Stream.of(USES_LGTM_CHECKS, USES_CODEQL_CHECKS, RUNS_CODEQL_SCANS)
-        .map(feature -> adviseForBooleanFeature(usedValues, feature, subject, context))
-        .collect(ArrayList::new, ArrayList::addAll, ArrayList::addAll);
+    List<Advice> advice = new ArrayList<>();
+    for (Feature<Boolean> feature : FEATURES) {
+      advice.addAll(adviceForBooleanFeature(usedValues, feature, subject, context));
+    }
+
+    return advice;
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/DependabotAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/DependabotAdvisor.java
@@ -1,45 +1,41 @@
 package com.sap.oss.phosphor.fosstars.advice.oss;
 
-import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.FUZZED_IN_OSS_FUZZ;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
 
 import com.sap.oss.phosphor.fosstars.advice.Advice;
 import com.sap.oss.phosphor.fosstars.advice.oss.OssAdviceContentYamlStorage.OssAdviceContext;
 import com.sap.oss.phosphor.fosstars.model.Subject;
 import com.sap.oss.phosphor.fosstars.model.Value;
-import com.sap.oss.phosphor.fosstars.model.score.oss.FuzzingScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.DependabotScore;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 /**
- * An advisor for features related to fuzzing.
+ * An advisor for features related to Dependabot.
  */
-public class FuzzingAdvisor extends AbstractOssAdvisor {
+public class DependabotAdvisor extends AbstractOssAdvisor {
 
   /**
    * Create a new advisor.
    *
    * @param contextFactory A factory that provides contexts for advice.
    */
-  public FuzzingAdvisor(OssAdviceContextFactory contextFactory) {
+  public DependabotAdvisor(OssAdviceContextFactory contextFactory) {
     super(OssAdviceContentYamlStorage.DEFAULT, contextFactory);
   }
 
   @Override
-  protected List<Advice> adviceFor(
+  protected List<Advice> adviseFor(
       Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
 
-    Optional<ScoreValue> fuzzingScoreValue = findSubScoreValue(subject, FuzzingScore.class);
+    Optional<ScoreValue> fuzzingScoreValue = findSubScoreValue(subject, DependabotScore.class);
 
-    if (!fuzzingScoreValue.isPresent()) {
+    if (!fuzzingScoreValue.isPresent() || fuzzingScoreValue.get().isNotApplicable()) {
       return Collections.emptyList();
     }
 
-    if (fuzzingScoreValue.get().isNotApplicable()) {
-      return Collections.emptyList();
-    }
-
-    return adviseForBooleanFeature(usedValues, FUZZED_IN_OSS_FUZZ, subject, context);
+    return adviseForBooleanFeature(usedValues, USES_DEPENDABOT, subject, context);
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/DependabotAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/DependabotAdvisor.java
@@ -8,6 +8,7 @@ import com.sap.oss.phosphor.fosstars.model.Subject;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.score.oss.DependabotScore;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import java.net.MalformedURLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -27,8 +28,9 @@ public class DependabotAdvisor extends AbstractOssAdvisor {
   }
 
   @Override
-  protected List<Advice> adviseFor(
-      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
+  protected List<Advice> adviceFor(
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context)
+      throws MalformedURLException {
 
     Optional<ScoreValue> dependabotScore = findSubScoreValue(subject, DependabotScore.class);
 
@@ -36,6 +38,6 @@ public class DependabotAdvisor extends AbstractOssAdvisor {
       return Collections.emptyList();
     }
 
-    return adviseForBooleanFeature(usedValues, USES_DEPENDABOT, subject, context);
+    return adviceForBooleanFeature(usedValues, USES_DEPENDABOT, subject, context);
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/DependabotAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/DependabotAdvisor.java
@@ -30,9 +30,9 @@ public class DependabotAdvisor extends AbstractOssAdvisor {
   protected List<Advice> adviseFor(
       Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
 
-    Optional<ScoreValue> fuzzingScoreValue = findSubScoreValue(subject, DependabotScore.class);
+    Optional<ScoreValue> dependabotScore = findSubScoreValue(subject, DependabotScore.class);
 
-    if (!fuzzingScoreValue.isPresent() || fuzzingScoreValue.get().isNotApplicable()) {
+    if (!dependabotScore.isPresent() || dependabotScore.get().isNotApplicable()) {
       return Collections.emptyList();
     }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/FindSecBugsAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/FindSecBugsAdvisor.java
@@ -6,6 +6,7 @@ import com.sap.oss.phosphor.fosstars.advice.Advice;
 import com.sap.oss.phosphor.fosstars.advice.oss.OssAdviceContentYamlStorage.OssAdviceContext;
 import com.sap.oss.phosphor.fosstars.model.Subject;
 import com.sap.oss.phosphor.fosstars.model.Value;
+import java.net.MalformedURLException;
 import java.util.List;
 
 /**
@@ -25,8 +26,9 @@ public class FindSecBugsAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviceFor(
-      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context)
+      throws MalformedURLException {
 
-    return adviseForBooleanFeature(usedValues, USES_FIND_SEC_BUGS, subject, context);
+    return adviceForBooleanFeature(usedValues, USES_FIND_SEC_BUGS, subject, context);
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/FuzzingAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/FuzzingAdvisor.java
@@ -8,6 +8,7 @@ import com.sap.oss.phosphor.fosstars.model.Subject;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.score.oss.FuzzingScore;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import java.net.MalformedURLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -28,7 +29,8 @@ public class FuzzingAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviceFor(
-      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context)
+      throws MalformedURLException {
 
     Optional<ScoreValue> fuzzingScoreValue = findSubScoreValue(subject, FuzzingScore.class);
 
@@ -40,6 +42,6 @@ public class FuzzingAdvisor extends AbstractOssAdvisor {
       return Collections.emptyList();
     }
 
-    return adviseForBooleanFeature(usedValues, FUZZED_IN_OSS_FUZZ, subject, context);
+    return adviceForBooleanFeature(usedValues, FUZZED_IN_OSS_FUZZ, subject, context);
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/LgtmAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/LgtmAdvisor.java
@@ -3,6 +3,7 @@ package com.sap.oss.phosphor.fosstars.advice.oss;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.WORST_LGTM_GRADE;
 import static com.sap.oss.phosphor.fosstars.model.other.Utils.findValue;
 import static com.sap.oss.phosphor.fosstars.model.value.LgtmGrade.A_PLUS;
+import static java.util.Collections.emptyList;
 
 import com.sap.oss.phosphor.fosstars.advice.Advice;
 import com.sap.oss.phosphor.fosstars.advice.SimpleAdvice;
@@ -10,8 +11,9 @@ import com.sap.oss.phosphor.fosstars.advice.oss.OssAdviceContentYamlStorage.OssA
 import com.sap.oss.phosphor.fosstars.model.Subject;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.value.LgtmGrade;
-import java.util.Collections;
+import java.net.MalformedURLException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -30,17 +32,22 @@ public class LgtmAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviceFor(
-      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context)
+      throws MalformedURLException {
 
-    return findValue(usedValues, WORST_LGTM_GRADE)
+    Optional<Value<LgtmGrade>> value = findValue(usedValues, WORST_LGTM_GRADE)
         .filter(LgtmAdvisor::isKnown)
-        .filter(LgtmAdvisor::notTheBest)
-        .map(value -> adviceStorage.adviceFor(value.feature(), context)
-            .stream()
-            .map(content -> new SimpleAdvice(subject, value, content))
-            .map(Advice.class::cast)
-            .collect(Collectors.toList()))
-        .orElse(Collections.emptyList());
+        .filter(LgtmAdvisor::notTheBest);
+
+    if (!value.isPresent()) {
+      return emptyList();
+    }
+
+    return adviceStorage.adviceFor(value.get().feature(), context)
+        .stream()
+        .map(content -> new SimpleAdvice(subject, value.get(), content))
+        .map(Advice.class::cast)
+        .collect(Collectors.toList());
   }
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/MemorySafetyAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/MemorySafetyAdvisor.java
@@ -11,6 +11,7 @@ import com.sap.oss.phosphor.fosstars.model.Subject;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.score.oss.MemorySafetyTestingScore;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,7 +40,8 @@ public class MemorySafetyAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviceFor(
-      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context)
+      throws MalformedURLException {
 
     Optional<ScoreValue> memorySafetyTestingScoreValue
         = findSubScoreValue(subject, MemorySafetyTestingScore.class);
@@ -52,8 +54,11 @@ public class MemorySafetyAdvisor extends AbstractOssAdvisor {
       return Collections.emptyList();
     }
 
-    return FEATURES.stream()
-        .map(feature -> adviseForBooleanFeature(usedValues, feature, subject, context))
-        .collect(ArrayList::new, ArrayList::addAll, ArrayList::addAll);
+    List<Advice> advice = new ArrayList<>();
+    for (Feature<Boolean> feature : FEATURES) {
+      advice.addAll(adviceForBooleanFeature(usedValues, feature, subject, context));
+    }
+
+    return advice;
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/NoHttpAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/NoHttpAdvisor.java
@@ -24,11 +24,11 @@ public class NoHttpAdvisor extends AbstractOssAdvisor {
   }
 
   @Override
-  protected List<Advice> adviseFor(
+  protected List<Advice> adviceFor(
       Subject subject, List<Value<?>> usedValues, OssAdviceContext context)
       throws MalformedURLException {
 
-    return adviseForFeature(usedValues, USES_NOHTTP, subject, context, NoHttpAdvisor::noHttpTool);
+    return adviceForFeature(usedValues, USES_NOHTTP, subject, context, NoHttpAdvisor::noHttpTool);
   }
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/NoHttpAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/NoHttpAdvisor.java
@@ -1,0 +1,45 @@
+package com.sap.oss.phosphor.fosstars.advice.oss;
+
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
+
+import com.sap.oss.phosphor.fosstars.advice.Advice;
+import com.sap.oss.phosphor.fosstars.advice.oss.OssAdviceContentYamlStorage.OssAdviceContext;
+import com.sap.oss.phosphor.fosstars.model.Subject;
+import com.sap.oss.phosphor.fosstars.model.Value;
+import java.net.MalformedURLException;
+import java.util.List;
+
+/**
+ * An advisor for features related to NoHttp tool.
+ */
+public class NoHttpAdvisor extends AbstractOssAdvisor {
+
+  /**
+   * Create a new advisor.
+   *
+   * @param contextFactory A factory that provides contexts for advice.
+   */
+  public NoHttpAdvisor(OssAdviceContextFactory contextFactory) {
+    super(OssAdviceContentYamlStorage.DEFAULT, contextFactory);
+  }
+
+  @Override
+  protected List<Advice> adviseFor(
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context)
+      throws MalformedURLException {
+
+    return adviseForFeature(usedValues, USES_NOHTTP, subject, context, NoHttpAdvisor::noHttpTool);
+  }
+
+  /**
+   * Checks if a value tells that NoHttp tool is not used.
+   *
+   * @param value The value.
+   * @return True if NoHttp tool is not used, false otherwise.
+   */
+  private static boolean noHttpTool(Value<?> value) {
+    return USES_NOHTTP.equals(value.feature())
+        && !value.isUnknown()
+        && Boolean.FALSE.equals(value.get());
+  }
+}

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/OssAdviceContentYamlStorage.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/OssAdviceContentYamlStorage.java
@@ -9,6 +9,7 @@ import com.sap.oss.phosphor.fosstars.model.RatingRepository;
 import com.sap.oss.phosphor.fosstars.model.rating.oss.OssArtifactSecurityRating;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -62,8 +63,11 @@ public class OssAdviceContentYamlStorage {
    * @param feature The feature.
    * @param context The context.
    * @return A list of advice.
+   * @throws MalformedURLException If the method couldn't parse URLs.
    */
-  public List<AdviceContent> adviceFor(Feature<?> feature, AdviceContext context) {
+  public List<AdviceContent> adviceFor(Feature<?> feature, AdviceContext context)
+      throws MalformedURLException {
+
     return adviceContentYamlStorage.adviceFor(feature, context);
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/OwaspDependencyCheckAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/OwaspDependencyCheckAdvisor.java
@@ -12,6 +12,7 @@ import com.sap.oss.phosphor.fosstars.model.score.oss.OwaspDependencyScanScore;
 import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckCvssThresholdValue;
 import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsageValue;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -33,7 +34,8 @@ public class OwaspDependencyCheckAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviseFor(
-      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context)
+      throws MalformedURLException {
 
     Optional<ScoreValue> owaspDependencyScanScore
         = findSubScoreValue(subject, OwaspDependencyScanScore.class);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/OwaspDependencyCheckAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/OwaspDependencyCheckAdvisor.java
@@ -1,0 +1,95 @@
+package com.sap.oss.phosphor.fosstars.advice.oss;
+
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_DEPENDENCY_CHECK_USAGE;
+import static com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsage.MANDATORY;
+
+import com.sap.oss.phosphor.fosstars.advice.Advice;
+import com.sap.oss.phosphor.fosstars.advice.oss.OssAdviceContentYamlStorage.OssAdviceContext;
+import com.sap.oss.phosphor.fosstars.model.Subject;
+import com.sap.oss.phosphor.fosstars.model.Value;
+import com.sap.oss.phosphor.fosstars.model.score.oss.OwaspDependencyScanScore;
+import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckCvssThresholdValue;
+import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsageValue;
+import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * An advisor for features related to OWASP Dependency Check.
+ */
+public class OwaspDependencyCheckAdvisor extends AbstractOssAdvisor {
+
+  /**
+   * Create a new advisor.
+   *
+   * @param contextFactory A factory that provides contexts for advice.
+   */
+  public OwaspDependencyCheckAdvisor(OssAdviceContextFactory contextFactory) {
+    super(OssAdviceContentYamlStorage.DEFAULT, contextFactory);
+  }
+
+  @Override
+  protected List<Advice> adviseFor(
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
+
+    Optional<ScoreValue> owaspDependencyScanScore
+        = findSubScoreValue(subject, OwaspDependencyScanScore.class);
+
+    if (!owaspDependencyScanScore.isPresent() || owaspDependencyScanScore.get().isNotApplicable()) {
+      return Collections.emptyList();
+    }
+
+    List<Advice> advice = new ArrayList<>();
+
+    advice.addAll(
+        adviceForFeature(usedValues, OWASP_DEPENDENCY_CHECK_USAGE, subject, context,
+            OwaspDependencyCheckAdvisor::notMandatoryOwaspDependencyCheck));
+
+    advice.addAll(
+        adviceForFeature(usedValues, OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD, subject, context,
+            OwaspDependencyCheckAdvisor::noThresholdForOwaspDependencyCheck));
+
+    return advice;
+  }
+
+  /**
+   * Checks if a value is
+   * {@link com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsageValue}
+   * and it is equal to
+   * {@link com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsage#MANDATORY}.
+   *
+   * @param value The value to be checked.
+   * @return True is the value is equal to
+   *         {@link com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsage#MANDATORY},
+   *         false otherwise.
+   */
+  private static boolean notMandatoryOwaspDependencyCheck(Value<?> value) {
+    return !value.isUnknown()
+        && value instanceof OwaspDependencyCheckUsageValue
+        && MANDATORY != value.get();
+  }
+
+  /**
+   * Check if a value is {@link OwaspDependencyCheckCvssThresholdValue}
+   * and a threshold is specified.
+   *
+   * @param value The value to be checked.
+   * @return True if the threshold for OWASP Dependency Check is specified.
+   */
+  private static boolean noThresholdForOwaspDependencyCheck(Value<?> value) {
+    if (value.isUnknown()) {
+      return false;
+    }
+
+    if (value instanceof OwaspDependencyCheckCvssThresholdValue) {
+      OwaspDependencyCheckCvssThresholdValue thresholdValue
+          = (OwaspDependencyCheckCvssThresholdValue) value;
+      return !thresholdValue.specified();
+    }
+
+    return false;
+  }
+}

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/OwaspDependencyCheckAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/OwaspDependencyCheckAdvisor.java
@@ -33,7 +33,7 @@ public class OwaspDependencyCheckAdvisor extends AbstractOssAdvisor {
   }
 
   @Override
-  protected List<Advice> adviseFor(
+  protected List<Advice> adviceFor(
       Subject subject, List<Value<?>> usedValues, OssAdviceContext context)
       throws MalformedURLException {
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/SecurityPolicyAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/SecurityPolicyAdvisor.java
@@ -6,6 +6,7 @@ import com.sap.oss.phosphor.fosstars.advice.Advice;
 import com.sap.oss.phosphor.fosstars.advice.oss.OssAdviceContentYamlStorage.OssAdviceContext;
 import com.sap.oss.phosphor.fosstars.model.Subject;
 import com.sap.oss.phosphor.fosstars.model.Value;
+import java.net.MalformedURLException;
 import java.util.List;
 
 /**
@@ -25,8 +26,9 @@ public class SecurityPolicyAdvisor extends AbstractOssAdvisor {
 
   @Override
   protected List<Advice> adviceFor(
-      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context)
+      throws MalformedURLException {
 
-    return adviseForBooleanFeature(usedValues, HAS_SECURITY_POLICY, subject, context);
+    return adviceForBooleanFeature(usedValues, HAS_SECURITY_POLICY, subject, context);
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/SigningAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/SigningAdvisor.java
@@ -1,0 +1,44 @@
+package com.sap.oss.phosphor.fosstars.advice.oss;
+
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
+
+import com.sap.oss.phosphor.fosstars.advice.Advice;
+import com.sap.oss.phosphor.fosstars.advice.oss.OssAdviceContentYamlStorage.OssAdviceContext;
+import com.sap.oss.phosphor.fosstars.model.Subject;
+import com.sap.oss.phosphor.fosstars.model.Value;
+import java.util.List;
+
+/**
+ * An advisor for features related to signing.
+ */
+public class SigningAdvisor extends AbstractOssAdvisor {
+
+  /**
+   * Create a new advisor.
+   *
+   * @param contextFactory A factory that provides contexts for advice.
+   */
+  public SigningAdvisor(OssAdviceContextFactory contextFactory) {
+    super(OssAdviceContentYamlStorage.DEFAULT, contextFactory);
+  }
+
+  @Override
+  protected List<Advice> adviseFor(
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
+
+    return adviseForFeature(
+        usedValues, SIGNS_ARTIFACTS, subject, context, SigningAdvisor::disabledArtifactSigning);
+  }
+
+  /**
+   * Checks if a value tells that artifact signing is disabled.
+   *
+   * @param value The value.
+   * @return True if artifact signing is disabled, false otherwise.
+   */
+  private static boolean disabledArtifactSigning(Value<?> value) {
+    return SIGNS_ARTIFACTS.equals(value.feature())
+        && !value.isUnknown()
+        && Boolean.FALSE.equals(value.get());
+  }
+}

--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/SigningAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/SigningAdvisor.java
@@ -6,6 +6,7 @@ import com.sap.oss.phosphor.fosstars.advice.Advice;
 import com.sap.oss.phosphor.fosstars.advice.oss.OssAdviceContentYamlStorage.OssAdviceContext;
 import com.sap.oss.phosphor.fosstars.model.Subject;
 import com.sap.oss.phosphor.fosstars.model.Value;
+import java.net.MalformedURLException;
 import java.util.List;
 
 /**
@@ -23,10 +24,11 @@ public class SigningAdvisor extends AbstractOssAdvisor {
   }
 
   @Override
-  protected List<Advice> adviseFor(
-      Subject subject, List<Value<?>> usedValues, OssAdviceContext context) {
+  protected List<Advice> adviceFor(
+      Subject subject, List<Value<?>> usedValues, OssAdviceContext context)
+      throws MalformedURLException {
 
-    return adviseForFeature(
+    return adviceForFeature(
         usedValues, SIGNS_ARTIFACTS, subject, context, SigningAdvisor::disabledArtifactSigning);
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/DependabotScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/DependabotScore.java
@@ -103,6 +103,15 @@ public class DependabotScore extends FeatureBasedScore {
     // then there is a chance that it takes advantage of security alerts
     // although we can't tell for sure
     if (usesGithub.orElse(false)) {
+      boolean dependabotCanBeUsed = packageManagers.orElse(PackageManagers.empty()).list().stream()
+          .anyMatch(SUPPORTED_LANGUAGES::containsKey);
+
+      // if the project does not use any package ecosystem that is supported by Dependabot,
+      // then a score is not applicable
+      if (!dependabotCanBeUsed) {
+        return scoreValue.makeNotApplicable();
+      }
+
       Languages usedLanguages = languages.orElse(Languages.empty());
       for (PackageManager packageManager : packageManagers.orElse(PackageManagers.empty())) {
         Languages supportedLanguages

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/OwaspDependencyScanScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/OwaspDependencyScanScore.java
@@ -2,7 +2,11 @@ package com.sap.oss.phosphor.fosstars.model.score.oss;
 
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_DEPENDENCY_CHECK_USAGE;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
 import static com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsage.NOT_USED;
+import static com.sap.oss.phosphor.fosstars.model.value.PackageManager.DOTNET;
+import static com.sap.oss.phosphor.fosstars.model.value.PackageManager.GRADLE;
+import static com.sap.oss.phosphor.fosstars.model.value.PackageManager.MAVEN;
 
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures;
@@ -10,6 +14,7 @@ import com.sap.oss.phosphor.fosstars.model.score.FeatureBasedScore;
 import com.sap.oss.phosphor.fosstars.model.value.CVSS;
 import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckCvssThresholdValue;
 import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsage;
+import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
 
 /**
@@ -28,6 +33,12 @@ public class OwaspDependencyScanScore extends FeatureBasedScore {
   private static final double STEP_SCORE = 3.0;
 
   /**
+   * Package ecosystems that are supported by OWASP Dependency Check.
+   */
+  private static final PackageManagers SUPPORTED_PACKAGE_MANAGERS
+      = PackageManagers.from(MAVEN, GRADLE, DOTNET);
+
+  /**
    * Initializes a new {@link OwaspDependencyScanScore}.
    */
   OwaspDependencyScanScore() {
@@ -40,8 +51,15 @@ public class OwaspDependencyScanScore extends FeatureBasedScore {
   public ScoreValue calculate(Value<?>... values) {
     Value<Double> thresholdValue = find(OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD, values);
     Value<OwaspDependencyCheckUsage> usageValue = find(OWASP_DEPENDENCY_CHECK_USAGE, values);
+    Value<PackageManagers> packageManagersValue = find(PACKAGE_MANAGERS, values);
 
-    ScoreValue scoreValue = scoreValue(MIN, usageValue, thresholdValue);
+    ScoreValue scoreValue = scoreValue(MIN, usageValue, thresholdValue, packageManagersValue);
+
+    if (!packageManagersValue.isUnknown()
+        && !SUPPORTED_PACKAGE_MANAGERS.containsAny(packageManagersValue.get())) {
+
+      return scoreValue.makeNotApplicable();
+    }
 
     OwaspDependencyCheckUsage usage = usageValue.orElse(NOT_USED);
     switch (usage) {

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/PackageManagers.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/PackageManagers.java
@@ -119,9 +119,19 @@ public class PackageManagers implements Iterable<PackageManager> {
    * @return True if the collection contains at least one of the package managers, false otherwise.
    */
   public boolean containsAny(PackageManager... packageManagers) {
+    return containsAny(from(packageManagers));
+  }
+
+  /**
+   * Check if the collection has at least one of the specified package managers.
+   *
+   * @param packageManagers The package managers.
+   * @return True if the collection contains at least one of the package managers, false otherwise.
+   */
+  public boolean containsAny(PackageManagers packageManagers) {
     Objects.requireNonNull(packageManagers, "Package manager can't be null!");
 
-    if (packageManagers.length == 0) {
+    if (packageManagers.size() == 0) {
       throw new IllegalArgumentException("Package managers can't be empty!");
     }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssArtifactSecurityRatingMarkdownFormatter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssArtifactSecurityRatingMarkdownFormatter.java
@@ -178,7 +178,7 @@ public class OssArtifactSecurityRatingMarkdownFormatter extends CommonFormatter 
    * @return Advice to be displayed.
    */
   private String adviceFor(Subject subject) {
-    List<Advice> adviseFor = advisor.adviseFor(subject);
+    List<Advice> adviseFor = advisor.adviceFor(subject);
     if (adviseFor.isEmpty()) {
       return StringUtils.EMPTY;
     }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssArtifactSecurityRatingMarkdownFormatter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssArtifactSecurityRatingMarkdownFormatter.java
@@ -11,6 +11,8 @@ import com.sap.oss.phosphor.fosstars.model.value.RatingValue;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerability;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -178,15 +180,21 @@ public class OssArtifactSecurityRatingMarkdownFormatter extends CommonFormatter 
    * @return Advice to be displayed.
    */
   private String adviceFor(Subject subject) {
-    List<Advice> adviseFor = advisor.adviceFor(subject);
-    if (adviseFor.isEmpty()) {
+    List<Advice> adviceList;
+    try {
+      adviceList = advisor.adviceFor(subject);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Oops! Could not print advice!", e);
+    }
+
+    if (adviceList.isEmpty()) {
       return StringUtils.EMPTY;
     }
 
     StringBuilder sb = new StringBuilder();
     sb.append("## How to improve the rating\n\n");
     int i = 1;
-    for (Advice advice : adviseFor) {
+    for (Advice advice : adviceList) {
       sb.append(String.format("%d.  %s", i++, advice.content().text()));
       if (!advice.content().links().isEmpty()) {
         sb.append("\n    More info:").append("\n");

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatter.java
@@ -179,7 +179,7 @@ public class OssSecurityRatingMarkdownFormatter extends CommonFormatter {
    * @return Advice to be displayed.
    */
   private String adviceFor(Subject subject) {
-    List<Advice> adviceList = advisor.adviseFor(subject);
+    List<Advice> adviceList = advisor.adviceFor(subject);
     if (adviceList.isEmpty()) {
       return StringUtils.EMPTY;
     }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatter.java
@@ -11,6 +11,8 @@ import com.sap.oss.phosphor.fosstars.model.value.RatingValue;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerability;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -179,7 +181,13 @@ public class OssSecurityRatingMarkdownFormatter extends CommonFormatter {
    * @return Advice to be displayed.
    */
   private String adviceFor(Subject subject) {
-    List<Advice> adviceList = advisor.adviceFor(subject);
+    List<Advice> adviceList;
+    try {
+      adviceList = advisor.adviceFor(subject);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Oops! Could not print advice!", e);
+    }
+
     if (adviceList.isEmpty()) {
       return StringUtils.EMPTY;
     }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinter.java
@@ -241,7 +241,7 @@ public class PrettyPrinter extends CommonFormatter {
       return StringUtils.EMPTY;
     }
 
-    List<Advice> adviceList = advisor.adviseFor(subject);
+    List<Advice> adviceList = advisor.adviceFor(subject);
     if (adviceList.isEmpty()) {
       return StringUtils.EMPTY;
     }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinter.java
@@ -10,6 +10,8 @@ import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.Weight;
 import com.sap.oss.phosphor.fosstars.model.value.RatingValue;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -241,7 +243,13 @@ public class PrettyPrinter extends CommonFormatter {
       return StringUtils.EMPTY;
     }
 
-    List<Advice> adviceList = advisor.adviceFor(subject);
+    List<Advice> adviceList;
+    try {
+      adviceList = advisor.adviceFor(subject);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Oops! Could not print advice!", e);
+    }
+
     if (adviceList.isEmpty()) {
       return StringUtils.EMPTY;
     }

--- a/src/main/resources/com/sap/oss/phosphor/fosstars/advice/oss/OssAdvice.yml
+++ b/src/main/resources/com/sap/oss/phosphor/fosstars/advice/oss/OssAdvice.yml
@@ -97,3 +97,9 @@ If a project signs artifacts:
     links:
       - name: Apache Maven Jarsigner Plugin
         url: https://maven.apache.org/plugins/maven-jarsigner-plugin/
+If a project uses nohttp tool:
+  - advice: >
+      You can enable NoHttp tool in the project's build pipeline.
+    links:
+      - name: NoHttp tool home page
+        url: https://github.com/spring-io/nohttp

--- a/src/main/resources/com/sap/oss/phosphor/fosstars/advice/oss/OssAdvice.yml
+++ b/src/main/resources/com/sap/oss/phosphor/fosstars/advice/oss/OssAdvice.yml
@@ -67,3 +67,9 @@ If an open-source project is included to OSS-Fuzz project:
 Version string:
   - advice: >
       Update the dependency version ${VERSION} to ${LATEST_VERSION}.
+If a project uses Dependabot:
+  - advice: >
+      You can configure Dependabot by creating a configuration file.
+    links:
+      - name: Configuration options for dependency updates
+        url: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates

--- a/src/main/resources/com/sap/oss/phosphor/fosstars/advice/oss/OssAdvice.yml
+++ b/src/main/resources/com/sap/oss/phosphor/fosstars/advice/oss/OssAdvice.yml
@@ -91,3 +91,9 @@ A CVSS threshold for OWASP Dependency Check to fail the build:
         url: https://jeremylong.github.io/DependencyCheck/
       - name: Configuring OWASP Dependency Check
         url: https://jeremylong.github.io/DependencyCheck/dependency-check-maven/configuration.html
+If a project signs artifacts:
+  - advice: >
+      You can enable artifact signing in the project's build pipeline.
+    links:
+      - name: Apache Maven Jarsigner Plugin
+        url: https://maven.apache.org/plugins/maven-jarsigner-plugin/

--- a/src/main/resources/com/sap/oss/phosphor/fosstars/advice/oss/OssAdvice.yml
+++ b/src/main/resources/com/sap/oss/phosphor/fosstars/advice/oss/OssAdvice.yml
@@ -73,3 +73,21 @@ If a project uses Dependabot:
     links:
       - name: Configuration options for dependency updates
         url: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+How OWASP Dependency Check is used:
+  - advice: >
+      You can add OWASP Dependency Check to the project's build pipeline.
+    links:
+      - name: OWASP Dependnecy Check
+        url: https://jeremylong.github.io/DependencyCheck/
+      - name: How to use OWASP Dependency Check with Maven
+        url: https://jeremylong.github.io/DependencyCheck/dependency-check-maven
+      - name: How to use OWASP Dependnecy Check with Gradle
+        url: https://github.com/dependency-check/dependency-check-gradle
+A CVSS threshold for OWASP Dependency Check to fail the build:
+  - advice: >
+      You can set a CVSS threshold for vulnerabilities reported by OWASP Dependency Check.
+    links:
+      - name: OWASP Dependnecy Check
+        url: https://jeremylong.github.io/DependencyCheck/
+      - name: Configuring OWASP Dependency Check
+        url: https://jeremylong.github.io/DependencyCheck/dependency-check-maven/configuration.html

--- a/src/test/java/com/sap/oss/phosphor/fosstars/TestUtils.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/TestUtils.java
@@ -62,7 +62,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/CodeqlAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/CodeqlAdvisorTest.java
@@ -14,12 +14,13 @@ import com.sap.oss.phosphor.fosstars.model.ValueSet;
 import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import java.net.MalformedURLException;
 import org.junit.Test;
 
 public class CodeqlAdvisorTest {
 
   @Test
-  public void testAdviseForCodeQl() {
+  public void testAdviseForCodeQl() throws MalformedURLException {
     CodeqlAdvisor advisor = new CodeqlAdvisor(OssAdviceContextFactory.WITH_EMPTY_CONTEXT);
     GitHubProject project = new GitHubProject("org", "test");
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/CodeqlAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/CodeqlAdvisorTest.java
@@ -24,33 +24,33 @@ public class CodeqlAdvisorTest {
     GitHubProject project = new GitHubProject("org", "test");
 
     // no advice if no rating value is set
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
     ValueSet values = new ValueHashSet();
 
     // no advice for an unknown values
     values.update(allUnknown(rating.score().allFeatures()));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     // no advice if the LGTM checks are enabled
     values.update(USES_LGTM_CHECKS.value(true));
     project.set(rating.calculate(values));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     // expect an advice if the LGTM checks are not enabled
     values.update(USES_LGTM_CHECKS.value(false));
     project.set(rating.calculate(values));
-    assertEquals(1, advisor.adviseFor(project).size());
+    assertEquals(1, advisor.adviceFor(project).size());
 
     // expect an advice if the  checks are not enabled
     values.update(USES_CODEQL_CHECKS.value(false));
     project.set(rating.calculate(values));
-    assertEquals(2, advisor.adviseFor(project).size());
+    assertEquals(2, advisor.adviceFor(project).size());
 
     // expect an advice if the LGTM checks are not enabled
     values.update(RUNS_CODEQL_SCANS.value(false));
     project.set(rating.calculate(values));
-    assertEquals(3, advisor.adviseFor(project).size());
+    assertEquals(3, advisor.adviceFor(project).size());
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/DependabotAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/DependabotAdvisorTest.java
@@ -21,12 +21,13 @@ import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.Languages;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import java.net.MalformedURLException;
 import org.junit.Test;
 
 public class DependabotAdvisorTest {
 
   @Test
-  public void testAdviseForDependabot() {
+  public void testAdviseForDependabot() throws MalformedURLException {
     DependabotAdvisor advisor = new DependabotAdvisor(WITH_EMPTY_CONTEXT);
     GitHubProject project = new GitHubProject("org", "test");
 
@@ -53,7 +54,7 @@ public class DependabotAdvisorTest {
   }
 
   @Test
-  public void testAdviceWhenDependabotScoreIsNotApplicable() {
+  public void testAdviceWhenDependabotScoreIsNotApplicable() throws MalformedURLException {
     final DependabotAdvisor advisor = new DependabotAdvisor(WITH_EMPTY_CONTEXT);
     final GitHubProject project = new GitHubProject("org", "test");
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/DependabotAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/DependabotAdvisorTest.java
@@ -1,0 +1,70 @@
+package com.sap.oss.phosphor.fosstars.advice.oss;
+
+import static com.sap.oss.phosphor.fosstars.advice.oss.AbstractOssAdvisor.OssAdviceContextFactory.WITH_EMPTY_CONTEXT;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_GITHUB_FOR_DEVELOPMENT;
+import static com.sap.oss.phosphor.fosstars.model.other.Utils.allUnknown;
+import static com.sap.oss.phosphor.fosstars.model.value.Language.C;
+import static com.sap.oss.phosphor.fosstars.model.value.Language.JAVA;
+import static com.sap.oss.phosphor.fosstars.model.value.PackageManager.MAVEN;
+import static com.sap.oss.phosphor.fosstars.model.value.PackageManager.OTHER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.oss.phosphor.fosstars.model.Rating;
+import com.sap.oss.phosphor.fosstars.model.RatingRepository;
+import com.sap.oss.phosphor.fosstars.model.ValueSet;
+import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.model.value.Languages;
+import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
+import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import org.junit.Test;
+
+public class DependabotAdvisorTest {
+
+  @Test
+  public void testAdviseForDependabot() {
+    DependabotAdvisor advisor = new DependabotAdvisor(WITH_EMPTY_CONTEXT);
+    GitHubProject project = new GitHubProject("org", "test");
+
+    // no advice if no rating value is set
+    assertTrue(advisor.adviseFor(project).isEmpty());
+
+    Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
+    ValueSet values = new ValueHashSet();
+
+    // no advice for an unknown values
+    values.update(allUnknown(rating.score().allFeatures()));
+    values.update(LANGUAGES.value(Languages.of(JAVA)));
+    values.update(PACKAGE_MANAGERS.value(PackageManagers.from(MAVEN)));
+    values.update(USES_GITHUB_FOR_DEVELOPMENT.value(true));
+    assertTrue(advisor.adviseFor(project).isEmpty());
+
+    values.update(USES_DEPENDABOT.value(true));
+    project.set(rating.calculate(values));
+    assertTrue(advisor.adviseFor(project).isEmpty());
+
+    values.update(USES_DEPENDABOT.value(false));
+    project.set(rating.calculate(values));
+    assertEquals(1, advisor.adviseFor(project).size());
+  }
+
+  @Test
+  public void testAdviceWhenDependabotScoreIsNotApplicable() {
+    final DependabotAdvisor advisor = new DependabotAdvisor(WITH_EMPTY_CONTEXT);
+    final GitHubProject project = new GitHubProject("org", "test");
+
+    Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
+    ValueSet values = new ValueHashSet();
+    values.update(allUnknown(rating.score().allFeatures()));
+    values.update(USES_DEPENDABOT.value(false));
+    values.update(USES_GITHUB_FOR_DEVELOPMENT.value(true));
+    values.update(LANGUAGES.value(Languages.of(C)));
+    values.update(PACKAGE_MANAGERS.value(PackageManagers.from(OTHER)));
+    project.set(rating.calculate(values));
+    assertTrue(advisor.adviseFor(project).isEmpty());
+  }
+}

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/FindSecBugsAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/FindSecBugsAdvisorTest.java
@@ -14,13 +14,14 @@ import com.sap.oss.phosphor.fosstars.model.ValueSet;
 import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import java.net.MalformedURLException;
 import java.util.List;
 import org.junit.Test;
 
 public class FindSecBugsAdvisorTest {
 
   @Test
-  public void testAdviseForFindSecBugs() {
+  public void testAdviseForFindSecBugs() throws MalformedURLException {
     FindSecBugsAdvisor advisor = new FindSecBugsAdvisor(WITH_EMPTY_CONTEXT);
     GitHubProject project = new GitHubProject("org", "test");
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/FindSecBugsAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/FindSecBugsAdvisorTest.java
@@ -25,24 +25,24 @@ public class FindSecBugsAdvisorTest {
     GitHubProject project = new GitHubProject("org", "test");
 
     // no advice if no rating value is set
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
     ValueSet values = new ValueHashSet();
 
     // no advice for an unknown values
     values.update(allUnknown(rating.score().allFeatures()));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     // no advice if the project already uses FindSecBugs
     values.update(USES_FIND_SEC_BUGS.value(true));
     project.set(rating.calculate(values));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     // expect an advice if the project doesn't use FindSecBugs
     values.update(USES_FIND_SEC_BUGS.value(false));
     project.set(rating.calculate(values));
-    List<Advice> adviceList = advisor.adviseFor(project);
+    List<Advice> adviceList = advisor.adviceFor(project);
     assertEquals(1, adviceList.size());
     Advice advice = adviceList.get(0);
     assertFalse(advice.content().text().isEmpty());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/FuzzingAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/FuzzingAdvisorTest.java
@@ -16,12 +16,13 @@ import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.Languages;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import java.net.MalformedURLException;
 import org.junit.Test;
 
 public class FuzzingAdvisorTest {
 
   @Test
-  public void testAdviseForOssFuzz() {
+  public void testAdviseForOssFuzz() throws MalformedURLException {
     FuzzingAdvisor advisor = new FuzzingAdvisor(WITH_EMPTY_CONTEXT);
     GitHubProject project = new GitHubProject("org", "test");
 
@@ -48,7 +49,7 @@ public class FuzzingAdvisorTest {
   }
 
   @Test
-  public void testAdviceWhenFuzzingScoreIsNotApplicable() {
+  public void testAdviceWhenFuzzingScoreIsNotApplicable() throws MalformedURLException {
     final FuzzingAdvisor advisor = new FuzzingAdvisor(WITH_EMPTY_CONTEXT);
     final GitHubProject project = new GitHubProject("org", "test");
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/FuzzingAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/FuzzingAdvisorTest.java
@@ -26,25 +26,25 @@ public class FuzzingAdvisorTest {
     GitHubProject project = new GitHubProject("org", "test");
 
     // no advice if no rating value is set
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
     ValueSet values = new ValueHashSet();
 
     // no advice for an unknown values
     values.update(allUnknown(rating.score().allFeatures()));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     // no advice if the project is fuzzed in OSS-Fuzz
     values.update(FUZZED_IN_OSS_FUZZ.value(true));
     values.update(LANGUAGES.value(Languages.of(C)));
     project.set(rating.calculate(values));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     // expect an advice if the project is not fuzzed in OSS-Fuzz
     values.update(FUZZED_IN_OSS_FUZZ.value(false));
     project.set(rating.calculate(values));
-    assertEquals(1, advisor.adviseFor(project).size());
+    assertEquals(1, advisor.adviceFor(project).size());
   }
 
   @Test
@@ -61,6 +61,6 @@ public class FuzzingAdvisorTest {
 
     // fuzzing score is not applicable for projects that use only Java
     // therefore no advice are expected.
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/LgtmScoreAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/LgtmScoreAdvisorTest.java
@@ -9,21 +9,34 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.sap.oss.phosphor.fosstars.advice.Advice;
-import com.sap.oss.phosphor.fosstars.advice.oss.AbstractOssAdvisor.OssAdviceContextFactory;
+import com.sap.oss.phosphor.fosstars.advice.oss.OssAdviceContentYamlStorage.OssAdviceContext;
 import com.sap.oss.phosphor.fosstars.model.Rating;
 import com.sap.oss.phosphor.fosstars.model.RatingRepository;
 import com.sap.oss.phosphor.fosstars.model.ValueSet;
 import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import java.net.MalformedURLException;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Test;
 
 public class LgtmScoreAdvisorTest {
 
   @Test
-  public void testAdviseForLgtmGrade() {
-    LgtmAdvisor advisor = new LgtmAdvisor(OssAdviceContextFactory.WITH_EMPTY_CONTEXT);
+  public void testAdviseForLgtmGrade() throws MalformedURLException {
+    LgtmAdvisor advisor = new LgtmAdvisor(subject -> new OssAdviceContext() {
+
+      @Override
+      public Optional<String> lgtmProjectLink() {
+        return Optional.of("https://lgtm.com");
+      }
+
+      @Override
+      public Optional<String> suggestSecurityPolicyLink() {
+        return Optional.of("https://github.com");
+      }
+    });
     GitHubProject project = new GitHubProject("org", "test");
 
     // no advice if no rating value is set
@@ -48,6 +61,6 @@ public class LgtmScoreAdvisorTest {
     assertEquals(1, adviceList.size());
     Advice advice = adviceList.get(0);
     assertFalse(advice.content().text().isEmpty());
-    assertTrue(advice.content().links().isEmpty());
+    assertFalse(advice.content().links().isEmpty());
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/LgtmScoreAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/LgtmScoreAdvisorTest.java
@@ -27,24 +27,24 @@ public class LgtmScoreAdvisorTest {
     GitHubProject project = new GitHubProject("org", "test");
 
     // no advice if no rating value is set
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
     ValueSet values = new ValueHashSet();
 
     // no advice for an unknown values
     values.update(allUnknown(rating.score().allFeatures()));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     // no advice if the LGTM grade is the best
     values.update(WORST_LGTM_GRADE.value(A_PLUS));
     project.set(rating.calculate(values));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     // expect an advice if the LGTM grade is not the best
     values.update(WORST_LGTM_GRADE.value(B));
     project.set(rating.calculate(values));
-    List<Advice> adviceList = advisor.adviseFor(project);
+    List<Advice> adviceList = advisor.adviceFor(project);
     assertEquals(1, adviceList.size());
     Advice advice = adviceList.get(0);
     assertFalse(advice.content().text().isEmpty());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/MemorySafetyAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/MemorySafetyAdvisorTest.java
@@ -17,12 +17,13 @@ import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.Languages;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import java.net.MalformedURLException;
 import org.junit.Test;
 
 public class MemorySafetyAdvisorTest {
 
   @Test
-  public void testAdviseForMemorySanitizers() {
+  public void testAdviseForMemorySanitizers() throws MalformedURLException {
     MemorySafetyAdvisor advisor = new MemorySafetyAdvisor(WITH_EMPTY_CONTEXT);
     GitHubProject project = new GitHubProject("org", "test");
 
@@ -60,7 +61,7 @@ public class MemorySafetyAdvisorTest {
   }
 
   @Test
-  public void testAdviseWhenMemorySafetyTestingScoreIsNotApplicable() {
+  public void testAdviseWhenMemorySafetyTestingScoreIsNotApplicable() throws MalformedURLException {
     final MemorySafetyAdvisor advisor = new MemorySafetyAdvisor(WITH_EMPTY_CONTEXT);
     final GitHubProject project = new GitHubProject("org", "test");
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/MemorySafetyAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/MemorySafetyAdvisorTest.java
@@ -27,36 +27,36 @@ public class MemorySafetyAdvisorTest {
     GitHubProject project = new GitHubProject("org", "test");
 
     // no advice if no rating value is set
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
     ValueSet values = new ValueHashSet();
 
     // no advice for an unknown values
     values.update(allUnknown(rating.score().allFeatures()));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     // no advice if sanitizers are enabled
     values.update(USES_ADDRESS_SANITIZER.value(true));
     values.update(USES_MEMORY_SANITIZER.value(true));
     values.update(USES_UNDEFINED_BEHAVIOR_SANITIZER.value(true));
     project.set(rating.calculate(values));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     // expect an advice if AddressSanitizer is not used
     values.update(USES_ADDRESS_SANITIZER.value(false));
     project.set(rating.calculate(values));
-    assertEquals(1, advisor.adviseFor(project).size());
+    assertEquals(1, advisor.adviceFor(project).size());
 
     // expect an advice if MemorySanitizer is not used
     values.update(USES_MEMORY_SANITIZER.value(false));
     project.set(rating.calculate(values));
-    assertEquals(2, advisor.adviseFor(project).size());
+    assertEquals(2, advisor.adviceFor(project).size());
 
     // expect an advice if UndefinedBehaviorSanitizer is not used
     values.update(USES_UNDEFINED_BEHAVIOR_SANITIZER.value(false));
     project.set(rating.calculate(values));
-    assertEquals(3, advisor.adviseFor(project).size());
+    assertEquals(3, advisor.adviceFor(project).size());
   }
 
   @Test
@@ -75,6 +75,6 @@ public class MemorySafetyAdvisorTest {
 
     // sanitizers are not applicable for projects that use only Java
     // therefore no advice are expected.
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/NoHttpAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/NoHttpAdvisorTest.java
@@ -23,7 +23,7 @@ public class NoHttpAdvisorTest {
     GitHubProject project = new GitHubProject("org", "test");
 
     // no advice if no rating value is set
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
     ValueSet values = new ValueHashSet();
@@ -31,10 +31,10 @@ public class NoHttpAdvisorTest {
 
     values.update(USES_NOHTTP.value(true));
     project.set(rating.calculate(values));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     values.update(USES_NOHTTP.value(false));
     project.set(rating.calculate(values));
-    assertFalse(advisor.adviseFor(project).isEmpty());
+    assertFalse(advisor.adviceFor(project).isEmpty());
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/NoHttpAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/NoHttpAdvisorTest.java
@@ -1,0 +1,40 @@
+package com.sap.oss.phosphor.fosstars.advice.oss;
+
+import static com.sap.oss.phosphor.fosstars.advice.oss.AbstractOssAdvisor.OssAdviceContextFactory.WITH_EMPTY_CONTEXT;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_NOHTTP;
+import static com.sap.oss.phosphor.fosstars.model.other.Utils.allUnknown;
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.oss.phosphor.fosstars.model.Rating;
+import com.sap.oss.phosphor.fosstars.model.RatingRepository;
+import com.sap.oss.phosphor.fosstars.model.ValueSet;
+import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import java.net.MalformedURLException;
+import org.junit.Test;
+
+public class NoHttpAdvisorTest {
+
+  @Test
+  public void testAdviseForNoHttp() throws MalformedURLException {
+    NoHttpAdvisor advisor = new NoHttpAdvisor(WITH_EMPTY_CONTEXT);
+    GitHubProject project = new GitHubProject("org", "test");
+
+    // no advice if no rating value is set
+    assertTrue(advisor.adviseFor(project).isEmpty());
+
+    Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
+    ValueSet values = new ValueHashSet();
+    values.update(allUnknown(rating.score().allFeatures()));
+
+    values.update(USES_NOHTTP.value(true));
+    project.set(rating.calculate(values));
+    assertTrue(advisor.adviseFor(project).isEmpty());
+
+    values.update(USES_NOHTTP.value(false));
+    project.set(rating.calculate(values));
+    assertFalse(advisor.adviseFor(project).isEmpty());
+  }
+}

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/OssAdviceContentYamlStorageTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/OssAdviceContentYamlStorageTest.java
@@ -7,13 +7,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.sap.oss.phosphor.fosstars.advice.AdviceContent;
+import java.net.MalformedURLException;
 import java.util.List;
 import org.junit.Test;
 
 public class OssAdviceContentYamlStorageTest {
 
   @Test
-  public void testDefault() {
+  public void testDefault() throws MalformedURLException {
     List<AdviceContent> advice = OssAdviceContentYamlStorage.DEFAULT.adviceFor(
         USES_LGTM_CHECKS, EMPTY_OSS_CONTEXT);
     assertFalse(advice.isEmpty());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/OwaspDependencyCheckAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/OwaspDependencyCheckAdvisorTest.java
@@ -1,13 +1,12 @@
 package com.sap.oss.phosphor.fosstars.advice.oss;
 
 import static com.sap.oss.phosphor.fosstars.advice.oss.AbstractOssAdvisor.OssAdviceContextFactory.WITH_EMPTY_CONTEXT;
-import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_DEPENDENCY_CHECK_USAGE;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
-import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_DEPENDABOT;
-import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_GITHUB_FOR_DEVELOPMENT;
 import static com.sap.oss.phosphor.fosstars.model.other.Utils.allUnknown;
-import static com.sap.oss.phosphor.fosstars.model.value.Language.C;
-import static com.sap.oss.phosphor.fosstars.model.value.Language.JAVA;
+import static com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsage.MANDATORY;
+import static com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsage.NOT_USED;
 import static com.sap.oss.phosphor.fosstars.model.value.PackageManager.MAVEN;
 import static com.sap.oss.phosphor.fosstars.model.value.PackageManager.OTHER;
 import static org.junit.Assert.assertEquals;
@@ -18,16 +17,15 @@ import com.sap.oss.phosphor.fosstars.model.RatingRepository;
 import com.sap.oss.phosphor.fosstars.model.ValueSet;
 import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
-import com.sap.oss.phosphor.fosstars.model.value.Languages;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
 import org.junit.Test;
 
-public class DependabotAdvisorTest {
+public class OwaspDependencyCheckAdvisorTest {
 
   @Test
-  public void testAdviseForDependabot() {
-    DependabotAdvisor advisor = new DependabotAdvisor(WITH_EMPTY_CONTEXT);
+  public void testAdviseForOwaspDependencyScan() {
+    OwaspDependencyCheckAdvisor advisor = new OwaspDependencyCheckAdvisor(WITH_EMPTY_CONTEXT);
     GitHubProject project = new GitHubProject("org", "test");
 
     // no advice if no rating value is set
@@ -38,31 +36,30 @@ public class DependabotAdvisorTest {
 
     // no advice for an unknown values
     values.update(allUnknown(rating.score().allFeatures()));
-    values.update(LANGUAGES.value(Languages.of(JAVA)));
+    values.update(OWASP_DEPENDENCY_CHECK_USAGE.value(MANDATORY));
+    values.update(OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.value(7.0));
     values.update(PACKAGE_MANAGERS.value(PackageManagers.from(MAVEN)));
-    values.update(USES_GITHUB_FOR_DEVELOPMENT.value(true));
     assertTrue(advisor.adviceFor(project).isEmpty());
 
-    values.update(USES_DEPENDABOT.value(true));
-    project.set(rating.calculate(values));
-    assertTrue(advisor.adviceFor(project).isEmpty());
-
-    values.update(USES_DEPENDABOT.value(false));
+    values.update(OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.notSpecifiedValue());
     project.set(rating.calculate(values));
     assertEquals(1, advisor.adviceFor(project).size());
+
+    values.update(OWASP_DEPENDENCY_CHECK_USAGE.value(NOT_USED));
+    project.set(rating.calculate(values));
+    assertEquals(2, advisor.adviceFor(project).size());
   }
 
   @Test
-  public void testAdviceWhenDependabotScoreIsNotApplicable() {
-    final DependabotAdvisor advisor = new DependabotAdvisor(WITH_EMPTY_CONTEXT);
+  public void testAdviceWhenOwaspDependencyScanScoreIsNotApplicable() {
+    final OwaspDependencyCheckAdvisor advisor = new OwaspDependencyCheckAdvisor(WITH_EMPTY_CONTEXT);
     final GitHubProject project = new GitHubProject("org", "test");
 
     Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
     ValueSet values = new ValueHashSet();
     values.update(allUnknown(rating.score().allFeatures()));
-    values.update(USES_DEPENDABOT.value(false));
-    values.update(USES_GITHUB_FOR_DEVELOPMENT.value(true));
-    values.update(LANGUAGES.value(Languages.of(C)));
+    values.update(OWASP_DEPENDENCY_CHECK_USAGE.value(NOT_USED));
+    values.update(OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.notSpecifiedValue());
     values.update(PACKAGE_MANAGERS.value(PackageManagers.from(OTHER)));
     project.set(rating.calculate(values));
     assertTrue(advisor.adviceFor(project).isEmpty());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/OwaspDependencyCheckAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/OwaspDependencyCheckAdvisorTest.java
@@ -19,12 +19,13 @@ import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import java.net.MalformedURLException;
 import org.junit.Test;
 
 public class OwaspDependencyCheckAdvisorTest {
 
   @Test
-  public void testAdviseForOwaspDependencyScan() {
+  public void testAdviseForOwaspDependencyScan() throws MalformedURLException {
     OwaspDependencyCheckAdvisor advisor = new OwaspDependencyCheckAdvisor(WITH_EMPTY_CONTEXT);
     GitHubProject project = new GitHubProject("org", "test");
 
@@ -51,7 +52,7 @@ public class OwaspDependencyCheckAdvisorTest {
   }
 
   @Test
-  public void testAdviceWhenOwaspDependencyScanScoreIsNotApplicable() {
+  public void testAdviceWhenOwaspDependencyScanScoreIsNotApplicable() throws MalformedURLException {
     final OwaspDependencyCheckAdvisor advisor = new OwaspDependencyCheckAdvisor(WITH_EMPTY_CONTEXT);
     final GitHubProject project = new GitHubProject("org", "test");
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/SecurityPolicyAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/SecurityPolicyAdvisorTest.java
@@ -1,6 +1,5 @@
 package com.sap.oss.phosphor.fosstars.advice.oss;
 
-import static com.sap.oss.phosphor.fosstars.advice.oss.AbstractOssAdvisor.OssAdviceContextFactory.WITH_EMPTY_CONTEXT;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_POLICY;
 import static com.sap.oss.phosphor.fosstars.model.other.Utils.allUnknown;
 import static org.junit.Assert.assertEquals;
@@ -8,20 +7,35 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.sap.oss.phosphor.fosstars.advice.Advice;
+import com.sap.oss.phosphor.fosstars.advice.oss.OssAdviceContentYamlStorage.OssAdviceContext;
 import com.sap.oss.phosphor.fosstars.model.Rating;
 import com.sap.oss.phosphor.fosstars.model.RatingRepository;
 import com.sap.oss.phosphor.fosstars.model.ValueSet;
 import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import java.net.MalformedURLException;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Test;
 
 public class SecurityPolicyAdvisorTest {
 
   @Test
-  public void testAdviseForSecurityPolicy() {
-    SecurityPolicyAdvisor advisor = new SecurityPolicyAdvisor(WITH_EMPTY_CONTEXT);
+  public void testAdviseForSecurityPolicy() throws MalformedURLException {
+    SecurityPolicyAdvisor advisor = new SecurityPolicyAdvisor(subject -> new OssAdviceContext() {
+
+      @Override
+      public Optional<String> lgtmProjectLink() {
+        return Optional.of("https://lgtm.com");
+      }
+
+      @Override
+      public Optional<String> suggestSecurityPolicyLink() {
+        return Optional.of("https://github.com");
+
+      }
+    });
     GitHubProject project = new GitHubProject("org", "test");
 
     // no advice if no rating value is set

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/SecurityPolicyAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/SecurityPolicyAdvisorTest.java
@@ -25,24 +25,24 @@ public class SecurityPolicyAdvisorTest {
     GitHubProject project = new GitHubProject("org", "test");
 
     // no advice if no rating value is set
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
     ValueSet values = new ValueHashSet();
 
     // no advice for an unknown values
     values.update(allUnknown(rating.score().allFeatures()));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     // no advice if the project has a security policy
     values.update(HAS_SECURITY_POLICY.value(true));
     project.set(rating.calculate(values));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     // expect an advice if the project doesn't have a security policy
     values.update(HAS_SECURITY_POLICY.value(false));
     project.set(rating.calculate(values));
-    List<Advice> adviceList = advisor.adviseFor(project);
+    List<Advice> adviceList = advisor.adviceFor(project);
     assertEquals(1, adviceList.size());
     Advice advice = adviceList.get(0);
     assertFalse(advice.content().text().isEmpty());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/SigningAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/SigningAdvisorTest.java
@@ -1,0 +1,39 @@
+package com.sap.oss.phosphor.fosstars.advice.oss;
+
+import static com.sap.oss.phosphor.fosstars.advice.oss.AbstractOssAdvisor.OssAdviceContextFactory.WITH_EMPTY_CONTEXT;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
+import static com.sap.oss.phosphor.fosstars.model.other.Utils.allUnknown;
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.oss.phosphor.fosstars.model.Rating;
+import com.sap.oss.phosphor.fosstars.model.RatingRepository;
+import com.sap.oss.phosphor.fosstars.model.ValueSet;
+import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import org.junit.Test;
+
+public class SigningAdvisorTest {
+
+  @Test
+  public void testAdviseForSigningArtifacts() {
+    SigningAdvisor advisor = new SigningAdvisor(WITH_EMPTY_CONTEXT);
+    GitHubProject project = new GitHubProject("org", "test");
+
+    // no advice if no rating value is set
+    assertTrue(advisor.adviseFor(project).isEmpty());
+
+    Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
+    ValueSet values = new ValueHashSet();
+    values.update(allUnknown(rating.score().allFeatures()));
+
+    values.update(SIGNS_ARTIFACTS.value(true));
+    project.set(rating.calculate(values));
+    assertTrue(advisor.adviseFor(project).isEmpty());
+
+    values.update(SIGNS_ARTIFACTS.value(false));
+    project.set(rating.calculate(values));
+    assertFalse(advisor.adviseFor(project).isEmpty());
+  }
+}

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/SigningAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/SigningAdvisorTest.java
@@ -3,6 +3,7 @@ package com.sap.oss.phosphor.fosstars.advice.oss;
 import static com.sap.oss.phosphor.fosstars.advice.oss.AbstractOssAdvisor.OssAdviceContextFactory.WITH_EMPTY_CONTEXT;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
 import static com.sap.oss.phosphor.fosstars.model.other.Utils.allUnknown;
+import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.sap.oss.phosphor.fosstars.model.Rating;
@@ -22,7 +23,7 @@ public class SigningAdvisorTest {
     GitHubProject project = new GitHubProject("org", "test");
 
     // no advice if no rating value is set
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
     ValueSet values = new ValueHashSet();
@@ -30,10 +31,10 @@ public class SigningAdvisorTest {
 
     values.update(SIGNS_ARTIFACTS.value(true));
     project.set(rating.calculate(values));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     values.update(SIGNS_ARTIFACTS.value(false));
     project.set(rating.calculate(values));
-    assertFalse(advisor.adviseFor(project).isEmpty());
+    assertFalse(advisor.adviceFor(project).isEmpty());
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/SigningAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/SigningAdvisorTest.java
@@ -3,7 +3,6 @@ package com.sap.oss.phosphor.fosstars.advice.oss;
 import static com.sap.oss.phosphor.fosstars.advice.oss.AbstractOssAdvisor.OssAdviceContextFactory.WITH_EMPTY_CONTEXT;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
 import static com.sap.oss.phosphor.fosstars.model.other.Utils.allUnknown;
-import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.sap.oss.phosphor.fosstars.model.Rating;
@@ -12,12 +11,13 @@ import com.sap.oss.phosphor.fosstars.model.ValueSet;
 import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import java.net.MalformedURLException;
 import org.junit.Test;
 
 public class SigningAdvisorTest {
 
   @Test
-  public void testAdviseForSigningArtifacts() {
+  public void testAdviseForSigningArtifacts() throws MalformedURLException {
     SigningAdvisor advisor = new SigningAdvisor(WITH_EMPTY_CONTEXT);
     GitHubProject project = new GitHubProject("org", "test");
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/github/OssSecurityGithubAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/github/OssSecurityGithubAdvisorTest.java
@@ -37,24 +37,24 @@ public class OssSecurityGithubAdvisorTest {
     GitHubProject project = new GitHubProject("org", "test");
 
     // no advice if no rating value is set
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
     ValueSet values = new ValueHashSet();
 
     // no advice for an unknown values
     values.update(allUnknown(rating.score().allFeatures()));
-    assertTrue(advisor.adviseFor(project).isEmpty());
+    assertTrue(advisor.adviceFor(project).isEmpty());
 
     // expect an advice if the LGTM checks are not enabled
     values.update(USES_LGTM_CHECKS.value(false));
     project.set(rating.calculate(values));
-    assertEquals(1, advisor.adviseFor(project).size());
+    assertEquals(1, advisor.adviceFor(project).size());
 
     // expect an advice if the LGTM grade is not the best
     values.update(WORST_LGTM_GRADE.value(B));
     project.set(rating.calculate(values));
-    assertEquals(2, advisor.adviseFor(project).size());
+    assertEquals(2, advisor.adviceFor(project).size());
   }
 
   @Test
@@ -69,7 +69,7 @@ public class OssSecurityGithubAdvisorTest {
     project.set(rating.calculate(values));
 
     // expect an advice if the LGTM grade is not the best
-    List<Advice> adviceList = advisor.adviseFor(project);
+    List<Advice> adviceList = advisor.adviceFor(project);
     assertEquals(1, adviceList.size());
     Advice advice = adviceList.get(0);
     assertFalse(advice.content().text().isEmpty());
@@ -90,7 +90,7 @@ public class OssSecurityGithubAdvisorTest {
     // expect an advice if the project doesn't have a security policy
     values.update(HAS_SECURITY_POLICY.value(false));
     project.set(rating.calculate(values));
-    List<Advice> adviceList = advisor.adviseFor(project);
+    List<Advice> adviceList = advisor.adviceFor(project);
     assertEquals(1, adviceList.size());
     Advice advice = adviceList.get(0);
     assertFalse(advice.content().text().isEmpty());
@@ -111,7 +111,7 @@ public class OssSecurityGithubAdvisorTest {
     // expect an advice if the project doesn't use FindSecBugs
     values.update(USES_FIND_SEC_BUGS.value(false));
     project.set(rating.calculate(values));
-    List<Advice> adviceList = advisor.adviseFor(project);
+    List<Advice> adviceList = advisor.adviceFor(project);
     assertEquals(1, adviceList.size());
     Advice advice = adviceList.get(0);
     assertFalse(advice.content().text().isEmpty());
@@ -134,7 +134,7 @@ public class OssSecurityGithubAdvisorTest {
     values.update(USES_MEMORY_SANITIZER.value(false));
     values.update(USES_UNDEFINED_BEHAVIOR_SANITIZER.value(false));
     project.set(rating.calculate(values));
-    List<Advice> adviceList = advisor.adviseFor(project);
+    List<Advice> adviceList = advisor.adviceFor(project);
     assertEquals(3, adviceList.size());
     for (Advice advice : adviceList) {
       assertFalse(advice.content().text().isEmpty());
@@ -154,7 +154,7 @@ public class OssSecurityGithubAdvisorTest {
     values.update(FUZZED_IN_OSS_FUZZ.value(false));
     values.update(LANGUAGES.value(Languages.of(C)));
     project.set(rating.calculate(values));
-    List<Advice> adviceList = advisor.adviseFor(project);
+    List<Advice> adviceList = advisor.adviceFor(project);
     Advice advice = adviceList.get(0);
     assertFalse(advice.content().text().isEmpty());
     assertFalse(advice.content().links().isEmpty());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/github/OssSecurityGithubAdvisorTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/advice/oss/github/OssSecurityGithubAdvisorTest.java
@@ -25,13 +25,14 @@ import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.Languages;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import java.io.IOException;
 import java.util.List;
 import org.junit.Test;
 
 public class OssSecurityGithubAdvisorTest {
 
   @Test
-  public void testBasics() {
+  public void testBasics() throws IOException {
     OssSecurityGithubAdvisor advisor = new OssSecurityGithubAdvisor();
 
     GitHubProject project = new GitHubProject("org", "test");
@@ -58,7 +59,7 @@ public class OssSecurityGithubAdvisorTest {
   }
 
   @Test
-  public void testAdviceForLgtmGrade() {
+  public void testAdviceForLgtmGrade() throws IOException {
     final OssSecurityGithubAdvisor advisor = new OssSecurityGithubAdvisor();
     final GitHubProject project = new GitHubProject("org", "test");
 
@@ -80,7 +81,7 @@ public class OssSecurityGithubAdvisorTest {
   }
 
   @Test
-  public void testAdviseForSecurityPolicy() {
+  public void testAdviseForSecurityPolicy() throws IOException {
     final OssSecurityGithubAdvisor advisor = new OssSecurityGithubAdvisor();
     final GitHubProject project = new GitHubProject("org", "test");
     final Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
@@ -101,7 +102,7 @@ public class OssSecurityGithubAdvisorTest {
   }
 
   @Test
-  public void testAdviseForFindSecBugs() {
+  public void testAdviseForFindSecBugs() throws IOException {
     final OssSecurityGithubAdvisor advisor = new OssSecurityGithubAdvisor();
     final GitHubProject project = new GitHubProject("org", "test");
     final Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
@@ -122,7 +123,7 @@ public class OssSecurityGithubAdvisorTest {
   }
 
   @Test
-  public void testAdviseForSanitizers() {
+  public void testAdviseForSanitizers() throws IOException {
     final OssSecurityGithubAdvisor advisor = new OssSecurityGithubAdvisor();
     final GitHubProject project = new GitHubProject("org", "test");
     final Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
@@ -143,7 +144,7 @@ public class OssSecurityGithubAdvisorTest {
   }
 
   @Test
-  public void testAdviseForOssFuzz() {
+  public void testAdviseForOssFuzz() throws IOException {
     final OssSecurityGithubAdvisor advisor = new OssSecurityGithubAdvisor();
     final GitHubProject project = new GitHubProject("org", "test");
     final Rating rating = RatingRepository.INSTANCE.rating(OssSecurityRating.class);

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/json/CompanySupportStorageTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/json/CompanySupportStorageTest.java
@@ -1,9 +1,9 @@
 package com.sap.oss.phosphor.fosstars.data.json;
 
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OwaspDependencyScanScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OwaspDependencyScanScoreTest.java
@@ -2,6 +2,8 @@ package com.sap.oss.phosphor.fosstars.model.score.oss;
 
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_DEPENDENCY_CHECK_USAGE;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
+import static com.sap.oss.phosphor.fosstars.model.value.PackageManager.MAVEN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -9,6 +11,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.sap.oss.phosphor.fosstars.model.Score;
 import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsage;
+import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
 import org.junit.Test;
 
@@ -22,7 +25,8 @@ public class OwaspDependencyScanScoreTest {
   public void testWithUnknown() {
     ScoreValue value = SCORE.calculate(
         OWASP_DEPENDENCY_CHECK_USAGE.unknown(),
-        OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.unknown());
+        OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.unknown(),
+        PACKAGE_MANAGERS.unknown());
     assertNotNull(value);
     assertFalse(value.isUnknown());
     assertEquals(Score.MIN, value.get(), ACCURACY);
@@ -32,7 +36,8 @@ public class OwaspDependencyScanScoreTest {
   public void testCalculate() {
     ScoreValue value = SCORE.calculate(
         OWASP_DEPENDENCY_CHECK_USAGE.value(OwaspDependencyCheckUsage.OPTIONAL),
-        OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.value(7.2));
+        OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.value(7.2),
+        PACKAGE_MANAGERS.value(PackageManagers.from(MAVEN)));
     assertNotNull(value);
     assertFalse(value.isUnknown());
     assertTrue(Score.INTERVAL.contains(value.get()));

--- a/test_config.yml
+++ b/test_config.yml
@@ -1,0 +1,7 @@
+cache: .fosstars/project_rating_cache.json
+reports:
+  - type: markdown
+    where: ./
+finder:
+  organizations:
+    - name: SAP


### PR DESCRIPTION
Here is a list of main updates:

- Added advisors for Dependabot, OWASP Dependency Check, artifact signing.
- Added tests.
- Updated `DependabotScore` and `OwaspDependnecyScanScore` to return a N/A score if a project doesn't use any package manager supported by Dependabot.

Closes #383
Closes #384
Closes #385
Closes #386
Closes #465