### PR TITLE
Added a data provider for security reviews in OpenSSF

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -48,6 +48,9 @@
   <suppress checks="AbbreviationAsWordInName"
     files="InputURL.java"
     lines="11"/>
+  <suppress checks="AbbreviationAsWordInName"
+    files="SecurityReviewsFromOpenSSF.java"
+    lines="38"/>
   <suppress checks="LineLength"
     files="package-info.java"
     lines="142"/>

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/experimental/SecurityReviewsFromOpenSSF.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/experimental/SecurityReviewsFromOpenSSF.java
@@ -1,0 +1,406 @@
+package com.sap.oss.phosphor.fosstars.data.github.experimental;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import com.sap.oss.phosphor.fosstars.data.github.CachedSingleFeatureGitHubDataProvider;
+import com.sap.oss.phosphor.fosstars.data.github.GitHubDataFetcher;
+import com.sap.oss.phosphor.fosstars.data.github.LocalRepository;
+import com.sap.oss.phosphor.fosstars.model.Feature;
+import com.sap.oss.phosphor.fosstars.model.Subject;
+import com.sap.oss.phosphor.fosstars.model.Value;
+import com.sap.oss.phosphor.fosstars.model.feature.AbstractFeature;
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.model.value.AbstractKnownValue;
+import com.sap.oss.phosphor.fosstars.util.Yaml;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+/**
+ * This data provider gather information about security reviews collected by OpenSSF.
+ *
+ * @see <a href="https://github.com/ossf/security-reviews">Security Reviews</a>
+ */
+public class SecurityReviewsFromOpenSSF
+    extends CachedSingleFeatureGitHubDataProvider<SecurityReviews> {
+
+  /**
+   * A feature that holds security reviews.
+   */
+  public static final SecurityReviewsFeature FEATURE
+      = new SecurityReviewsFeature("Security reviews from OpenSSF");
+
+  /**
+   * A repository that stores security review.
+   */
+  static final GitHubProject SECURITY_REVIEWS_PROJECT
+      = new GitHubProject("ossf", "security-reviews");
+
+  /**
+   * A parser for dates.
+   */
+  private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+  /**
+   * Initializes a data provider.
+   *
+   * @param fetcher An interface to GitHub.
+   */
+  public SecurityReviewsFromOpenSSF(GitHubDataFetcher fetcher) {
+    super(fetcher);
+  }
+
+  @Override
+  protected Feature<SecurityReviews> supportedFeature() {
+    return FEATURE;
+  }
+
+  @Override
+  protected Value<SecurityReviews> fetchValueFor(GitHubProject project) throws IOException {
+    Objects.requireNonNull(project, "Project can't be null!");
+
+    LocalRepository reviewsRepository
+        = GitHubDataFetcher.localRepositoryFor(SECURITY_REVIEWS_PROJECT);
+
+    List<Path> reviewFiles = reviewsRepository.files(
+        Paths.get("reviews"), SecurityReviewsFromOpenSSF::isReview);
+
+    SecurityReviews reviews = new SecurityReviews();
+    for (Path file : reviewFiles) {
+      Optional<JsonNode> metadata = readMetadataFrom(file);
+      if (!metadata.isPresent()) {
+        logger.warn("Oops! Could not load metadata from {}", file);
+        continue;
+      }
+
+      if (isReviewFor(project, metadata.get())) {
+        Optional<Date> reviewDate = readReviewDateFrom(metadata.get());
+        if (!reviewDate.isPresent()) {
+          continue;
+        }
+        reviews.add(new SecurityReview(project, reviewDate.get()));
+      }
+    }
+
+    return new SecurityReviewsValue(FEATURE, reviews);
+  }
+
+  /**
+   * Reads a review date from metadata.
+   *
+   * @param metadata The metadata.
+   * @return A review date if available.
+   */
+  Optional<Date> readReviewDateFrom(JsonNode metadata) {
+    JsonNode node = metadata.at("/Review-Date");
+    if (!node.isTextual()) {
+      logger.warn("Oops! Review date is not a string!");
+      return Optional.empty();
+    }
+
+    try {
+      return Optional.of(DATE_FORMAT.parse(node.asText()));
+    } catch (ParseException e) {
+      logger.warn(() -> String.format("Oops! Could not parse date: %s", node.asText()), e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Checks if a review was done for a project.
+   *
+   * @param project The project.
+   * @param metadata Metadata of the review.
+   * @return True if the review was done for the project, false otherwise.
+   */
+  boolean isReviewFor(GitHubProject project, JsonNode metadata) {
+    JsonNode node = metadata.at("/Package-URLs");
+    if (!node.isArray()) {
+      logger.warn("Oops! Package-URLs is not an array!");
+      return false;
+    }
+
+    return StreamSupport.stream(node.spliterator(), false)
+        .filter(JsonNode::isTextual)
+        .map(JsonNode::asText)
+        .anyMatch(purl -> purlBelongsTo(project, purl));
+  }
+
+  /**
+   * Checks if a PURL belongs to a project.
+   *
+   * @param project The project.
+   * @param purl The PURL.
+   * @return True if the PURL belongs to the project, false otherwise.
+   */
+  boolean purlBelongsTo(GitHubProject project, String purl) {
+    try {
+      PackageURL packageURL = new PackageURL(purl);
+      return "github".equalsIgnoreCase(packageURL.getType())
+          && packageURL.getNamespace() != null
+          && packageURL.getName() != null
+          && project.equals(new GitHubProject(packageURL.getNamespace(), packageURL.getName()));
+    } catch (MalformedPackageURLException e) {
+      logger.warn(() -> format("Oops! Could not parse package URL: %s", purl), e);
+    }
+
+    return false;
+  }
+
+  /**
+   * Reads review metadata from a file.
+   *
+   * @param file The file.
+   * @return Metadata if available.
+   * @throws IOException If something went wrong.
+   */
+  private static Optional<JsonNode> readMetadataFrom(Path file) throws IOException {
+    try (BufferedReader reader = Files.newBufferedReader(file)) {
+      return readMetadataFrom(reader);
+    }
+  }
+
+  /**
+   * Reads review metadata from a reader.
+   *
+   * @param reader The reader.
+   * @return Metadata if available.
+   * @throws IOException If something wrong.
+   */
+  static Optional<JsonNode> readMetadataFrom(BufferedReader reader) throws IOException {
+    String line = reader.readLine();
+    if (!"---".equals(line)) {
+      return Optional.empty();
+    }
+
+    StringBuilder metadata = new StringBuilder();
+    do {
+      metadata.append(line).append("\n");
+      line = reader.readLine();
+    } while (line != null && !"---".equals(line));
+
+    return Optional.of(Yaml.mapper().readTree(metadata.toString()));
+  }
+
+  /**
+   * Checks if a file looks like a security review.
+   *
+   * @param path A path to the file.
+   * @return True if the file looks like a security review, false otherwise.
+   */
+  private static boolean isReview(Path path) {
+    return Files.isRegularFile(path) && path.getFileName().toString().endsWith(".md");
+  }
+}
+
+/**
+ * A security review.
+ */
+class SecurityReview {
+
+  /**
+   * What was reviewed.
+   */
+  private final Subject subject;
+
+  /**
+   * When the review was done.
+   */
+  private final Date date;
+
+  /**
+   * Create a new review.
+   *
+   * @param subject What was reviewed.
+   * @param date Whe the review wes done.
+   */
+  SecurityReview(Subject subject, Date date) {
+    this.subject = Objects.requireNonNull(subject, "Subject can't be null!");
+    this.date = Objects.requireNonNull(date, "Date can't be null!");
+  }
+
+  /**
+   * Returns what was reviewed.
+   *
+   * @return What was reviewed.
+   */
+  public Subject subject() {
+    return subject;
+  }
+
+  /**
+   * Returns a date when the review was done.
+   *
+   * @return A date of review.
+   */
+  public Date date() {
+    return date;
+  }
+}
+
+/**
+ * A set of security reviews.
+ */
+class SecurityReviews implements Set<SecurityReview> {
+
+  /**
+   * Security reviews.
+   */
+  private final Set<SecurityReview> elements = new HashSet<>();
+
+  /**
+   * Create a set of security reviews.
+   *
+   * @param elements Reviews to be added to the new set.
+   */
+  public SecurityReviews(SecurityReview... elements) {
+    Objects.requireNonNull(elements, "Elements can't be null!");
+    this.elements.addAll(asList(elements));
+  }
+
+  /**
+   * Create a set of security reviews.
+   *
+   * @param reviews Reviews to be added to the new set.
+   */
+  public SecurityReviews(SecurityReviews reviews) {
+    Objects.requireNonNull(reviews, "Reviews can't be null!");
+    this.elements.addAll(reviews.elements);
+  }
+
+  @Override
+  public int size() {
+    return elements.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return elements.isEmpty();
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    return elements.contains(o);
+  }
+
+  @Override
+  public Iterator<SecurityReview> iterator() {
+    return elements.iterator();
+  }
+
+  @Override
+  public Object[] toArray() {
+    return elements.toArray();
+  }
+
+  @Override
+  public <T> T[] toArray(T[] a) {
+    return elements.toArray(a);
+  }
+
+  @Override
+  public boolean add(SecurityReview review) {
+    return elements.add(review);
+  }
+
+  @Override
+  public boolean remove(Object element) {
+    return elements.remove(element);
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> elements) {
+    return this.elements.containsAll(elements);
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends SecurityReview> elements) {
+    return this.elements.addAll(elements);
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> elements) {
+    return this.elements.retainAll(elements);
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> elements) {
+    return this.elements.removeAll(elements);
+  }
+
+  @Override
+  public void clear() {
+    elements.clear();
+  }
+}
+
+/**
+ * A features that holds security reviews.
+ */
+class SecurityReviewsFeature extends AbstractFeature<SecurityReviews> {
+
+  /**
+   * Initializes a feature.
+   *
+   * @param name The feature name.
+   */
+  public SecurityReviewsFeature(String name) {
+    super(name);
+  }
+
+  @Override
+  public Value<SecurityReviews> value(SecurityReviews reviews) {
+    return new SecurityReviewsValue(this, reviews);
+  }
+
+  @Override
+  public Value<SecurityReviews> parse(String string) {
+    throw new UnsupportedOperationException("Unfortunately I can't parse security reviews");
+  }
+}
+
+/**
+ * A value that holds security reviews.
+ */
+class SecurityReviewsValue extends AbstractKnownValue<SecurityReviews> {
+
+  /**
+   * A set of security reviews.
+   */
+  private final SecurityReviews reviews;
+
+  /**
+   * Create a value with security reviews.
+   *
+   * @param feature A features for the value.
+   * @param reviews A set of security reviews.
+   */
+  public SecurityReviewsValue(SecurityReviewsFeature feature, SecurityReviews reviews) {
+    super(feature);
+    Objects.requireNonNull(reviews, "Reviews can't be null!");
+    this.reviews = new SecurityReviews(reviews);
+  }
+
+  @Override
+  public SecurityReviews get() {
+    return new SecurityReviews(reviews);
+  }
+}

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/experimental/SecurityReviewsFromOpenSSF.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/experimental/SecurityReviewsFromOpenSSF.java
@@ -1,7 +1,6 @@
 package com.sap.oss.phosphor.fosstars.data.github.experimental;
 
 import static java.lang.String.format;
-import static java.util.Arrays.asList;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.packageurl.MalformedPackageURLException;
@@ -10,11 +9,12 @@ import com.sap.oss.phosphor.fosstars.data.github.CachedSingleFeatureGitHubDataPr
 import com.sap.oss.phosphor.fosstars.data.github.GitHubDataFetcher;
 import com.sap.oss.phosphor.fosstars.data.github.LocalRepository;
 import com.sap.oss.phosphor.fosstars.model.Feature;
-import com.sap.oss.phosphor.fosstars.model.Subject;
 import com.sap.oss.phosphor.fosstars.model.Value;
-import com.sap.oss.phosphor.fosstars.model.feature.AbstractFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.oss.SecurityReviewsFeature;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
-import com.sap.oss.phosphor.fosstars.model.value.AbstractKnownValue;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReview;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviewsValue;
 import com.sap.oss.phosphor.fosstars.util.Yaml;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -24,14 +24,10 @@ import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Collection;
 import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.StreamSupport;
 
 /**
@@ -153,11 +149,11 @@ public class SecurityReviewsFromOpenSSF
    */
   boolean purlBelongsTo(GitHubProject project, String purl) {
     try {
-      PackageURL packageURL = new PackageURL(purl);
-      return "github".equalsIgnoreCase(packageURL.getType())
-          && packageURL.getNamespace() != null
-          && packageURL.getName() != null
-          && project.equals(new GitHubProject(packageURL.getNamespace(), packageURL.getName()));
+      PackageURL packageUrl = new PackageURL(purl);
+      return "github".equalsIgnoreCase(packageUrl.getType())
+          && packageUrl.getNamespace() != null
+          && packageUrl.getName() != null
+          && project.equals(new GitHubProject(packageUrl.getNamespace(), packageUrl.getName()));
     } catch (MalformedPackageURLException e) {
       logger.warn(() -> format("Oops! Could not parse package URL: %s", purl), e);
     }
@@ -211,196 +207,3 @@ public class SecurityReviewsFromOpenSSF
   }
 }
 
-/**
- * A security review.
- */
-class SecurityReview {
-
-  /**
-   * What was reviewed.
-   */
-  private final Subject subject;
-
-  /**
-   * When the review was done.
-   */
-  private final Date date;
-
-  /**
-   * Create a new review.
-   *
-   * @param subject What was reviewed.
-   * @param date Whe the review wes done.
-   */
-  SecurityReview(Subject subject, Date date) {
-    this.subject = Objects.requireNonNull(subject, "Subject can't be null!");
-    this.date = Objects.requireNonNull(date, "Date can't be null!");
-  }
-
-  /**
-   * Returns what was reviewed.
-   *
-   * @return What was reviewed.
-   */
-  public Subject subject() {
-    return subject;
-  }
-
-  /**
-   * Returns a date when the review was done.
-   *
-   * @return A date of review.
-   */
-  public Date date() {
-    return date;
-  }
-}
-
-/**
- * A set of security reviews.
- */
-class SecurityReviews implements Set<SecurityReview> {
-
-  /**
-   * Security reviews.
-   */
-  private final Set<SecurityReview> elements = new HashSet<>();
-
-  /**
-   * Create a set of security reviews.
-   *
-   * @param elements Reviews to be added to the new set.
-   */
-  public SecurityReviews(SecurityReview... elements) {
-    Objects.requireNonNull(elements, "Elements can't be null!");
-    this.elements.addAll(asList(elements));
-  }
-
-  /**
-   * Create a set of security reviews.
-   *
-   * @param reviews Reviews to be added to the new set.
-   */
-  public SecurityReviews(SecurityReviews reviews) {
-    Objects.requireNonNull(reviews, "Reviews can't be null!");
-    this.elements.addAll(reviews.elements);
-  }
-
-  @Override
-  public int size() {
-    return elements.size();
-  }
-
-  @Override
-  public boolean isEmpty() {
-    return elements.isEmpty();
-  }
-
-  @Override
-  public boolean contains(Object o) {
-    return elements.contains(o);
-  }
-
-  @Override
-  public Iterator<SecurityReview> iterator() {
-    return elements.iterator();
-  }
-
-  @Override
-  public Object[] toArray() {
-    return elements.toArray();
-  }
-
-  @Override
-  public <T> T[] toArray(T[] a) {
-    return elements.toArray(a);
-  }
-
-  @Override
-  public boolean add(SecurityReview review) {
-    return elements.add(review);
-  }
-
-  @Override
-  public boolean remove(Object element) {
-    return elements.remove(element);
-  }
-
-  @Override
-  public boolean containsAll(Collection<?> elements) {
-    return this.elements.containsAll(elements);
-  }
-
-  @Override
-  public boolean addAll(Collection<? extends SecurityReview> elements) {
-    return this.elements.addAll(elements);
-  }
-
-  @Override
-  public boolean retainAll(Collection<?> elements) {
-    return this.elements.retainAll(elements);
-  }
-
-  @Override
-  public boolean removeAll(Collection<?> elements) {
-    return this.elements.removeAll(elements);
-  }
-
-  @Override
-  public void clear() {
-    elements.clear();
-  }
-}
-
-/**
- * A features that holds security reviews.
- */
-class SecurityReviewsFeature extends AbstractFeature<SecurityReviews> {
-
-  /**
-   * Initializes a feature.
-   *
-   * @param name The feature name.
-   */
-  public SecurityReviewsFeature(String name) {
-    super(name);
-  }
-
-  @Override
-  public Value<SecurityReviews> value(SecurityReviews reviews) {
-    return new SecurityReviewsValue(this, reviews);
-  }
-
-  @Override
-  public Value<SecurityReviews> parse(String string) {
-    throw new UnsupportedOperationException("Unfortunately I can't parse security reviews");
-  }
-}
-
-/**
- * A value that holds security reviews.
- */
-class SecurityReviewsValue extends AbstractKnownValue<SecurityReviews> {
-
-  /**
-   * A set of security reviews.
-   */
-  private final SecurityReviews reviews;
-
-  /**
-   * Create a value with security reviews.
-   *
-   * @param feature A features for the value.
-   * @param reviews A set of security reviews.
-   */
-  public SecurityReviewsValue(SecurityReviewsFeature feature, SecurityReviews reviews) {
-    super(feature);
-    Objects.requireNonNull(reviews, "Reviews can't be null!");
-    this.reviews = new SecurityReviews(reviews);
-  }
-
-  @Override
-  public SecurityReviews get() {
-    return new SecurityReviews(reviews);
-  }
-}

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/experimental/SecurityReviewsFromOpenSSF.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/experimental/SecurityReviewsFromOpenSSF.java
@@ -53,7 +53,7 @@ public class SecurityReviewsFromOpenSSF
   /**
    * A parser for dates.
    */
-  private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+  static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
   /**
    * Initializes a data provider.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/oss/SecurityReviewsFeature.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/oss/SecurityReviewsFeature.java
@@ -1,0 +1,32 @@
+package com.sap.oss.phosphor.fosstars.model.feature.oss;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sap.oss.phosphor.fosstars.model.Value;
+import com.sap.oss.phosphor.fosstars.model.feature.AbstractFeature;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviewsValue;
+
+/**
+ * A features that holds security reviews.
+ */
+public class SecurityReviewsFeature extends AbstractFeature<SecurityReviews> {
+
+  /**
+   * Initializes a feature.
+   *
+   * @param name The feature name.
+   */
+  public SecurityReviewsFeature(@JsonProperty("name") String name) {
+    super(name);
+  }
+
+  @Override
+  public Value<SecurityReviews> value(SecurityReviews reviews) {
+    return new SecurityReviewsValue(this, reviews);
+  }
+
+  @Override
+  public Value<SecurityReviews> parse(String string) {
+    throw new UnsupportedOperationException("Unfortunately I can't parse security reviews");
+  }
+}

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/AbstractKnownValue.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/AbstractKnownValue.java
@@ -19,7 +19,7 @@ public abstract class AbstractKnownValue<T> extends AbstractValue<T, AbstractKno
    *
    * @param feature The feature.
    */
-  AbstractKnownValue(@JsonProperty("feature") Feature<T> feature) {
+  public AbstractKnownValue(@JsonProperty("feature") Feature<T> feature) {
     super(feature);
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReview.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReview.java
@@ -1,0 +1,74 @@
+package com.sap.oss.phosphor.fosstars.model.value;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sap.oss.phosphor.fosstars.model.Subject;
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * A security review.
+ */
+public class SecurityReview {
+
+  /**
+   * What was reviewed.
+   */
+  private final Subject subject;
+
+  /**
+   * When the review was done.
+   */
+  private final Date date;
+
+  /**
+   * Create a new review.
+   *
+   * @param subject What was reviewed.
+   * @param date Whe the review wes done.
+   */
+  public SecurityReview(
+      @JsonProperty("subject") Subject subject,
+      @JsonProperty("date") Date date) {
+
+    this.subject = Objects.requireNonNull(subject, "Subject can't be null!");
+    this.date = Objects.requireNonNull(date, "Date can't be null!");
+  }
+
+  /**
+   * Returns what was reviewed.
+   *
+   * @return What was reviewed.
+   */
+  @JsonGetter("subject")
+  public Subject subject() {
+    return subject;
+  }
+
+  /**
+   * Returns a date when the review was done.
+   *
+   * @return A date of review.
+   */
+  @JsonGetter("date")
+  public Date date() {
+    return date;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o != null && !SecurityReview.class.isAssignableFrom(o.getClass())) {
+      return false;
+    }
+    SecurityReview that = (SecurityReview) o;
+    return Objects.equals(subject, that.subject) && Objects.equals(date, that.date);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(subject, date);
+  }
+}

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReview.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReview.java
@@ -25,7 +25,7 @@ public class SecurityReview {
    * Create a new review.
    *
    * @param subject What was reviewed.
-   * @param date Whe the review wes done.
+   * @param date When the review was done.
    */
   public SecurityReview(
       @JsonProperty("subject") Subject subject,

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviews.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviews.java
@@ -2,10 +2,7 @@ package com.sap.oss.phosphor.fosstars.model.value;
 
 import static java.util.Arrays.asList;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviews.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviews.java
@@ -1,0 +1,143 @@
+package com.sap.oss.phosphor.fosstars.model.value;
+
+import static java.util.Arrays.asList;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A set of security reviews.
+ */
+public class SecurityReviews implements Set<SecurityReview> {
+
+  /**
+   * Security reviews.
+   */
+  private final Set<SecurityReview> elements = new HashSet<>();
+
+  /**
+   * Create an empty set of security reviews.
+   */
+  public SecurityReviews() {
+
+  }
+
+  /**
+   * Create a set of security reviews.
+   *
+   * @param elements Reviews to be added to the new set.
+   */
+  public SecurityReviews(SecurityReview... elements) {
+    Objects.requireNonNull(elements, "Elements can't be null!");
+    this.elements.addAll(asList(elements));
+  }
+
+  /**
+   * Returns a set of security reviews.
+   *
+   * @return A set of security reviews.
+   */
+  @JsonGetter("elements")
+  public Set<SecurityReview> elements() {
+    return new HashSet<>(elements);
+  }
+
+  /**
+   * Create a set of security reviews.
+   *
+   * @param reviews Reviews to be added to the new set.
+   */
+  public SecurityReviews(SecurityReviews reviews) {
+    Objects.requireNonNull(reviews, "Reviews can't be null!");
+    this.elements.addAll(reviews.elements);
+  }
+
+  @Override
+  public int size() {
+    return elements.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return elements.isEmpty();
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    return elements.contains(o);
+  }
+
+  @Override
+  public Iterator<SecurityReview> iterator() {
+    return elements.iterator();
+  }
+
+  @Override
+  public Object[] toArray() {
+    return elements.toArray();
+  }
+
+  @Override
+  public <T> T[] toArray(T[] a) {
+    return elements.toArray(a);
+  }
+
+  @Override
+  public boolean add(SecurityReview review) {
+    return elements.add(review);
+  }
+
+  @Override
+  public boolean remove(Object element) {
+    return elements.remove(element);
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> elements) {
+    return this.elements.containsAll(elements);
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends SecurityReview> elements) {
+    return this.elements.addAll(elements);
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> elements) {
+    return this.elements.retainAll(elements);
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> elements) {
+    return this.elements.removeAll(elements);
+  }
+
+  @Override
+  public void clear() {
+    elements.clear();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o != null && !SecurityReviews.class.isAssignableFrom(o.getClass())) {
+      return false;
+    }
+    SecurityReviews that = (SecurityReviews) o;
+    return Objects.equals(elements, that.elements);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(elements);
+  }
+}

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewsValue.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewsValue.java
@@ -1,0 +1,38 @@
+package com.sap.oss.phosphor.fosstars.model.value;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sap.oss.phosphor.fosstars.model.feature.oss.SecurityReviewsFeature;
+import java.util.Objects;
+
+/**
+ * A value that holds security reviews.
+ */
+public class SecurityReviewsValue extends AbstractKnownValue<SecurityReviews> {
+
+  /**
+   * A set of security reviews.
+   */
+  private final SecurityReviews reviews;
+
+  /**
+   * Create a value with security reviews.
+   *
+   * @param feature A features for the value.
+   * @param reviews A set of security reviews.
+   */
+  public SecurityReviewsValue(
+      @JsonProperty("feature") SecurityReviewsFeature feature,
+      @JsonProperty("reviews") SecurityReviews reviews) {
+
+    super(feature);
+    Objects.requireNonNull(reviews, "Reviews can't be null!");
+    this.reviews = new SecurityReviews(reviews);
+  }
+
+  @Override
+  @JsonGetter("reviews")
+  public SecurityReviews get() {
+    return new SecurityReviews(reviews);
+  }
+}

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/TestGitHubDataFetcherHolder.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/TestGitHubDataFetcherHolder.java
@@ -89,7 +89,7 @@ public class TestGitHubDataFetcherHolder {
      * @param project The {@link GitHubProject}.
      * @param repository The {@link LocalRepository}.
      */
-    static void addForTesting(GitHubProject project, LocalRepository repository) {
+    public static void addForTesting(GitHubProject project, LocalRepository repository) {
       LOCAL_REPOSITORIES.put(project.scm(), repository);
     }
     

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/experimental/SecurityReviewsFromOpenSSFTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/experimental/SecurityReviewsFromOpenSSFTest.java
@@ -1,0 +1,207 @@
+package com.sap.oss.phosphor.fosstars.data.github.experimental;
+
+import static com.sap.oss.phosphor.fosstars.data.github.experimental.SecurityReviewsFromOpenSSF.SECURITY_REVIEWS_PROJECT;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sap.oss.phosphor.fosstars.data.github.LocalRepository;
+import com.sap.oss.phosphor.fosstars.data.github.TestGitHubDataFetcherHolder;
+import com.sap.oss.phosphor.fosstars.model.Value;
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.util.Yaml;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Optional;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+public class SecurityReviewsFromOpenSSFTest extends TestGitHubDataFetcherHolder {
+
+  @Test
+  public void testPurlBelongsTo() {
+    SecurityReviewsFromOpenSSF provider = new SecurityReviewsFromOpenSSF(fetcher);
+    GitHubProject project = new GitHubProject("org", "test");
+    assertTrue(provider.purlBelongsTo(project, "pkg:github/org/test"));
+    assertTrue(provider.purlBelongsTo(project, "pkg:github/org/test@1.0.1"));
+    assertFalse(provider.purlBelongsTo(project, "pkg:other/org/test"));
+    assertFalse(provider.purlBelongsTo(project, "pkg:github/org/other"));
+    assertFalse(provider.purlBelongsTo(project, "pkg:github/other/test"));
+    assertFalse(provider.purlBelongsTo(project, "pkg:github/noname"));
+  }
+
+  @Test
+  public void testIsReviewFor() throws JsonProcessingException {
+    SecurityReviewsFromOpenSSF provider = new SecurityReviewsFromOpenSSF(fetcher);
+
+    JsonNode metadata = Yaml.mapper().readTree(
+        "---\n"
+        + "Publication-State: Active\n"
+        + "Access: Public\n"
+        + "Reviewers:\n"
+        + "- Organization: Trail of Bits\n"
+        + "  Associated-With-Project: false\n"
+        + "  Compensation-Source: non-project\n"
+        + "- Organization: TrustInSoft\n"
+        + "  Associated-With-Project: false\n"
+        + "  Compensation-Source: non-project  \n"
+        + "Domain: Security\n"
+        + "Methodology:\n"
+        + "- External-Review\n"
+        + "Issues-Identified: Non-Severe\n"
+        + "Package-URLs:\n"
+        + "- pkg:github/madler/zlib@1.2.8\n"
+        + "Review-Date: 2016-09-30\n"
+        + "Scope: Implementation/Partial\n"
+        + "Schema-Version: 1.0\n"
+        + "SPDX-License-Identifier: CC-BY-4.0");
+
+    GitHubProject zlib = new GitHubProject("madler", "zlib");
+    assertTrue(provider.isReviewFor(zlib, metadata));
+
+    GitHubProject other = new GitHubProject("org", "other");
+    assertFalse(provider.isReviewFor(other, metadata));
+  }
+
+  @Test
+  public void testReadMetadataFrom() throws IOException {
+    String content = "---\n"
+        + "Publication-State: Active\n"
+        + "Access: Public\n"
+        + "Reviewers:\n"
+        + "- Organization: Trail of Bits\n"
+        + "  Associated-With-Project: false\n"
+        + "  Compensation-Source: non-project\n"
+        + "- Organization: TrustInSoft\n"
+        + "  Associated-With-Project: false\n"
+        + "  Compensation-Source: non-project  \n"
+        + "Domain: Security\n"
+        + "Methodology:\n"
+        + "- External-Review\n"
+        + "Issues-Identified: Non-Severe\n"
+        + "Package-URLs:\n"
+        + "- pkg:github/madler/zlib@1.2.8\n"
+        + "Review-Date: 2016-09-30\n"
+        + "Scope: Implementation/Partial\n"
+        + "Schema-Version: 1.0\n"
+        + "SPDX-License-Identifier: CC-BY-4.0\n"
+        + "---\n"
+        + "\n"
+        + "### Summary\n"
+        + "\n"
+        + "Here is some text.\n";
+
+    try (BufferedReader reader = new BufferedReader(new StringReader(content))) {
+      Optional<JsonNode> metadata = SecurityReviewsFromOpenSSF.readMetadataFrom(reader);
+      assertTrue(metadata.isPresent());
+      assertEquals("2016-09-30", metadata.get().at("/Review-Date").asText());
+      assertTrue(metadata.get().at("/Package-URLs").isArray());
+    }
+
+    try (BufferedReader reader = new BufferedReader(new StringReader("Something else"))) {
+      Optional<JsonNode> metadata = SecurityReviewsFromOpenSSF.readMetadataFrom(reader);
+      assertFalse(metadata.isPresent());
+    }
+
+    String wrongContent = "---\n# Something else\n\nText\n"; // technically, it is valid YAML
+    try (BufferedReader reader = new BufferedReader(new StringReader(wrongContent))) {
+      Optional<JsonNode> metadata = SecurityReviewsFromOpenSSF.readMetadataFrom(reader);
+      assertTrue(metadata.isPresent());
+    }
+  }
+
+  @Test
+  public void testReadReviewDateFrom() throws JsonProcessingException {
+    SecurityReviewsFromOpenSSF provider = new SecurityReviewsFromOpenSSF(fetcher);
+
+    String content = "---\n"
+        + "Package-URLs:\n"
+        + "- pkg:github/madler/zlib@1.2.8\n"
+        + "Review-Date: 2016-09-30\n";
+
+    Optional<Date> date = provider.readReviewDateFrom(Yaml.mapper().readTree(content));
+    assertTrue(date.isPresent());
+    assertEquals("Fri Sep 30 00:00:00 CEST 2016", date.get().toString());
+
+    String wrongContent = "---\n"
+        + "Package-URLs:\n"
+        + "- pkg:github/madler/zlib@1.2.8\n"
+        + "Review-Date: wrong\n";
+
+    date = provider.readReviewDateFrom(Yaml.mapper().readTree(wrongContent));
+    assertFalse(date.isPresent());
+
+    wrongContent = "---\n"
+        + "Package-URLs:\n"
+        + "- pkg:github/madler/zlib@1.2.8\n";
+
+    date = provider.readReviewDateFrom(Yaml.mapper().readTree(wrongContent));
+    assertFalse(date.isPresent());
+  }
+
+  @Test
+  public void testFetchValueFor() throws IOException {
+    Path repositoryDirectory
+        = Files.createTempDirectory(SecurityReviewsFromOpenSSFTest.class.getName());
+    try {
+      GitHubProject project = new GitHubProject("org", "test");
+      LocalRepository repository = mock(LocalRepository.class);
+      TestGitHubDataFetcher.addForTesting(SECURITY_REVIEWS_PROJECT, repository);
+
+      Path reviewFile = repositoryDirectory.resolve("reviews").resolve("github").resolve("test.md");
+      Files.createDirectories(reviewFile.getParent());
+
+      SecurityReviewsFromOpenSSF provider = new SecurityReviewsFromOpenSSF(fetcher);
+
+      String content = "---\n"
+          + "Publication-State: Active\n"
+          + "Access: Public\n"
+          + "Reviewers:\n"
+          + "- Organization: Mordor\n"
+          + "  Associated-With-Project: false\n"
+          + "  Compensation-Source: non-project\n"
+          + "Domain: Security\n"
+          + "Methodology:\n"
+          + "- External-Review\n"
+          + "Issues-Identified: Non-Severe\n"
+          + "Package-URLs:\n"
+          + "- pkg:github/org/test@1.2.3\n"
+          + "Review-Date: 2020-12-25\n"
+          + "Scope: Implementation/Partial\n"
+          + "Schema-Version: 1.0\n"
+          + "SPDX-License-Identifier: CC-BY-4.0\n"
+          + "---\n"
+          + "\n"
+          + "### Summary\n"
+          + "\n"
+          + "Some text here.\n";
+      Files.write(reviewFile, content.getBytes());
+      when(repository.files(any(), any())).thenReturn(Collections.singletonList(reviewFile));
+
+      Value<SecurityReviews> value = provider.fetchValueFor(project);
+      assertFalse(value.isUnknown());
+      assertFalse(value.isNotApplicable());
+      SecurityReviews reviews = value.get();
+      assertEquals(1, reviews.size());
+      SecurityReview review = reviews.iterator().next();
+      assertEquals("Fri Dec 25 00:00:00 CET 2020", review.date().toString());
+      assertEquals(project, review.subject());
+
+      when(repository.files(any(), any())).thenReturn(Collections.emptyList());
+      value = provider.fetchValueFor(project);
+      assertFalse(value.isUnknown());
+      assertFalse(value.isNotApplicable());
+      assertTrue(value.get().isEmpty());
+    } finally {
+      FileUtils.forceDeleteOnExit(repositoryDirectory.toFile());
+    }
+  }
+}

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/experimental/SecurityReviewsFromOpenSSFTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/experimental/SecurityReviewsFromOpenSSFTest.java
@@ -1,5 +1,6 @@
 package com.sap.oss.phosphor.fosstars.data.github.experimental;
 
+import static com.sap.oss.phosphor.fosstars.data.github.experimental.SecurityReviewsFromOpenSSF.DATE_FORMAT;
 import static com.sap.oss.phosphor.fosstars.data.github.experimental.SecurityReviewsFromOpenSSF.SECURITY_REVIEWS_PROJECT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -133,7 +134,7 @@ public class SecurityReviewsFromOpenSSFTest extends TestGitHubDataFetcherHolder 
 
     Optional<Date> date = provider.readReviewDateFrom(Yaml.mapper().readTree(content));
     assertTrue(date.isPresent());
-    assertEquals("Fri Sep 30 00:00:00 CEST 2016", date.get().toString());
+    assertEquals("2016-09-30", DATE_FORMAT.format(date.get()));
 
     String wrongContent = "---\n"
         + "Package-URLs:\n"
@@ -197,7 +198,7 @@ public class SecurityReviewsFromOpenSSFTest extends TestGitHubDataFetcherHolder 
       SecurityReviews reviews = value.get();
       assertEquals(1, reviews.size());
       SecurityReview review = reviews.iterator().next();
-      assertEquals("Fri Dec 25 00:00:00 CET 2020", review.date().toString());
+      assertEquals("2020-12-25", DATE_FORMAT.format(review.date()));
       assertEquals(project, review.subject());
 
       when(repository.files(any(), any())).thenReturn(Collections.emptyList());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/experimental/SecurityReviewsFromOpenSSFTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/experimental/SecurityReviewsFromOpenSSFTest.java
@@ -1,7 +1,9 @@
 package com.sap.oss.phosphor.fosstars.data.github.experimental;
 
 import static com.sap.oss.phosphor.fosstars.data.github.experimental.SecurityReviewsFromOpenSSF.SECURITY_REVIEWS_PROJECT;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -12,6 +14,8 @@ import com.sap.oss.phosphor.fosstars.data.github.LocalRepository;
 import com.sap.oss.phosphor.fosstars.data.github.TestGitHubDataFetcherHolder;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReview;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
 import com.sap.oss.phosphor.fosstars.util.Yaml;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -152,7 +156,6 @@ public class SecurityReviewsFromOpenSSFTest extends TestGitHubDataFetcherHolder 
     Path repositoryDirectory
         = Files.createTempDirectory(SecurityReviewsFromOpenSSFTest.class.getName());
     try {
-      GitHubProject project = new GitHubProject("org", "test");
       LocalRepository repository = mock(LocalRepository.class);
       TestGitHubDataFetcher.addForTesting(SECURITY_REVIEWS_PROJECT, repository);
 
@@ -185,6 +188,8 @@ public class SecurityReviewsFromOpenSSFTest extends TestGitHubDataFetcherHolder 
           + "Some text here.\n";
       Files.write(reviewFile, content.getBytes());
       when(repository.files(any(), any())).thenReturn(Collections.singletonList(reviewFile));
+
+      GitHubProject project = new GitHubProject("org", "test");
 
       Value<SecurityReviews> value = provider.fetchValueFor(project);
       assertFalse(value.isUnknown());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/oss/SecurityReviewsFeatureTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/feature/oss/SecurityReviewsFeatureTest.java
@@ -1,0 +1,19 @@
+package com.sap.oss.phosphor.fosstars.model.feature.oss;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.oss.phosphor.fosstars.util.Json;
+import java.io.IOException;
+import org.junit.Test;
+
+public class SecurityReviewsFeatureTest {
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    SecurityReviewsFeature feature = new SecurityReviewsFeature("test");
+    SecurityReviewsFeature clone = Json.read(Json.toBytes(feature), SecurityReviewsFeature.class);
+    assertTrue(feature.equals(clone) && clone.equals(feature));
+    assertEquals(feature.hashCode(), clone.hashCode());
+  }
+}

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewTest.java
@@ -1,0 +1,23 @@
+package com.sap.oss.phosphor.fosstars.model.value;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.util.Json;
+import java.io.IOException;
+import java.util.Date;
+import org.junit.Test;
+
+public class SecurityReviewTest {
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    GitHubProject project = new GitHubProject("org", "test");
+    Date reviewDate = new Date();
+    SecurityReview review = new SecurityReview(project, reviewDate);
+    SecurityReview clone = Json.read(Json.toBytes(review), SecurityReview.class);
+    assertTrue(review.equals(clone) && clone.equals(review));
+    assertEquals(review.hashCode(), clone.hashCode());
+  }
+}

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewsTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewsTest.java
@@ -1,0 +1,41 @@
+package com.sap.oss.phosphor.fosstars.model.value;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.util.Json;
+import java.io.IOException;
+import java.util.Date;
+import org.junit.Test;
+
+public class SecurityReviewsTest {
+
+  @Test
+  public void testClone() {
+    GitHubProject project = new GitHubProject("org", "test");
+    SecurityReview firstReview = new SecurityReview(project, new Date(1));
+    SecurityReview secondReview = new SecurityReview(project, new Date(2));
+    SecurityReviews securityReviews = new SecurityReviews(firstReview, secondReview);
+    assertEquals(2, securityReviews.size());
+    assertTrue(securityReviews.contains(firstReview));
+    assertTrue(securityReviews.contains(secondReview));
+
+    SecurityReviews clone = new SecurityReviews(securityReviews);
+    assertTrue(securityReviews.equals(clone) && clone.equals(securityReviews));
+    assertEquals(securityReviews.hashCode(), clone.hashCode());
+    assertTrue(clone.containsAll(asList(firstReview, secondReview)));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    GitHubProject project = new GitHubProject("org", "test");
+    SecurityReview firstReview = new SecurityReview(project, new Date(1));
+    SecurityReview secondReview = new SecurityReview(project, new Date(2));
+    SecurityReviews securityReviews = new SecurityReviews(firstReview, secondReview);
+
+    SecurityReviews clone = Json.read(Json.toBytes(securityReviews), SecurityReviews.class);
+    assertEquals(securityReviews, clone);
+  }
+}

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewsValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewsValueTest.java
@@ -1,0 +1,28 @@
+package com.sap.oss.phosphor.fosstars.model.value;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.oss.phosphor.fosstars.model.feature.oss.SecurityReviewsFeature;
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.util.Json;
+import java.io.IOException;
+import java.util.Date;
+import org.junit.Test;
+
+public class SecurityReviewsValueTest {
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    GitHubProject project = new GitHubProject("org", "test");
+    SecurityReview firstReview = new SecurityReview(project, new Date(1));
+    SecurityReview secondReview = new SecurityReview(project, new Date(2));
+    SecurityReviews reviews = new SecurityReviews(firstReview, secondReview);
+    SecurityReviewsFeature feature = new SecurityReviewsFeature("feature");
+    SecurityReviewsValue value = new SecurityReviewsValue(feature, reviews);
+
+    SecurityReviewsValue clone = Json.read(Json.toBytes(value), SecurityReviewsValue.class);
+    assertTrue(value.equals(clone) && clone.equals(value));
+    assertEquals(value.hashCode(), clone.hashCode());
+  }
+}


### PR DESCRIPTION
Updates:

- Added a feature and a value for security reviews.
- Added an experimental data provider that fetches data about security reviews from OpenSSF project.
- Added tests.

Fixes #524