### PR TITLE
Better Markdown formatters

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/CommonFormatter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/CommonFormatter.java
@@ -84,6 +84,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.math3.util.Precision;
 
 /**
  * The class contains common methods for formatters.
@@ -244,10 +245,10 @@ public abstract class CommonFormatter implements Formatter {
    * @return A human-readable label.
    */
   static String confidenceLabelFor(double confidence) {
-    if (Double.compare(confidence, Confidence.MAX) == 0) {
+    if (Precision.equals(confidence, Confidence.MAX)) {
       return "Max";
     }
-    if (Double.compare(confidence, Confidence.MIN) == 0) {
+    if (Precision.equals(confidence, Confidence.MIN)) {
       return "Min";
     }
     return confidence >= 9.0 ? "High" : "Low";

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssArtifactSecurityRatingMarkdownFormatter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssArtifactSecurityRatingMarkdownFormatter.java
@@ -14,31 +14,47 @@ import java.util.Objects;
 public class OssArtifactSecurityRatingMarkdownFormatter extends AbstractMarkdownFormatter {
 
   /**
-   * A resource with a Markdown template.
+   * A resource with a default Markdown template.
    */
   private static final String RATING_VALUE_TEMPLATE_RESOURCE
       = "OssArtifactSecurityRatingMarkdownRatingValueTemplate.md";
 
   /**
-   * A Markdown template for a rating value.
+   * A default Markdown template for a rating value.
    */
-  private static final String RATING_VALUE_TEMPLATE
+  private static final String DEFAULT_RATING_VALUE_TEMPLATE
       = loadFrom(RATING_VALUE_TEMPLATE_RESOURCE, OssArtifactSecurityRatingMarkdownFormatter.class);
+
+  /**
+   * A Markdown template for reports.
+   */
+  private final String template;
+
+  /**
+   * Create a new formatter with the default report template.
+   *
+   * @param advisor An advisor for calculated ratings.
+   */
+  public OssArtifactSecurityRatingMarkdownFormatter(Advisor advisor) {
+    this(advisor, DEFAULT_RATING_VALUE_TEMPLATE);
+  }
 
   /**
    * Create a new formatter.
    *
    * @param advisor An advisor for calculated ratings.
+   * @param template A Markdown template for reports.
    */
-  public OssArtifactSecurityRatingMarkdownFormatter(Advisor advisor) {
+  public OssArtifactSecurityRatingMarkdownFormatter(Advisor advisor, String template) {
     super(advisor);
+    this.template = Objects.requireNonNull(template, "Oh no! Template can't be null!");
   }
 
   protected String print(RatingValue ratingValue, String advice) {
     Objects.requireNonNull(ratingValue, "Hey! Rating can't be null!");
 
     ScoreValue scoreValue = ratingValue.scoreValue();
-    return RATING_VALUE_TEMPLATE
+    return template
         .replaceAll("%MAX_SCORE%", formatted(Score.MAX))
         .replaceAll("%MAX_CONFIDENCE%", formatted(Confidence.MAX))
         .replace("%SCORE_VALUE%", actualValueOf(scoreValue))

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatter.java
@@ -14,24 +14,40 @@ import java.util.Objects;
 public class OssSecurityRatingMarkdownFormatter extends AbstractMarkdownFormatter {
 
   /**
-   * A resource with a Markdown template.
+   * A resource with a default Markdown template.
    */
   private static final String RATING_VALUE_TEMPLATE_RESOURCE
       = "OssSecurityRatingMarkdownRatingValueTemplate.md";
 
   /**
-   * A Markdown template for a rating value.
+   * A default Markdown template for a rating value.
    */
-  private static final String RATING_VALUE_TEMPLATE
+  private static final String DEFAULT_RATING_VALUE_TEMPLATE
       = loadFrom(RATING_VALUE_TEMPLATE_RESOURCE, OssSecurityRatingMarkdownFormatter.class);
+
+  /**
+   * A Markdown template for reports.
+   */
+  private final String template;
+
+  /**
+   * Create a new formatter with the default report template.
+   *
+   * @param advisor An advisor for calculated ratings.
+   */
+  public OssSecurityRatingMarkdownFormatter(Advisor advisor) {
+    this(advisor, DEFAULT_RATING_VALUE_TEMPLATE);
+  }
 
   /**
    * Create a new formatter.
    *
    * @param advisor An advisor for calculated ratings.
+   * @param template A Markdown template for reports.
    */
-  public OssSecurityRatingMarkdownFormatter(Advisor advisor) {
+  public OssSecurityRatingMarkdownFormatter(Advisor advisor, String template) {
     super(advisor);
+    this.template = Objects.requireNonNull(template, "Oh no! Template can't be null!");
   }
 
   @Override
@@ -39,7 +55,7 @@ public class OssSecurityRatingMarkdownFormatter extends AbstractMarkdownFormatte
     Objects.requireNonNull(ratingValue, "Hey! Rating can't be null!");
 
     ScoreValue scoreValue = ratingValue.scoreValue();
-    return RATING_VALUE_TEMPLATE
+    return template
         .replaceAll("%MAX_SCORE%", formatted(Score.MAX))
         .replaceAll("%MAX_CONFIDENCE%", formatted(Confidence.MAX))
         .replace("%SCORE_VALUE%", formatted(scoreValue.get()))

--- a/src/main/resources/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownRatingValueTemplate.md
+++ b/src/main/resources/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownRatingValueTemplate.md
@@ -16,13 +16,13 @@ It used the following sub-scores:
 
 %MAIN_SCORE_VALUE_DETAILS%
 
+%ADVICE%
+
 ## Sub-scores
 
 Below are the details about all the used sub-scores.
 
 %SUB_SCORE_DETAILS%
-
-%ADVICE%
 
 ## Known vulnerabilities
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatterTest.java
@@ -126,6 +126,6 @@ public class OssSecurityRatingMarkdownFormatterTest {
     String text = formatter.print(project);
 
     assertNotNull(text);
-    assertEquals("BAD|4.09|10.0|High|10.0|10.0|security score for open-source projects||", text);
+    assertEquals("BAD|4.09|10.0|Max|10.0|10.0|security score for open-source projects||", text);
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatterTest.java
@@ -38,6 +38,7 @@ import static com.sap.oss.phosphor.fosstars.model.other.Utils.setOf;
 import static com.sap.oss.phosphor.fosstars.model.value.Language.C;
 import static com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsage.NOT_USED;
 import static com.sap.oss.phosphor.fosstars.model.value.PackageManager.MAVEN;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
@@ -97,7 +98,7 @@ public class OssSecurityRatingMarkdownFormatterTest {
       PACKAGE_MANAGERS.value(new PackageManagers(MAVEN)));
 
   @Test
-  public void testPrint() {
+  public void testWithDefaultTemplate() {
     RatingValue ratingValue = RATING.calculate(TEST_VALUES);
     GitHubProject project = new GitHubProject("org", "test");
     project.set(ratingValue);
@@ -108,6 +109,23 @@ public class OssSecurityRatingMarkdownFormatterTest {
 
     assertNotNull(text);
     assertFalse(text.isEmpty());
-    System.out.println(text);
+  }
+
+  @Test
+  public void testWithCustomTemplate() {
+    RatingValue ratingValue = RATING.calculate(TEST_VALUES);
+    GitHubProject project = new GitHubProject("org", "test");
+    project.set(ratingValue);
+
+    String template = "%RATING_LABEL%|%SCORE_VALUE%|%MAX_SCORE%|%CONFIDENCE_LABEL%"
+        + "|%CONFIDENCE_VALUE%|%MAX_CONFIDENCE%|%MAIN_SCORE_NAME%"
+        + "|%MAIN_SCORE_DESCRIPTION%|%MAIN_SCORE_EXPLANATION%";
+
+    OssSecurityRatingMarkdownFormatter formatter
+        = new OssSecurityRatingMarkdownFormatter(new OssSecurityGithubAdvisor(), template);
+    String text = formatter.print(project);
+
+    assertNotNull(text);
+    assertEquals("BAD|4.09|10.0|High|10.0|10.0|security score for open-source projects||", text);
   }
 }


### PR DESCRIPTION
Here is a list of updates:

- Updated formatters to accept custom templates.
- Show advice higher in Markdown reports for `OssSecurityRating`.
- Updated `CommonFormatter` to use `Precision.equals()` when comparing doubles.

Fixes #501