### PR TITLE
OSS RoP: Add repository exceptions for license check

### DIFF
--- a/LicenseInfo.config.yml
+++ b/LicenseInfo.config.yml
@@ -5,3 +5,6 @@ allowedLicenses:
   - MIT
   - EPL-2.0
 disallowedLicensePatterns: "API"
+repositoryExceptions:
+  - https://github.com/SAP/SapMachine
+  - https://github.com/SAP/styleguides

--- a/LicenseInfo.yml
+++ b/LicenseInfo.yml
@@ -1,9 +1,0 @@
----
-allowedLicenses:
-  - Apache-2.0
-  - MIT
-disallowedLicensePatterns:
-  - Disallowed text
-repositoryExceptions:
-  - https://github.com/SAP/SapMachine
-  - https://github.com/SAP/styleguides

--- a/LicenseInfo.yml
+++ b/LicenseInfo.yml
@@ -1,0 +1,9 @@
+---
+allowedLicenses:
+  - Apache-2.0
+  - MIT
+disallowedLicensePatterns:
+  - Disallowed text
+repositoryExceptions:
+  - https://github.com/SAP/SapMachine
+  - https://github.com/SAP/styleguides


### PR DESCRIPTION
Two repositories don't use standard licenses at the moment, won't change and are accepted by us. Therefore, they can be added as exceptions.