### PR TITLE
OssArtifactSecurityRatingVerificationTest should work with dynamic dates

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/ArtifactVersionAdvisor.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/advice/oss/ArtifactVersionAdvisor.java
@@ -45,13 +45,13 @@ public class ArtifactVersionAdvisor extends AbstractOssAdvisor {
 
     if (isAllVersionInformationAvailable(versionValue, releasedVersionsValue)) {
       // isAllVersionInformationAvailable() checks that both values are present and known
-      ArtifactVersion latestVersion = getLatestVersion(releasedVersionsValue.get());
+      ArtifactVersion latestArtifact = getLatestVersion(releasedVersionsValue.get());
       String usedVersion = versionValue.get().get();
 
-      if (!latestVersion.getVersion().equals(usedVersion)) {
+      if (!latestArtifact.version().equals(usedVersion)) {
         List<AdviceContent> advice =
             adviceStorage.adviceFor(versionValue.get().feature(),
-                getAdviceContext(usedVersion, latestVersion.getVersion()));
+                getAdviceContext(usedVersion, latestArtifact.version()));
 
         return advice.stream()
             .map(content -> new SimpleAdvice(subject, versionValue.get(), content))

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactLatestReleaseAgeScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactLatestReleaseAgeScore.java
@@ -49,11 +49,11 @@ public class ArtifactLatestReleaseAgeScore extends FeatureBasedScore {
     LocalDate oneYearBack = LocalDate.now().minusYears(1);
 
     // check age of latest release
-    if (latestVersion.getReleaseDate().isAfter(oneMonthBack)) {
+    if (latestVersion.releaseDate().isAfter(oneMonthBack)) {
       return scoreValue.set(Score.MAX);
-    } else if (latestVersion.getReleaseDate().isAfter(sixMonthBack)) {
+    } else if (latestVersion.releaseDate().isAfter(sixMonthBack)) {
       return scoreValue.set(5.0);
-    } else if (latestVersion.getReleaseDate().isAfter(oneYearBack)) {
+    } else if (latestVersion.releaseDate().isAfter(oneYearBack)) {
       return scoreValue.set(2.0);
     }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactLatestReleaseAgeScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactLatestReleaseAgeScore.java
@@ -43,17 +43,17 @@ public class ArtifactLatestReleaseAgeScore extends FeatureBasedScore {
       return scoreValue.makeUnknown().withMinConfidence();
     }
 
-    ArtifactVersion latestVersion = sortedByReleaseDate.iterator().next();
+    ArtifactVersion latestArtifact = sortedByReleaseDate.iterator().next();
     LocalDate oneMonthBack = LocalDate.now().minusMonths(1);
     LocalDate sixMonthBack = LocalDate.now().minusMonths(6);
     LocalDate oneYearBack = LocalDate.now().minusYears(1);
 
     // check age of latest release
-    if (latestVersion.releaseDate().isAfter(oneMonthBack)) {
+    if (latestArtifact.releaseDate().isAfter(oneMonthBack)) {
       return scoreValue.set(Score.MAX);
-    } else if (latestVersion.releaseDate().isAfter(sixMonthBack)) {
+    } else if (latestArtifact.releaseDate().isAfter(sixMonthBack)) {
       return scoreValue.set(5.0);
-    } else if (latestVersion.releaseDate().isAfter(oneYearBack)) {
+    } else if (latestArtifact.releaseDate().isAfter(oneYearBack)) {
       return scoreValue.set(2.0);
     }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactReleaseHistoryScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactReleaseHistoryScore.java
@@ -52,8 +52,8 @@ public class ArtifactReleaseHistoryScore extends FeatureBasedScore {
         ArtifactVersions.sortByReleaseDate(artifactVersions);
 
     // check release frequency over time
-    Collection<VersionInfo> versionInfos = createVersionInfos(sortedByReleaseDate);
-    VersionStats stats = calculateVersionStats(versionInfos);
+    Collection<VersionInfo> versionInfo = createVersionInfo(sortedByReleaseDate);
+    VersionStats stats = calculateVersionStats(versionInfo);
 
     if (stats.averageDaysBetweenReleases < 10) {
       scoreValue.increase(3);
@@ -113,30 +113,30 @@ public class ArtifactReleaseHistoryScore extends FeatureBasedScore {
   /**
    * Create the version info based on list of sorted artifact versions.
    *
-   * @param artifactVersions sorted collection of artifact versions
-   * @return version infos
+   * @param artifactVersions A sorted collection of artifact versions.
+   * @return Version info.
    */
-  static Collection<VersionInfo> createVersionInfos(Collection<ArtifactVersion> artifactVersions) {
-    Collection<VersionInfo> versionInfos = new ArrayList<>();
-    ArtifactVersion beforeVersion = null;
+  static Collection<VersionInfo> createVersionInfo(Collection<ArtifactVersion> artifactVersions) {
+    Collection<VersionInfo> versionInfo = new ArrayList<>();
+    ArtifactVersion previousArtifact = null;
     Iterator<ArtifactVersion> iterator = artifactVersions.iterator();
     while (iterator.hasNext()) {
       int daysDiff = -1;
-      ArtifactVersion next = beforeVersion;
-      if (beforeVersion == null) {
-        next = iterator.next();
+      ArtifactVersion nextArtifact = previousArtifact;
+      if (previousArtifact == null) {
+        nextArtifact = iterator.next();
       }
       if (iterator.hasNext()) {
-        beforeVersion = iterator.next();
-        daysDiff = (int) DAYS.between(beforeVersion.releaseDate(), next.releaseDate());
+        previousArtifact = iterator.next();
+        daysDiff = (int) DAYS.between(previousArtifact.releaseDate(), nextArtifact.releaseDate());
       }
-      versionInfos.add(new VersionInfo(daysDiff, next));
+      versionInfo.add(new VersionInfo(daysDiff, nextArtifact));
     }
-    if (artifactVersions.size() != versionInfos.size()) {
-      versionInfos.add(new VersionInfo(-1, beforeVersion));
+    if (artifactVersions.size() != versionInfo.size()) {
+      versionInfo.add(new VersionInfo(-1, previousArtifact));
     }
 
-    return versionInfos;
+    return versionInfo;
   }
 
   static class VersionStats {

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactReleaseHistoryScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactReleaseHistoryScore.java
@@ -128,7 +128,7 @@ public class ArtifactReleaseHistoryScore extends FeatureBasedScore {
       }
       if (iterator.hasNext()) {
         beforeVersion = iterator.next();
-        daysDiff = (int) DAYS.between(beforeVersion.getReleaseDate(), next.getReleaseDate());
+        daysDiff = (int) DAYS.between(beforeVersion.releaseDate(), next.releaseDate());
       }
       versionInfos.add(new VersionInfo(daysDiff, next));
     }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactReleaseHistoryScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactReleaseHistoryScore.java
@@ -52,7 +52,7 @@ public class ArtifactReleaseHistoryScore extends FeatureBasedScore {
         ArtifactVersions.sortByReleaseDate(artifactVersions);
 
     // check release frequency over time
-    Collection<VersionInfo> versionInfo = createVersionInfo(sortedByReleaseDate);
+    Collection<VersionInfo> versionInfo = versionInfo(sortedByReleaseDate);
     VersionStats stats = calculateVersionStats(versionInfo);
 
     if (stats.averageDaysBetweenReleases < 10) {
@@ -79,20 +79,20 @@ public class ArtifactReleaseHistoryScore extends FeatureBasedScore {
   }
 
   /**
-   * Calculate the VersionStatistics based on given version infos.
+   * Calculate statistics.
    *
-   * @param versionInfos used to calculate statistics
-   * @return calculated version statistics
+   * @param versionInfoCollection Information about artifact versions.
+   * @return Calculated statistics.
    */
-  static VersionStats calculateVersionStats(Collection<VersionInfo> versionInfos) {
-    IntSummaryStatistics stats = versionInfos.stream()
+  static VersionStats calculateVersionStats(Collection<VersionInfo> versionInfoCollection) {
+    IntSummaryStatistics stats = versionInfoCollection.stream()
         .filter(v -> v.daysDiffToVersionBefore >= 0)
         .mapToInt(v -> v.daysDiffToVersionBefore)
         .summaryStatistics();
 
     int releaseCycleTrend = 0;
     int lastDays = -1;
-    for (VersionInfo versionInfo : versionInfos) {
+    for (VersionInfo versionInfo : versionInfoCollection) {
       if (versionInfo.daysDiffToVersionBefore >= 0) {
         if (lastDays < 0) {
           lastDays = versionInfo.daysDiffToVersionBefore;
@@ -111,12 +111,12 @@ public class ArtifactReleaseHistoryScore extends FeatureBasedScore {
   }
 
   /**
-   * Create the version info based on list of sorted artifact versions.
+   * Extract additional information about artifact versions.
    *
    * @param artifactVersions A sorted collection of artifact versions.
-   * @return Version info.
+   * @return A collection of {@link VersionInfo}.
    */
-  static Collection<VersionInfo> createVersionInfo(Collection<ArtifactVersion> artifactVersions) {
+  static Collection<VersionInfo> versionInfo(Collection<ArtifactVersion> artifactVersions) {
     Collection<VersionInfo> versionInfo = new ArrayList<>();
     ArtifactVersion previousArtifact = null;
     Iterator<ArtifactVersion> iterator = artifactVersions.iterator();
@@ -139,10 +139,27 @@ public class ArtifactReleaseHistoryScore extends FeatureBasedScore {
     return versionInfo;
   }
 
+  /**
+   * Statistics about artifact versions.
+   */
   static class VersionStats {
+
+    /**
+     * Shows whether the release frequency is increasing or not.
+     */
     final double releaseCycleTrend;
+
+    /**
+     * An average number of days between releases.
+     */
     final double averageDaysBetweenReleases;
 
+    /**
+     * Initializes a new {@link VersionStats}.
+     *
+     * @param releaseCycleTrend Shows whether the release frequency is increasing or not.
+     * @param averageDaysBetweenReleases An average number of days between releases.
+     */
     public VersionStats(double releaseCycleTrend, double averageDaysBetweenReleases) {
       this.releaseCycleTrend = releaseCycleTrend;
       this.averageDaysBetweenReleases = averageDaysBetweenReleases;
@@ -157,10 +174,27 @@ public class ArtifactReleaseHistoryScore extends FeatureBasedScore {
     }
   }
 
+  /**
+   * Holds information about artifact version.
+   */
   static class VersionInfo {
+
+    /**
+     * A number of days since the previous version.
+     */
     final int daysDiffToVersionBefore;
+
+    /**
+     * A version string.
+     */
     final ArtifactVersion version;
 
+    /**
+     * Creates a new {@link VersionInfo}.
+     *
+     * @param daysDiffToVersionBefore A number of days since the previous version.
+     * @param version A version string.
+     */
     public VersionInfo(int daysDiffToVersionBefore, ArtifactVersion version) {
       this.daysDiffToVersionBefore = daysDiffToVersionBefore;
       this.version = version;

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactVersionUpToDateScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactVersionUpToDateScore.java
@@ -63,11 +63,11 @@ public class ArtifactVersionUpToDateScore extends FeatureBasedScore {
         scoreValue.set(8.0);
       }
 
-      if (checkVersion.getReleaseDate().isBefore(oneYearBack)) {
+      if (checkVersion.releaseDate().isBefore(oneYearBack)) {
         return scoreValue.decrease(8);
-      } else if (checkVersion.getReleaseDate().isBefore(sixMonthBack)) {
+      } else if (checkVersion.releaseDate().isBefore(sixMonthBack)) {
         return scoreValue.decrease(4);
-      } else if (checkVersion.getReleaseDate().isBefore(oneMonthBack)) {
+      } else if (checkVersion.releaseDate().isBefore(oneMonthBack)) {
         return scoreValue.decrease(1);
       }
       return scoreValue;

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/ArtifactVersion.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/ArtifactVersion.java
@@ -1,7 +1,9 @@
 package com.sap.oss.phosphor.fosstars.model.value;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -25,32 +27,46 @@ import java.util.TreeSet;
  * This class represents a specific version of an artifact that is produced by an open source
  * project. For example, it may be a jar file.
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class ArtifactVersion {
 
+  /**
+   * An empty artifact version.
+   */
   public static final ArtifactVersion EMPTY = new ArtifactVersion("", LocalDate.now());
 
   /**
    * Comparator for artifact versions release date.
    */
   static final Comparator<ArtifactVersion> RELEASE_DATE_COMPARISON =
-      (a, b) -> b.getReleaseDate().compareTo(a.getReleaseDate());
+      (a, b) -> b.releaseDate().compareTo(a.releaseDate());
 
+  /**
+   * A version of the artifact.
+   */
   private final String version;
 
+  /**
+   * When the aftifact was released.
+   */
   @JsonDeserialize(using = LocalDateDeserializer.class)
   @JsonSerialize(using = LocalDateSerializer.class)
   private final LocalDate releaseDate;
 
+  /**
+   * A semantic version if available.
+   */
   @JsonIgnore
   private final Optional<SemanticVersion> semanticVersion;
 
   /**
-   * Initialize the ArtifactVersion based on version tag and release date.
+   * Initialize an artifact version based on version tag and release date.
    *
-   * @param version version tag
-   * @param releaseDate release date
+   * @param version The version tag.
+   * @param releaseDate The release date.
    */
-  public ArtifactVersion(@JsonProperty("version") String version,
+  public ArtifactVersion(
+      @JsonProperty("version") String version,
       @JsonProperty("releaseDate") LocalDate releaseDate) {
 
     Objects.requireNonNull(version, "Version must be set");
@@ -64,8 +80,8 @@ public class ArtifactVersion {
   /**
    * Sort artifact versions by release date.
    *
-   * @param versions the artifact versions
-   * @return sorted collection of ArtifactVersion
+   * @param versions The artifact versions
+   * @return A new sorted collection of artifact versions.
    */
   public static Collection<ArtifactVersion> sortByReleaseDate(Set<ArtifactVersion> versions) {
     SortedSet<ArtifactVersion> sortedArtifacts = new TreeSet<>(RELEASE_DATE_COMPARISON);
@@ -73,20 +89,42 @@ public class ArtifactVersion {
     return sortedArtifacts;
   }
 
+  /**
+   * Returns a semantic version.
+   *
+   * @return A semantic version if available.
+   */
   public Optional<SemanticVersion> getSemanticVersion() {
     return semanticVersion;
   }
 
+  /**
+   * Checks if the artifact versions has a semantic version.
+   *
+   * @return True if the version is semantic, false otherwise.
+   */
   @JsonIgnore
-  public boolean isValidSemanticVersion() {
+  public boolean hasValidSemanticVersion() {
     return semanticVersion.isPresent();
   }
 
-  public String getVersion() {
+  /**
+   * Returns a version string of the artifact.
+   *
+   * @return A version string of the artifact.
+   */
+  @JsonGetter("version")
+  public String version() {
     return version;
   }
 
-  public LocalDate getReleaseDate() {
+  /**
+   * Returns a release date of the artifact.
+   *
+   * @return A release date of the artifact.
+   */
+  @JsonGetter("releaseDate")
+  public LocalDate releaseDate() {
     return releaseDate;
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/ArtifactVersion.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/ArtifactVersion.java
@@ -80,7 +80,7 @@ public class ArtifactVersion {
   /**
    * Sort artifact versions by release date.
    *
-   * @param versions The artifact versions
+   * @param versions The artifact versions.
    * @return A new sorted collection of artifact versions.
    */
   public static Collection<ArtifactVersion> sortByReleaseDate(Set<ArtifactVersion> versions) {

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/ArtifactVersions.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/ArtifactVersions.java
@@ -136,7 +136,7 @@ public class ArtifactVersions implements Iterable<ArtifactVersion> {
    */
   public Optional<ArtifactVersion> get(String version) {
     return elements.stream()
-        .filter(v -> v.getVersion().equals(version))
+        .filter(artifact -> artifact.version().equals(version))
         .findFirst();
   }
 
@@ -176,7 +176,7 @@ public class ArtifactVersions implements Iterable<ArtifactVersion> {
     final int max = 5;
     String message = sortByReleaseDate.stream()
         .limit(max)
-        .map(v -> String.format("%s:%s", v.getVersion(), v.getReleaseDate()))
+        .map(artifact -> String.format("%s:%s", artifact.version(), artifact.releaseDate()))
         .collect(Collectors.joining(", "));
 
     if (sortByReleaseDate.size() > max) {

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/rating/oss/OssArtifactSecurityRatingVerificationTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/rating/oss/OssArtifactSecurityRatingVerificationTest.java
@@ -2,19 +2,19 @@ package com.sap.oss.phosphor.fosstars.model.rating.oss;
 
 import static org.junit.Assert.assertNotNull;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.oss.phosphor.fosstars.model.RatingRepository;
 import com.sap.oss.phosphor.fosstars.model.qa.RatingVerification;
 import com.sap.oss.phosphor.fosstars.model.qa.TestVectors;
 import com.sap.oss.phosphor.fosstars.model.qa.VerificationFailedException;
+import com.sap.oss.phosphor.fosstars.util.Yaml;
 import java.io.IOException;
 import java.io.InputStream;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class OssArtifactSecurityRatingVerificationTest {
 
   @Test
-  @Ignore("This must be migrated to a programmatic test")
   public void testVerification() throws VerificationFailedException, IOException {
     OssArtifactSecurityRating rating =
         RatingRepository.INSTANCE.rating(OssArtifactSecurityRating.class);
@@ -54,7 +54,11 @@ public class OssArtifactSecurityRatingVerificationTest {
       try (InputStream is = OssArtifactSecurityRatingVerification.class
           .getResourceAsStream(TEST_VECTORS_YAML)) {
 
-        return new OssArtifactSecurityRatingVerification(rating, TestVectors.loadFromYaml(is));
+        ObjectMapper mapper = Yaml.mapper();
+        mapper.registerSubtypes(TestArtifactVersion.class);
+        TestVectors testVectors = mapper.readValue(is, TestVectors.class);
+
+        return new OssArtifactSecurityRatingVerification(rating, testVectors);
       }
     }
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/rating/oss/TestArtifactVersion.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/rating/oss/TestArtifactVersion.java
@@ -1,0 +1,25 @@
+package com.sap.oss.phosphor.fosstars.model.rating.oss;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sap.oss.phosphor.fosstars.model.value.ArtifactVersion;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+/**
+ * An artifact version for testing.
+ */
+public class TestArtifactVersion extends ArtifactVersion {
+
+  /**
+   * Creates a new artifact version for testing.
+   *
+   * @param version A version string.
+   * @param age An age of the artifact.
+   */
+  public TestArtifactVersion(
+      @JsonProperty("version") String version,
+      @JsonProperty("age") String age) {
+
+    super(version, LocalDateTime.now().minus(Duration.parse(age)).toLocalDate());
+  }
+}

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactReleaseHistoryScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactReleaseHistoryScoreTest.java
@@ -64,9 +64,9 @@ public class ArtifactReleaseHistoryScoreTest {
     artifactVersions.add(new ArtifactVersion("1.5.0", LocalDate.now().minusDays(270)));
     artifactVersions.add(new ArtifactVersion("1.0.0", LocalDate.now().minusDays(520)));
 
-    Collection<VersionInfo> versionInfos =
-        ArtifactReleaseHistoryScore.createVersionInfos(artifactVersions);
-    VersionStats stats = ArtifactReleaseHistoryScore.calculateVersionStats(versionInfos);
+    Collection<VersionInfo> versionInfo =
+        ArtifactReleaseHistoryScore.createVersionInfo(artifactVersions);
+    VersionStats stats = ArtifactReleaseHistoryScore.calculateVersionStats(versionInfo);
     Assert.assertEquals(173.33333333333334, stats.averageDaysBetweenReleases, DELTA);
     Assert.assertEquals(0.6666666666666666, stats.releaseCycleTrend, DELTA);
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactReleaseHistoryScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactReleaseHistoryScoreTest.java
@@ -65,7 +65,7 @@ public class ArtifactReleaseHistoryScoreTest {
     artifactVersions.add(new ArtifactVersion("1.0.0", LocalDate.now().minusDays(520)));
 
     Collection<VersionInfo> versionInfo =
-        ArtifactReleaseHistoryScore.createVersionInfo(artifactVersions);
+        ArtifactReleaseHistoryScore.versionInfo(artifactVersions);
     VersionStats stats = ArtifactReleaseHistoryScore.calculateVersionStats(versionInfo);
     Assert.assertEquals(173.33333333333334, stats.averageDaysBetweenReleases, DELTA);
     Assert.assertEquals(0.6666666666666666, stats.releaseCycleTrend, DELTA);

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ArtifactVersionTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ArtifactVersionTest.java
@@ -4,6 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.sap.oss.phosphor.fosstars.util.Json;
+import com.sap.oss.phosphor.fosstars.util.Yaml;
+import java.io.IOException;
 import java.time.LocalDate;
 import org.junit.Test;
 
@@ -12,19 +15,19 @@ public class ArtifactVersionTest {
   @Test
   public void testIsValidSemanticVersion() {
     ArtifactVersion invalidVersion2 = new ArtifactVersion("MIGHTY-1.2", LocalDate.now());
-    assertFalse(invalidVersion2.isValidSemanticVersion());
+    assertFalse(invalidVersion2.hasValidSemanticVersion());
     ArtifactVersion toLessDigits = new ArtifactVersion("2.0", LocalDate.now());
-    assertFalse(toLessDigits.isValidSemanticVersion());
+    assertFalse(toLessDigits.hasValidSemanticVersion());
 
     ArtifactVersion validVersion = new ArtifactVersion("2.0.2", LocalDate.now());
-    assertTrue(validVersion.isValidSemanticVersion());
+    assertTrue(validVersion.hasValidSemanticVersion());
     SemanticVersion semVerValid = validVersion.getSemanticVersion().get();
     assertEquals(2, semVerValid.getMajor());
     assertEquals(0, semVerValid.getMinor());
     assertEquals(2, semVerValid.getMicro());
 
     ArtifactVersion validVersionWithSuffix = new ArtifactVersion("1.0.0-MIGHTY", LocalDate.now());
-    assertTrue(validVersionWithSuffix.isValidSemanticVersion());
+    assertTrue(validVersionWithSuffix.hasValidSemanticVersion());
     SemanticVersion semVerSuffix = validVersionWithSuffix.getSemanticVersion().get();
     assertEquals(1, semVerSuffix.getMajor());
     assertEquals(0, semVerSuffix.getMinor());
@@ -32,11 +35,27 @@ public class ArtifactVersionTest {
 
     ArtifactVersion validVersionHighNumbers =
         new ArtifactVersion("1232.2134234.23423", LocalDate.now());
-    assertTrue(validVersionHighNumbers.isValidSemanticVersion());
+    assertTrue(validVersionHighNumbers.hasValidSemanticVersion());
 
     SemanticVersion semVerHigh = validVersionHighNumbers.getSemanticVersion().get();
     assertEquals(1232, semVerHigh.getMajor());
     assertEquals(2134234, semVerHigh.getMinor());
     assertEquals(23423, semVerHigh.getMicro());
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException  {
+    ArtifactVersion version = new ArtifactVersion("2.0.2", LocalDate.now());
+    ArtifactVersion clone = Json.read(Json.toBytes(version), ArtifactVersion.class);
+    assertTrue(version.equals(clone) && clone.equals(version));
+    assertEquals(version.hashCode(), clone.hashCode());
+  }
+
+  @Test
+  public void testYamlSerialization() throws IOException  {
+    ArtifactVersion version = new ArtifactVersion("MIGHTY-1.2", LocalDate.now());
+    ArtifactVersion clone = Yaml.read(Yaml.toBytes(version), ArtifactVersion.class);
+    assertTrue(version.equals(clone) && clone.equals(version));
+    assertEquals(version.hashCode(), clone.hashCode());
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ArtifactVersionsTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/ArtifactVersionsTest.java
@@ -1,7 +1,11 @@
 package com.sap.oss.phosphor.fosstars.model.value;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import com.sap.oss.phosphor.fosstars.util.Json;
+import com.sap.oss.phosphor.fosstars.util.Yaml;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Collection;
 import org.junit.Test;
@@ -22,5 +26,25 @@ public class ArtifactVersionsTest {
     for (ArtifactVersion version : sorted) {
       assertEquals(expectedOrder[i++], version);
     }
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    ArtifactVersions versions = new ArtifactVersions(
+        new ArtifactVersion("1.0.0", LocalDate.now().minusDays(30)),
+        new ArtifactVersion("1.1.0", LocalDate.now().minusDays(20)));
+    ArtifactVersions clone = Json.read(Json.toBytes(versions), ArtifactVersions.class);
+    assertTrue(versions.equals(clone) && clone.equals(versions));
+    assertEquals(versions.hashCode(), clone.hashCode());
+  }
+
+  @Test
+  public void testYamlSerialization() throws IOException {
+    ArtifactVersions versions = new ArtifactVersions(
+        new ArtifactVersion("something", LocalDate.now().minusDays(30)),
+        new ArtifactVersion("something else", LocalDate.now().minusDays(20)));
+    ArtifactVersions clone = Yaml.read(Yaml.toBytes(versions), ArtifactVersions.class);
+    assertTrue(versions.equals(clone) && clone.equals(versions));
+    assertEquals(versions.hashCode(), clone.hashCode());
   }
 }

--- a/src/test/resources/com/sap/oss/phosphor/fosstars/model/rating/oss/OssArtifactSecurityRatingTestVectors.yml
+++ b/src/test/resources/com/sap/oss/phosphor/fosstars/model/rating/oss/OssArtifactSecurityRatingTestVectors.yml
@@ -13,16 +13,21 @@ defaults:
       name: "Released artifact versions"
     versions:
       elements:
-        - version: "1.0.0"
-          releaseDate: "TEST-300d"
-        - version: "1.1.0"
-          releaseDate: "TEST-200d"
-        - version: "1.2.0"
-          releaseDate: "TEST-100d"
-        - version: "1.3.0"
-          releaseDate: "TEST-50d"
-        - version: "2.0.0"
-          releaseDate: "TEST-10d"
+        - type: "TestArtifactVersion"
+          version: "1.0.0"
+          age: "p300d"
+        - type: "TestArtifactVersion"
+          version: "1.1.0"
+          age: "p200d"
+        - type: "TestArtifactVersion"
+          version: "1.2.0"
+          age: "p100d"
+        - type: "TestArtifactVersion"
+          version: "1.3.0"
+          age: "p50d"
+        - type: "TestArtifactVersion"
+          version: "2.0.0"
+          age: "p10d"
   - type: "BooleanValue"
     feature:
       type: "BooleanFeature"
@@ -511,20 +516,19 @@ elements:
               cvss:
                 version: "V3"
                 value: 9.0
-              references: []
-              resolution: "PATCHED"
+              references: [ ]
+              resolution: "UNPATCHED"
               introduced: "2019-01-01"
-              fixed: "2019-01-03"
               published: "2019-01-03"
               vulnerableVersions:
                 - versionStart: 1.0.0
                   versionEnd: 1.1.0
     expectedScore:
       type: "DoubleInterval"
-      from: 4.0
+      from: 0.0
       openLeft: false
       negativeInfinity: false
-      to: 5.0
+      to: 4.49
       openRight: false
       positiveInfinity: false
     expectedLabel:

--- a/src/test/resources/com/sap/oss/phosphor/fosstars/model/rating/oss/OssArtifactSecurityRatingTestVectors.yml
+++ b/src/test/resources/com/sap/oss/phosphor/fosstars/model/rating/oss/OssArtifactSecurityRatingTestVectors.yml
@@ -516,7 +516,7 @@ elements:
               cvss:
                 version: "V3"
                 value: 9.0
-              references: [ ]
+              references: []
               resolution: "UNPATCHED"
               introduced: "2019-01-01"
               published: "2019-01-03"


### PR DESCRIPTION
Here is a list of main updates:

- Added `TestArtifactVersion` that takes an age of artifact and calculates its release date.
- Updated the test vectors for `OssArtifactSecurityRating` to use `TestArtifactVersion`.
- Added more javadoc, renamed several methods and variables.
- Added more test cases for serialization.

Fixes #484