### PR TITLE
Flexible serialization for implementations of main interfaces

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/Feature.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/Feature.java
@@ -1,27 +1,6 @@
 package com.sap.oss.phosphor.fosstars.model;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.sap.oss.phosphor.fosstars.model.feature.BooleanFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.BoundedDoubleFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.BoundedIntegerFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.DateFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.DoubleFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.EnumFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.LgtmGradeFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.OwaspDependencyCheckCvssThreshold;
-import com.sap.oss.phosphor.fosstars.model.feature.OwaspDependencyCheckUsageFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.PositiveIntegerFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.StringFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.example.NumberOfCommitsLastMonthExample;
-import com.sap.oss.phosphor.fosstars.model.feature.example.NumberOfContributorsLastMonthExample;
-import com.sap.oss.phosphor.fosstars.model.feature.example.SecurityReviewDoneExample;
-import com.sap.oss.phosphor.fosstars.model.feature.example.StaticCodeAnalysisDoneExample;
-import com.sap.oss.phosphor.fosstars.model.feature.oss.ArtifactVersionFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.oss.ArtifactVersionsFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.oss.LanguagesFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.oss.PackageManagersFeature;
-import com.sap.oss.phosphor.fosstars.model.feature.oss.VulnerabilitiesInProject;
 
 /**
  * An interface for a feature.
@@ -35,28 +14,6 @@ import com.sap.oss.phosphor.fosstars.model.feature.oss.VulnerabilitiesInProject;
  * @param <T> Type of data of a feature
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = PositiveIntegerFeature.class),
-    @JsonSubTypes.Type(value = DoubleFeature.class),
-    @JsonSubTypes.Type(value = BooleanFeature.class),
-    @JsonSubTypes.Type(value = BoundedIntegerFeature.class),
-    @JsonSubTypes.Type(value = BoundedDoubleFeature.class),
-    @JsonSubTypes.Type(value = DateFeature.class),
-    @JsonSubTypes.Type(value = EnumFeature.class),
-    @JsonSubTypes.Type(value = VulnerabilitiesInProject.class),
-    @JsonSubTypes.Type(value = SecurityReviewDoneExample.class),
-    @JsonSubTypes.Type(value = StaticCodeAnalysisDoneExample.class),
-    @JsonSubTypes.Type(value = NumberOfCommitsLastMonthExample.class),
-    @JsonSubTypes.Type(value = NumberOfContributorsLastMonthExample.class),
-    @JsonSubTypes.Type(value = LgtmGradeFeature.class),
-    @JsonSubTypes.Type(value = LanguagesFeature.class),
-    @JsonSubTypes.Type(value = PackageManagersFeature.class),
-    @JsonSubTypes.Type(value = StringFeature.class),
-    @JsonSubTypes.Type(value = ArtifactVersionFeature.class),
-    @JsonSubTypes.Type(value = ArtifactVersionsFeature.class),
-    @JsonSubTypes.Type(value = OwaspDependencyCheckUsageFeature.class),
-    @JsonSubTypes.Type(value = OwaspDependencyCheckCvssThreshold.class)
-})
 public interface Feature<T> {
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/Interval.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/Interval.java
@@ -1,16 +1,11 @@
 package com.sap.oss.phosphor.fosstars.model;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.sap.oss.phosphor.fosstars.model.math.DoubleInterval;
 
 /**
  * An interface which represents an interval.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = DoubleInterval.class)
-})
 public interface Interval {
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/Label.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/Label.java
@@ -1,24 +1,12 @@
 package com.sap.oss.phosphor.fosstars.model;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sap.oss.phosphor.fosstars.model.rating.NotApplicableLabel;
-import com.sap.oss.phosphor.fosstars.model.rating.example.SecurityRatingExample;
-import com.sap.oss.phosphor.fosstars.model.rating.oss.OssArtifactSecurityRating.ArtifactSecurityLabel;
-import com.sap.oss.phosphor.fosstars.model.rating.oss.OssRulesOfPlayRating;
-import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
 
 /**
  * An interface for a label.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = ArtifactSecurityLabel.class),
-    @JsonSubTypes.Type(value = OssSecurityRating.SecurityLabel.class),
-    @JsonSubTypes.Type(value = SecurityRatingExample.SecurityLabelExample.class),
-    @JsonSubTypes.Type(value = OssRulesOfPlayRating.OssRulesOfPlayLabel.class),
-    @JsonSubTypes.Type(value = NotApplicableLabel.class),
-})
 public interface Label {
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/Rating.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/Rating.java
@@ -1,10 +1,6 @@
 package com.sap.oss.phosphor.fosstars.model;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.sap.oss.phosphor.fosstars.model.rating.example.SecurityRatingExample;
-import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
-import com.sap.oss.phosphor.fosstars.model.score.oss.OssRulesOfPlayScore;
 import com.sap.oss.phosphor.fosstars.model.value.RatingValue;
 import java.util.Set;
 
@@ -14,11 +10,6 @@ import java.util.Set;
  * All ratings have to support serialization to JSON with Jackson.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = SecurityRatingExample.class),
-    @JsonSubTypes.Type(value = OssSecurityRating.class),
-    @JsonSubTypes.Type(value = OssRulesOfPlayScore.class),
-})
 public interface Rating {
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/Score.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/Score.java
@@ -1,38 +1,7 @@
 package com.sap.oss.phosphor.fosstars.model;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sap.oss.phosphor.fosstars.model.math.DoubleInterval;
-import com.sap.oss.phosphor.fosstars.model.score.AverageCompositeScore;
-import com.sap.oss.phosphor.fosstars.model.score.WeightedCompositeScore;
-import com.sap.oss.phosphor.fosstars.model.score.example.ProjectActivityScoreExample;
-import com.sap.oss.phosphor.fosstars.model.score.example.SecurityScoreExample;
-import com.sap.oss.phosphor.fosstars.model.score.example.SecurityTestingScoreExample;
-import com.sap.oss.phosphor.fosstars.model.score.oss.ArtifactLatestReleaseAgeScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.ArtifactReleaseHistoryScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.ArtifactVersionUpToDateScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.ArtifactVersionVulnerabilityScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.CodeqlScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.CommunityCommitmentScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.DependabotScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.DependencyScanScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.FindSecBugsScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.FuzzingScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.LgtmScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.MemorySafetyTestingScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.NoHttpToolScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.OssArtifactSecurityScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.OssRulesOfPlayScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.OssSecurityScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.OwaspDependencyScanScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectActivityScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.StaticAnalysisScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore;
-import com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityLifetimeScore;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
 import java.util.Set;
 
@@ -46,38 +15,6 @@ import java.util.Set;
  * for a specific score.</p>
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = SecurityScoreExample.class),
-    @JsonSubTypes.Type(value = ProjectActivityScoreExample.class),
-    @JsonSubTypes.Type(value = SecurityTestingScoreExample.class),
-    @JsonSubTypes.Type(value = WeightedCompositeScore.class),
-    @JsonSubTypes.Type(value = AverageCompositeScore.class),
-    @JsonSubTypes.Type(value = ProjectActivityScore.class),
-    @JsonSubTypes.Type(value = ProjectPopularityScore.class),
-    @JsonSubTypes.Type(value = CommunityCommitmentScore.class),
-    @JsonSubTypes.Type(value = ProjectSecurityAwarenessScore.class),
-    @JsonSubTypes.Type(value = ProjectSecurityTestingScore.class),
-    @JsonSubTypes.Type(value = UnpatchedVulnerabilitiesScore.class),
-    @JsonSubTypes.Type(value = VulnerabilityLifetimeScore.class),
-    @JsonSubTypes.Type(value = OssSecurityScore.class),
-    @JsonSubTypes.Type(value = DependencyScanScore.class),
-    @JsonSubTypes.Type(value = LgtmScore.class),
-    @JsonSubTypes.Type(value = CodeqlScore.class),
-    @JsonSubTypes.Type(value = NoHttpToolScore.class),
-    @JsonSubTypes.Type(value = MemorySafetyTestingScore.class),
-    @JsonSubTypes.Type(value = FindSecBugsScore.class),
-    @JsonSubTypes.Type(value = FuzzingScore.class),
-    @JsonSubTypes.Type(value = StaticAnalysisScore.class),
-    @JsonSubTypes.Type(value = DependabotScore.class),
-    @JsonSubTypes.Type(value = OwaspDependencyScanScore.class),
-    @JsonSubTypes.Type(value = VulnerabilityDiscoveryAndSecurityTestingScore.class),
-    @JsonSubTypes.Type(value = OssArtifactSecurityScore.class),
-    @JsonSubTypes.Type(value = OssRulesOfPlayScore.class),
-    @JsonSubTypes.Type(value = ArtifactLatestReleaseAgeScore.class),
-    @JsonSubTypes.Type(value = ArtifactVersionUpToDateScore.class),
-    @JsonSubTypes.Type(value = ArtifactVersionVulnerabilityScore.class),
-    @JsonSubTypes.Type(value = ArtifactReleaseHistoryScore.class)
-})
 public interface Score extends Feature<Double> {
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/Subject.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/Subject.java
@@ -1,8 +1,6 @@
 package com.sap.oss.phosphor.fosstars.model;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.RatingValue;
 import java.util.Date;
 import java.util.Optional;
@@ -11,9 +9,6 @@ import java.util.Optional;
  * A subject for which a rating or a score may be calculated.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = GitHubProject.class)
-})
 public interface Subject {
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/Value.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/Value.java
@@ -1,25 +1,6 @@
 package com.sap.oss.phosphor.fosstars.model;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.sap.oss.phosphor.fosstars.model.value.ArtifactVersionValue;
-import com.sap.oss.phosphor.fosstars.model.value.ArtifactVersionsValue;
-import com.sap.oss.phosphor.fosstars.model.value.BooleanValue;
-import com.sap.oss.phosphor.fosstars.model.value.DateValue;
-import com.sap.oss.phosphor.fosstars.model.value.DoubleValue;
-import com.sap.oss.phosphor.fosstars.model.value.EnumValue;
-import com.sap.oss.phosphor.fosstars.model.value.ExpiringValue;
-import com.sap.oss.phosphor.fosstars.model.value.IntegerValue;
-import com.sap.oss.phosphor.fosstars.model.value.LanguagesValue;
-import com.sap.oss.phosphor.fosstars.model.value.LgtmGradeValue;
-import com.sap.oss.phosphor.fosstars.model.value.NotApplicableValue;
-import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckCvssThresholdValue;
-import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsageValue;
-import com.sap.oss.phosphor.fosstars.model.value.PackageManagersValue;
-import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
-import com.sap.oss.phosphor.fosstars.model.value.StringValue;
-import com.sap.oss.phosphor.fosstars.model.value.UnknownValue;
-import com.sap.oss.phosphor.fosstars.model.value.VulnerabilitiesValue;
 
 /**
  * An interface for a feature value of specific type.
@@ -27,26 +8,6 @@ import com.sap.oss.phosphor.fosstars.model.value.VulnerabilitiesValue;
  * @param <T> Type of date that the feature provides.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = IntegerValue.class),
-    @JsonSubTypes.Type(value = DoubleValue.class),
-    @JsonSubTypes.Type(value = BooleanValue.class),
-    @JsonSubTypes.Type(value = DateValue.class),
-    @JsonSubTypes.Type(value = ScoreValue.class),
-    @JsonSubTypes.Type(value = ExpiringValue.class),
-    @JsonSubTypes.Type(value = VulnerabilitiesValue.class),
-    @JsonSubTypes.Type(value = UnknownValue.class),
-    @JsonSubTypes.Type(value = NotApplicableValue.class),
-    @JsonSubTypes.Type(value = EnumValue.class),
-    @JsonSubTypes.Type(value = LgtmGradeValue.class),
-    @JsonSubTypes.Type(value = LanguagesValue.class),
-    @JsonSubTypes.Type(value = PackageManagersValue.class),
-    @JsonSubTypes.Type(value = StringValue.class),
-    @JsonSubTypes.Type(value = ArtifactVersionValue.class),
-    @JsonSubTypes.Type(value = ArtifactVersionsValue.class),
-    @JsonSubTypes.Type(value = OwaspDependencyCheckUsageValue.class),
-    @JsonSubTypes.Type(value = OwaspDependencyCheckCvssThresholdValue.class)
-})
 public interface Value<T> {
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/ValueSet.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/ValueSet.java
@@ -1,17 +1,12 @@
 package com.sap.oss.phosphor.fosstars.model;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
 import java.util.Optional;
 import java.util.Set;
 
 /**
  * A set of feature values. The set contains only unique features.
  */
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = ValueHashSet.class, name = "ValueHashSet")
-})
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
 public interface ValueSet extends Iterable<Value<?>> {
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/Weight.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/Weight.java
@@ -1,20 +1,13 @@
 package com.sap.oss.phosphor.fosstars.model;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sap.oss.phosphor.fosstars.model.math.DoubleInterval;
-import com.sap.oss.phosphor.fosstars.model.weight.ImmutableWeight;
-import com.sap.oss.phosphor.fosstars.model.weight.MutableWeight;
 
 /**
  * An interface for a weight.
  * All implementations have to support serialization to JSON with Jackson.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = MutableWeight.class),
-    @JsonSubTypes.Type(value = ImmutableWeight.class)
-})
 public interface Weight extends Parameter {
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/StringFeature.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/StringFeature.java
@@ -3,7 +3,6 @@ package com.sap.oss.phosphor.fosstars.model.feature;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sap.oss.phosphor.fosstars.model.Value;
-import com.sap.oss.phosphor.fosstars.model.feature.AbstractFeature;
 import com.sap.oss.phosphor.fosstars.model.value.StringValue;
 
 /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/TestVector.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/qa/TestVector.java
@@ -1,6 +1,5 @@
 package com.sap.oss.phosphor.fosstars.model.qa;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sap.oss.phosphor.fosstars.model.Interval;
 import com.sap.oss.phosphor.fosstars.model.Label;
@@ -14,10 +13,6 @@ import java.util.Set;
  * and an optional expected label.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = StandardTestVector.class),
-    @JsonSubTypes.Type(value = ScoreTestVector.class)
-})
 public interface TestVector {
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/subject/oss/Artifact.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/subject/oss/Artifact.java
@@ -1,6 +1,5 @@
 package com.sap.oss.phosphor.fosstars.model.subject.oss;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.Optional;
 
@@ -9,10 +8,6 @@ import java.util.Optional;
  * can be downloaded from a Maven repository.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = MavenArtifact.class),
-    @JsonSubTypes.Type(value = NpmArtifact.class)
-})
 public interface Artifact {
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/util/Deserialization.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/util/Deserialization.java
@@ -5,9 +5,92 @@ import static java.util.Collections.singletonList;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator.Builder;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.sap.oss.phosphor.fosstars.model.feature.BooleanFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.BoundedDoubleFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.BoundedIntegerFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.DateFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.DoubleFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.EnumFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.LgtmGradeFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.OwaspDependencyCheckCvssThreshold;
+import com.sap.oss.phosphor.fosstars.model.feature.OwaspDependencyCheckUsageFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.PositiveIntegerFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.StringFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.example.NumberOfCommitsLastMonthExample;
+import com.sap.oss.phosphor.fosstars.model.feature.example.NumberOfContributorsLastMonthExample;
+import com.sap.oss.phosphor.fosstars.model.feature.example.SecurityReviewDoneExample;
+import com.sap.oss.phosphor.fosstars.model.feature.example.StaticCodeAnalysisDoneExample;
+import com.sap.oss.phosphor.fosstars.model.feature.oss.ArtifactVersionFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.oss.ArtifactVersionsFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.oss.LanguagesFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.oss.PackageManagersFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.oss.VulnerabilitiesInProject;
+import com.sap.oss.phosphor.fosstars.model.math.DoubleInterval;
+import com.sap.oss.phosphor.fosstars.model.qa.ScoreTestVector;
+import com.sap.oss.phosphor.fosstars.model.qa.StandardTestVector;
+import com.sap.oss.phosphor.fosstars.model.rating.NotApplicableLabel;
+import com.sap.oss.phosphor.fosstars.model.rating.example.SecurityRatingExample;
+import com.sap.oss.phosphor.fosstars.model.rating.oss.OssArtifactSecurityRating.ArtifactSecurityLabel;
+import com.sap.oss.phosphor.fosstars.model.rating.oss.OssRulesOfPlayRating;
+import com.sap.oss.phosphor.fosstars.model.rating.oss.OssSecurityRating;
+import com.sap.oss.phosphor.fosstars.model.score.AverageCompositeScore;
+import com.sap.oss.phosphor.fosstars.model.score.WeightedCompositeScore;
+import com.sap.oss.phosphor.fosstars.model.score.example.ProjectActivityScoreExample;
+import com.sap.oss.phosphor.fosstars.model.score.example.SecurityScoreExample;
+import com.sap.oss.phosphor.fosstars.model.score.example.SecurityTestingScoreExample;
+import com.sap.oss.phosphor.fosstars.model.score.oss.ArtifactLatestReleaseAgeScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.ArtifactReleaseHistoryScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.ArtifactVersionUpToDateScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.ArtifactVersionVulnerabilityScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.CodeqlScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.CommunityCommitmentScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.DependabotScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.DependencyScanScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.FindSecBugsScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.FuzzingScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.LgtmScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.MemorySafetyTestingScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.NoHttpToolScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.OssArtifactSecurityScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.OssRulesOfPlayScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.OssSecurityScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.OwaspDependencyScanScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectActivityScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.StaticAnalysisScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityLifetimeScore;
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.model.subject.oss.MavenArtifact;
+import com.sap.oss.phosphor.fosstars.model.subject.oss.NpmArtifact;
+import com.sap.oss.phosphor.fosstars.model.value.ArtifactVersionValue;
+import com.sap.oss.phosphor.fosstars.model.value.ArtifactVersionsValue;
+import com.sap.oss.phosphor.fosstars.model.value.BooleanValue;
+import com.sap.oss.phosphor.fosstars.model.value.DateValue;
+import com.sap.oss.phosphor.fosstars.model.value.DoubleValue;
+import com.sap.oss.phosphor.fosstars.model.value.EnumValue;
+import com.sap.oss.phosphor.fosstars.model.value.ExpiringValue;
+import com.sap.oss.phosphor.fosstars.model.value.IntegerValue;
+import com.sap.oss.phosphor.fosstars.model.value.LanguagesValue;
+import com.sap.oss.phosphor.fosstars.model.value.LgtmGradeValue;
+import com.sap.oss.phosphor.fosstars.model.value.NotApplicableValue;
+import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckCvssThresholdValue;
+import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsageValue;
+import com.sap.oss.phosphor.fosstars.model.value.PackageManagersValue;
+import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import com.sap.oss.phosphor.fosstars.model.value.StringValue;
+import com.sap.oss.phosphor.fosstars.model.value.UnknownValue;
+import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
+import com.sap.oss.phosphor.fosstars.model.value.VulnerabilitiesValue;
+import com.sap.oss.phosphor.fosstars.model.weight.ImmutableWeight;
+import com.sap.oss.phosphor.fosstars.model.weight.MutableWeight;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,7 +108,7 @@ public abstract class Deserialization {
   /**
    * A type reference for deserialization to a Map.
    */
-  static final TypeReference<Map<String,Object>> MAP_TYPE_REFERENCE
+  static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE
       = new TypeReference<Map<String, Object>>() {};
 
   /**
@@ -94,5 +177,124 @@ public abstract class Deserialization {
     }
 
     return list;
+  }
+
+  /**
+   * Registers known sub-types in an {@link ObjectMapper}.
+   *
+   * @param mapper The {@link ObjectMapper}.
+   * @return The same {@link ObjectMapper};
+   */
+  static ObjectMapper registerSubTypesIn(ObjectMapper mapper) {
+
+    // features
+    mapper.registerSubtypes(
+        PositiveIntegerFeature.class,
+        DoubleFeature.class,
+        BooleanFeature.class,
+        BoundedIntegerFeature.class,
+        BoundedDoubleFeature.class,
+        DateFeature.class,
+        EnumFeature.class,
+        VulnerabilitiesInProject.class,
+        SecurityReviewDoneExample.class,
+        StaticCodeAnalysisDoneExample.class,
+        NumberOfCommitsLastMonthExample.class,
+        NumberOfContributorsLastMonthExample.class,
+        LgtmGradeFeature.class,
+        LanguagesFeature.class,
+        PackageManagersFeature.class,
+        StringFeature.class,
+        ArtifactVersionFeature.class,
+        ArtifactVersionsFeature.class,
+        OwaspDependencyCheckUsageFeature.class,
+        OwaspDependencyCheckCvssThreshold.class
+    );
+
+    // values
+    mapper.registerSubtypes(
+        IntegerValue.class,
+        DoubleValue.class,
+        BooleanValue.class,
+        DateValue.class,
+        ScoreValue.class,
+        ExpiringValue.class,
+        VulnerabilitiesValue.class,
+        UnknownValue.class,
+        NotApplicableValue.class,
+        EnumValue.class,
+        LgtmGradeValue.class,
+        LanguagesValue.class,
+        PackageManagersValue.class,
+        StringValue.class,
+        ArtifactVersionValue.class,
+        ArtifactVersionsValue.class,
+        OwaspDependencyCheckUsageValue.class,
+        OwaspDependencyCheckCvssThresholdValue.class
+    );
+
+    // labels
+    mapper.registerSubtypes(
+        ArtifactSecurityLabel.class,
+        OssSecurityRating.SecurityLabel.class,
+        SecurityRatingExample.SecurityLabelExample.class,
+        OssRulesOfPlayRating.OssRulesOfPlayLabel.class,
+        NotApplicableLabel.class
+    );
+
+    // scores
+    mapper.registerSubtypes(
+        SecurityScoreExample.class,
+        ProjectActivityScoreExample.class,
+        SecurityTestingScoreExample.class,
+        WeightedCompositeScore.class,
+        AverageCompositeScore.class,
+        ProjectActivityScore.class,
+        ProjectPopularityScore.class,
+        CommunityCommitmentScore.class,
+        ProjectSecurityAwarenessScore.class,
+        ProjectSecurityTestingScore.class,
+        UnpatchedVulnerabilitiesScore.class,
+        VulnerabilityLifetimeScore.class,
+        OssSecurityScore.class,
+        DependencyScanScore.class,
+        LgtmScore.class,
+        CodeqlScore.class,
+        NoHttpToolScore.class,
+        MemorySafetyTestingScore.class,
+        FindSecBugsScore.class,
+        FuzzingScore.class,
+        StaticAnalysisScore.class,
+        DependabotScore.class,
+        OwaspDependencyScanScore.class,
+        VulnerabilityDiscoveryAndSecurityTestingScore.class,
+        OssArtifactSecurityScore.class,
+        OssRulesOfPlayScore.class,
+        ArtifactLatestReleaseAgeScore.class,
+        ArtifactVersionUpToDateScore.class,
+        ArtifactVersionVulnerabilityScore.class,
+        ArtifactReleaseHistoryScore.class
+    );
+
+    // ratings
+    mapper.registerSubtypes(
+        SecurityRatingExample.class,
+        OssSecurityRating.class,
+        OssRulesOfPlayScore.class
+    );
+
+    // weights
+    mapper.registerSubtypes(MutableWeight.class, ImmutableWeight.class);
+
+    // test vectors
+    mapper.registerSubtypes(StandardTestVector.class, ScoreTestVector.class);
+
+    // artifacts
+    mapper.registerSubtypes(MavenArtifact.class, NpmArtifact.class);
+
+    // other
+    mapper.registerSubtypes(DoubleInterval.class, GitHubProject.class, ValueHashSet.class);
+
+    return mapper;
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/util/Json.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/util/Json.java
@@ -60,6 +60,6 @@ public class Json extends Deserialization {
    * @return A shared {@link ObjectMapper} for JSON.
    */
   public static ObjectMapper mapper() {
-    return JsonMapper.builder().polymorphicTypeValidator(validator()).build();
+    return registerSubTypesIn(JsonMapper.builder().polymorphicTypeValidator(validator()).build());
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/util/Yaml.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/util/Yaml.java
@@ -87,6 +87,6 @@ public class Yaml extends Deserialization {
     ObjectMapper mapper = JsonMapper.builder(YAML_FACTORY)
         .polymorphicTypeValidator(validator()).build();
     mapper.findAndRegisterModules();
-    return mapper;
+    return registerSubTypesIn(mapper);
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/StringFeatureTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/StringFeatureTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.sap.oss.phosphor.fosstars.model.Value;
-import com.sap.oss.phosphor.fosstars.model.feature.StringFeature;
 import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import org.junit.Test;

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactVersionSecurityScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ArtifactVersionSecurityScoreTest.java
@@ -31,6 +31,7 @@ import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerability;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Set;
@@ -43,7 +44,7 @@ public class ArtifactVersionSecurityScoreTest {
 
   @Test
   public void testSerializeAndDeserialize() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = Json.mapper();
     ArtifactVersionSecurityScore score = new ArtifactVersionSecurityScore();
     byte[] bytes = mapper.writeValueAsBytes(score);
     assertNotNull(bytes);

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssArtifactSecurityScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssArtifactSecurityScoreTest.java
@@ -21,6 +21,7 @@ import com.sap.oss.phosphor.fosstars.model.value.ArtifactVersions;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerability;
+import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Set;
@@ -33,7 +34,7 @@ public class OssArtifactSecurityScoreTest {
 
   @Test
   public void testSerializeAndDeserialize() throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = Json.mapper();
     ArtifactVersionSecurityScore artifactVersionSecurityScore = new ArtifactVersionSecurityScore();
     OssSecurityScore ossSecurityScore = new OssSecurityScore();
     OssArtifactSecurityScore score =


### PR DESCRIPTION
Currently, the main interfaces in the package `com.sap.oss.phosphor.fosstars.model` use `@JsonSubTypes` annotation to list all implementations for deserialization. Otherwise, Jackson would fail to deserialize them. It means that no other implementation of those interfaces can be deserialized.

To overcome this, `Json` and `Yaml` classes now use `ObjectMapper.registerSubtypes()` to register known subtypes for deserialization. Then, callers can register additional sybtypes if necessary.

Here is a list of main updates:

- Get rid of `@JsonSubTypes`
- Updated `Json` and `Yaml` to return an `ObjectMapper` with registered default subtypes.
- Fixed a few tests that create their own `ObjectMapper`.

Fixes #514