### PR TITLE
Smarter CpeMatch.getCpeUri()

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/NvdEntryMatcher.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/NvdEntryMatcher.java
@@ -284,10 +284,13 @@ public class NvdEntryMatcher implements Matcher {
   private static boolean projectCheck(CpeMatch cpeMatch, boolean referenceMatch,
       GitHubProject project) {
 
-    CpeUri cpeUri = cpeMatch.getCpeUri();
+    Optional<CpeUri> cpeUri = cpeMatch.getCpeUri();
+    if (!cpeUri.isPresent()) {
+      return false;
+    }
 
-    boolean productMatch = match(cpeUri.getProduct(), project.name());
-    boolean vendorMatch = match(cpeUri.getVendor(), project.organization().name());
+    boolean productMatch = match(cpeUri.get().getProduct(), project.name());
+    boolean vendorMatch = match(cpeUri.get().getVendor(), project.organization().name());
 
     // check if product's name matches the project's name,
     // or at least one reference URL matches with the project's URL

--- a/src/main/java/com/sap/oss/phosphor/fosstars/nvd/NVD.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/nvd/NVD.java
@@ -140,7 +140,7 @@ public class NVD {
       updateTimestamp();
     }
     if (nvdEntries.isEmpty()) {
-      LOGGER.info("Parse NVD data...");
+      LOGGER.info("Parse NVD data ...");
       parse();
     }
     LOGGER.info("Loaded {} CVE entries from NVD", nvdEntries.size());

--- a/src/main/java/com/sap/oss/phosphor/fosstars/nvd/data/CpeMatch.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/nvd/data/CpeMatch.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -78,12 +79,20 @@ public class CpeMatch {
   }
 
   /**
-   * Get the {@link CpeUri} instance. It will check which CPE URI format is applicable and returns
-   * the appropriate instance.
+   * Get the {@link CpeUri} instance if available.
+   * It will check which CPE URI format is applicable and return the appropriate instance.
    * 
-   * @return instance of a type {@link CpeUri}.
+   * @return A {@link CpeUri} if available.
    */
-  public CpeUri getCpeUri() {
-    return !StringUtils.isEmpty(cpe23Uri) ? new Cpe23Uri(cpe23Uri) : new Cpe22Uri(cpe22Uri);
+  public Optional<CpeUri> getCpeUri() {
+    if (!StringUtils.isEmpty(cpe23Uri)) {
+      return Optional.of(new Cpe23Uri(cpe23Uri));
+    }
+
+    if (!StringUtils.isEmpty(cpe22Uri)) {
+      return Optional.of(new Cpe22Uri(cpe22Uri));
+    }
+
+    return Optional.empty();
   }
 }


### PR DESCRIPTION
Updated `CpeMatch.getCpeUri()` to return an empty Optional if no CPE is available.

Fixes #529