### PR TITLE
Security review score

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -50,7 +50,7 @@
     lines="11"/>
   <suppress checks="AbbreviationAsWordInName"
     files="SecurityReviewsFromOpenSSF.java"
-    lines="38"/>
+    lines="35"/>
   <suppress checks="AbbreviationAsWordInName"
     files="GAV.java"
     lines="12"/>

--- a/docs/oss_security_rating.md
+++ b/docs/oss_security_rating.md
@@ -51,46 +51,48 @@ The procedure for re-calculating the thresholds is described [here](oss_security
 The security rating assesses the following factors of an open source project:
 
 1.  How well the project implements security testing.
-1.  Whether the project has vulnerabilities that have not been fixed.
-1.  How well the community is aware about security.
+1.  Unpatched vulnerabilities.
+1.  Security reviews.
+1.  How well the community is aware of security.
 1.  How the project is active.
 1.  How the project is popular.
 1.  How the community commits to support the project.
 
 To assess these factors, the security rating uses the following info about the open source project:
 
-1.  Whether the project runs CodeQL checks
-1.  Whether the project runs CodeQL scans
-1.  Whether the project uses LGTM checks for commits
-1.  The worst LGTM grade for the project
-1.  Whether the project uses FindSecBugs
-1.  Whether the project uses Dependabot
-1.  Whether the project uses OWASP Dependency Check
-1.  Whether the project has a CVSS threshold for OWASP Dependency Check to fail the build
-1.  Whether the project uses AddressSanitizer
-1.  Whether the project uses MemorySanitizer
-1.  Whether the project uses UndefinedBehaviorSanitizer
-1.  Whether the project uses OWASP Enterprise Security API (ESAPI)
-1.  Whether the project uses OWASP Java Encoder
-1.  Whether the project uses OWASP Java HTML Sanitizer
-1.  Whether the project uses nohttp tool
-1.  Info about vulnerabilities in the project
-1.  Whether the project is included to OSS-Fuzz project
-1.  Whether the project signs artifacts
-1.  Whether the project uses signed commits
-1.  Whether the project has a security policy
-1.  Whether the project has a security team
-1.  Whether the project has a bug bounty program
-1.  Whether the project belongs to Apache Foundation
-1.  Whether the project belongs to Eclipse Foundation
-1.  Whether the project is supported by a company
-1.  Whether the project uses GitHub for development
-1.  Programming languages used in the project
-1.  Package managers used in the project
-1.  Number of commits in the last three months
-1.  Number of contributors in the last three months
-1.  Number of stars in the GitHub repository
-1.  Number of watchers in the GitHub repository
+1.  Whether the project runs CodeQL checks or not.
+1.  Whether the project runs CodeQL scans or not.
+1.  Whether the project uses LGTM checks for commits or not.
+1.  The worst LGTM grade for the project.
+1.  Whether the project uses FindSecBugs or not.
+1.  Whether the project uses Dependabot or not.
+1.  Whether the project uses OWASP Dependency Check or not.
+1.  Whether the project has a CVSS threshold for OWASP Dependency Check to fail the build or not.
+1.  Whether the project uses AddressSanitizer or not.
+1.  Whether the project uses MemorySanitizer or not.
+1.  Whether the project uses UndefinedBehaviorSanitizer or not.
+1.  Whether the project uses OWASP Enterprise Security API (ESAPI) or not.
+1.  Whether the project uses OWASP Java Encoder or not.
+1.  Whether the project uses OWASP Java HTML Sanitizer or not.
+1.  Whether the project uses NoHTTP tool or not.
+1.  Info about security reviews that have been done for the project.
+1.  Info about vulnerabilities in the project.
+1.  Whether the project is included to OSS-Fuzz project or not.
+1.  Whether the project signs artifacts or not.
+1.  Whether the project uses signed commits or not.
+1.  Whether the project has a security policy or not.
+1.  Whether the project has a security team or not.
+1.  Whether the project has a bug bounty program or not.
+1.  Whether the project belongs to Apache Foundation or not.
+1.  Whether the project belongs to Eclipse Foundation or not.
+1.  Whether the project is supported by a company or not.
+1.  Whether the project uses GitHub for development or not.
+1.  Programming languages used in the project.
+1.  Package managers used in the project.
+1.  Number of commits in the last three months.
+1.  Number of contributors in the last three months.
+1.  Number of stars in the GitHub repository.
+1.  Number of watchers in the GitHub repository.
 
 For example, here is a [detailed report](oss/security/curl/curl.md)
 that shows all sub-scores, structure and data that were used to calculate the security rating for curl.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSF.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSF.java
@@ -1,13 +1,10 @@
-package com.sap.oss.phosphor.fosstars.data.github.experimental;
+package com.sap.oss.phosphor.fosstars.data.github;
 
 import static java.lang.String.format;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
-import com.sap.oss.phosphor.fosstars.data.github.CachedSingleFeatureGitHubDataProvider;
-import com.sap.oss.phosphor.fosstars.data.github.GitHubDataFetcher;
-import com.sap.oss.phosphor.fosstars.data.github.LocalRepository;
 import com.sap.oss.phosphor.fosstars.model.Feature;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.feature.oss.SecurityReviewsFeature;

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSF.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSF.java
@@ -1,5 +1,6 @@
 package com.sap.oss.phosphor.fosstars.data.github;
 
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SECURITY_REVIEWS;
 import static java.lang.String.format;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -7,7 +8,6 @@ import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.sap.oss.phosphor.fosstars.model.Feature;
 import com.sap.oss.phosphor.fosstars.model.Value;
-import com.sap.oss.phosphor.fosstars.model.feature.oss.SecurityReviewsFeature;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.SecurityReview;
 import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
@@ -36,12 +36,6 @@ public class SecurityReviewsFromOpenSSF
     extends CachedSingleFeatureGitHubDataProvider<SecurityReviews> {
 
   /**
-   * A feature that holds security reviews.
-   */
-  public static final SecurityReviewsFeature FEATURE
-      = new SecurityReviewsFeature("Security reviews from OpenSSF");
-
-  /**
    * A repository that stores security review.
    */
   static final GitHubProject SECURITY_REVIEWS_PROJECT
@@ -63,7 +57,7 @@ public class SecurityReviewsFromOpenSSF
 
   @Override
   protected Feature<SecurityReviews> supportedFeature() {
-    return FEATURE;
+    return SECURITY_REVIEWS;
   }
 
   @Override
@@ -93,7 +87,7 @@ public class SecurityReviewsFromOpenSSF
       }
     }
 
-    return new SecurityReviewsValue(FEATURE, reviews);
+    return new SecurityReviewsValue(SECURITY_REVIEWS, reviews);
   }
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/oss/OssFeatures.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/oss/OssFeatures.java
@@ -12,7 +12,6 @@ import com.sap.oss.phosphor.fosstars.model.value.ArtifactVersions;
 import com.sap.oss.phosphor.fosstars.model.value.Languages;
 import com.sap.oss.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
-import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import java.util.Date;
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/oss/OssFeatures.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/oss/OssFeatures.java
@@ -12,6 +12,7 @@ import com.sap.oss.phosphor.fosstars.model.value.ArtifactVersions;
 import com.sap.oss.phosphor.fosstars.model.value.Languages;
 import com.sap.oss.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import java.util.Date;
 
@@ -426,4 +427,10 @@ public class OssFeatures {
    */
   public static final BooleanFeature HAS_UNRESOLVED_VULNERABILITY_ALERTS
       = new BooleanFeature("If a project has unresolved vulnerability alerts");
+
+  /**
+   * Contains a set of security reviews that have been done for an open source project.
+   */
+  public static final SecurityReviewsFeature SECURITY_REVIEWS
+      = new SecurityReviewsFeature("Security reviews for a project");
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScore.java
@@ -35,6 +35,7 @@ public class OssSecurityScore extends WeightedCompositeScore {
     SUB_SCORES.add(new ProjectSecurityAwarenessScore());
     SUB_SCORES.add(new UnpatchedVulnerabilitiesScore());
     SUB_SCORES.add(new VulnerabilityDiscoveryAndSecurityTestingScore(securityTestingScore));
+    SUB_SCORES.add(new SecurityReviewScore());
   }
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScore.java
@@ -1,0 +1,62 @@
+package com.sap.oss.phosphor.fosstars.model.score.oss;
+
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SECURITY_REVIEWS;
+import static com.sap.oss.phosphor.fosstars.model.other.Utils.findValue;
+
+import com.sap.oss.phosphor.fosstars.model.Value;
+import com.sap.oss.phosphor.fosstars.model.score.FeatureBasedScore;
+import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReview;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * This scoring function checks if and how security reviews have been done
+ * for an open source project. The score is based on
+ * {@link com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures#SECURITY_REVIEWS} feature.
+ */
+public class SecurityReviewScore extends FeatureBasedScore {
+
+  /**
+   * Create a new scoring function.
+   */
+  public SecurityReviewScore() {
+    super("How security reviews have been done for an open source project", SECURITY_REVIEWS);
+  }
+
+  @Override
+  public ScoreValue calculate(Value<?>... values) {
+    Value<SecurityReviews> reviews = findValue(values, SECURITY_REVIEWS,
+        "Hey! You have to tell me about security reviews!");
+
+    ScoreValue score = scoreValue(MIN, reviews);
+    if (reviews.isUnknown()) {
+      return score.explain("No info about security reviews");
+    }
+
+    if (reviews.get().isEmpty()) {
+      return score.explain("No security reviews have been done");
+    }
+
+    double value = 0.0;
+    Instant now = Instant.now();
+    for (SecurityReview review : reviews.get()) {
+      value += pointsFor(review, now);
+    }
+
+    return score.set(value);
+  }
+
+  /**
+   * Calculate points for a security review.
+   *
+   * @param review The security review.
+   * @param now Current time.
+   * @return Points for the security review.
+   */
+  static double pointsFor(SecurityReview review, Instant now) {
+    long years = (Duration.between(review.date().toInstant(), now).toDays() / 365) + 1;
+    return MAX / years;
+  }
+}

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviews.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviews.java
@@ -146,4 +146,9 @@ public class SecurityReviews implements Set<SecurityReview> {
   public int hashCode() {
     return Objects.hash(elements);
   }
+
+  @Override
+  public String toString() {
+    return String.format("%d security review%s", size(), size() == 1 ? "" : "s");
+  }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviews.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviews.java
@@ -15,6 +15,15 @@ import java.util.Set;
 public class SecurityReviews implements Set<SecurityReview> {
 
   /**
+   * Returns an empty set of security reviews.
+   *
+   * @return An empty set of security reviews.
+   */
+  public static SecurityReviews noReviews() {
+    return new SecurityReviews();
+  }
+
+  /**
    * Security reviews.
    */
   private final Set<SecurityReview> elements = new HashSet<>();

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewsValue.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewsValue.java
@@ -35,4 +35,9 @@ public class SecurityReviewsValue extends AbstractKnownValue<SecurityReviews> {
   public SecurityReviews get() {
     return new SecurityReviews(reviews);
   }
+
+  @Override
+  public String toString() {
+    return reviews.toString();
+  }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/CommonFormatter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/CommonFormatter.java
@@ -30,6 +30,7 @@ import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.README
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.REGISTERED_IN_REUSE;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.RUNS_CODEQL_SCANS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SCANS_FOR_VULNERABLE_DEPENDENCIES;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SECURITY_REVIEWS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_ADDRESS_SANITIZER;
@@ -67,6 +68,7 @@ import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectActivityScore;
 import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore;
 import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore;
 import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.SecurityReviewScore;
 import com.sap.oss.phosphor.fosstars.model.score.oss.StaticAnalysisScore;
 import com.sap.oss.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore;
 import com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore;
@@ -117,6 +119,7 @@ public abstract class CommonFormatter implements Formatter {
     add(FindSecBugsScore.class, "FindSecBugs score");
     add(VulnerabilityDiscoveryAndSecurityTestingScore.class,
         "Vulnerability discovery and security testing");
+    add(SecurityReviewScore.class, "Security reviews");
   }
 
   /**
@@ -192,6 +195,7 @@ public abstract class CommonFormatter implements Formatter {
         "Does it have a team with push privileges on GitHub?");
     add(HAS_UNRESOLVED_VULNERABILITY_ALERTS, "Does it have unresolved vulnerability alerts?");
     add(ENABLED_VULNERABILITY_ALERTS_ON_GITHUB, "Are vulnerability alerts enabled?");
+    add(SECURITY_REVIEWS, "Info about security reviews");
   }
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/DataProviderSelector.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/github/DataProviderSelector.java
@@ -25,6 +25,7 @@ import com.sap.oss.phosphor.fosstars.data.github.PackageManagement;
 import com.sap.oss.phosphor.fosstars.data.github.ProgrammingLanguages;
 import com.sap.oss.phosphor.fosstars.data.github.ReadmeInfo;
 import com.sap.oss.phosphor.fosstars.data.github.ReleasesFromGitHub;
+import com.sap.oss.phosphor.fosstars.data.github.SecurityReviewsFromOpenSSF;
 import com.sap.oss.phosphor.fosstars.data.github.SignsJarArtifacts;
 import com.sap.oss.phosphor.fosstars.data.github.TeamsInfo;
 import com.sap.oss.phosphor.fosstars.data.github.UseReuseDataProvider;
@@ -105,6 +106,7 @@ public class DataProviderSelector {
         new TeamsInfo(fetcher),
         new ContributingGuidelineInfo(fetcher),
         new VulnerabilityAlertsInfo(fetcher),
+        new SecurityReviewsFromOpenSSF(fetcher),
 
         // currently interactive data provider have to be added to the end, see issue #133
         new AskAboutSecurityTeam(),

--- a/src/main/java/com/sap/oss/phosphor/fosstars/util/Deserialization.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/util/Deserialization.java
@@ -88,7 +88,6 @@ import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckCvssThresho
 import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsageValue;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagersValue;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
-import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
 import com.sap.oss.phosphor.fosstars.model.value.SecurityReviewsValue;
 import com.sap.oss.phosphor.fosstars.model.value.StringValue;
 import com.sap.oss.phosphor.fosstars.model.value.UnknownValue;

--- a/src/main/java/com/sap/oss/phosphor/fosstars/util/Deserialization.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/util/Deserialization.java
@@ -28,6 +28,7 @@ import com.sap.oss.phosphor.fosstars.model.feature.oss.ArtifactVersionFeature;
 import com.sap.oss.phosphor.fosstars.model.feature.oss.ArtifactVersionsFeature;
 import com.sap.oss.phosphor.fosstars.model.feature.oss.LanguagesFeature;
 import com.sap.oss.phosphor.fosstars.model.feature.oss.PackageManagersFeature;
+import com.sap.oss.phosphor.fosstars.model.feature.oss.SecurityReviewsFeature;
 import com.sap.oss.phosphor.fosstars.model.feature.oss.VulnerabilitiesInProject;
 import com.sap.oss.phosphor.fosstars.model.math.DoubleInterval;
 import com.sap.oss.phosphor.fosstars.model.qa.ScoreTestVector;
@@ -63,6 +64,7 @@ import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectActivityScore;
 import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore;
 import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore;
 import com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityTestingScore;
+import com.sap.oss.phosphor.fosstars.model.score.oss.SecurityReviewScore;
 import com.sap.oss.phosphor.fosstars.model.score.oss.StaticAnalysisScore;
 import com.sap.oss.phosphor.fosstars.model.score.oss.UnpatchedVulnerabilitiesScore;
 import com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore;
@@ -86,6 +88,8 @@ import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckCvssThresho
 import com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsageValue;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagersValue;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviewsValue;
 import com.sap.oss.phosphor.fosstars.model.value.StringValue;
 import com.sap.oss.phosphor.fosstars.model.value.UnknownValue;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
@@ -209,7 +213,8 @@ public abstract class Deserialization {
         ArtifactVersionFeature.class,
         ArtifactVersionsFeature.class,
         OwaspDependencyCheckUsageFeature.class,
-        OwaspDependencyCheckCvssThreshold.class
+        OwaspDependencyCheckCvssThreshold.class,
+        SecurityReviewsFeature.class
     );
 
     // values
@@ -231,7 +236,8 @@ public abstract class Deserialization {
         ArtifactVersionValue.class,
         ArtifactVersionsValue.class,
         OwaspDependencyCheckUsageValue.class,
-        OwaspDependencyCheckCvssThresholdValue.class
+        OwaspDependencyCheckCvssThresholdValue.class,
+        SecurityReviewsValue.class
     );
 
     // labels
@@ -269,6 +275,7 @@ public abstract class Deserialization {
         DependabotScore.class,
         OwaspDependencyScanScore.class,
         VulnerabilityDiscoveryAndSecurityTestingScore.class,
+        SecurityReviewScore.class,
         OssArtifactSecurityScore.class,
         OssRulesOfPlayScore.class,
         ArtifactLatestReleaseAgeScore.class,

--- a/src/main/resources/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreWeights.json
+++ b/src/main/resources/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreWeights.json
@@ -27,6 +27,10 @@
     "com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore" : {
       "type" : "MutableWeight",
       "value" : 0.6
+    },
+    "com.sap.oss.phosphor.fosstars.model.score.oss.SecurityReviewScore" : {
+      "type" : "MutableWeight",
+      "value" : 0.3
     }
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/TestUtils.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/TestUtils.java
@@ -18,6 +18,7 @@ import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAG
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.RELEASED_ARTIFACT_VERSIONS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.RUNS_CODEQL_SCANS;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SECURITY_REVIEWS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_ADDRESS_SANITIZER;
@@ -39,6 +40,7 @@ import static com.sap.oss.phosphor.fosstars.model.other.Utils.setOf;
 import static com.sap.oss.phosphor.fosstars.model.value.Language.JAVA;
 import static com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsage.MANDATORY;
 import static com.sap.oss.phosphor.fosstars.model.value.PackageManager.MAVEN;
+import static com.sap.oss.phosphor.fosstars.model.value.SecurityReviews.noReviews;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -46,6 +48,7 @@ import com.sap.oss.phosphor.fosstars.model.Confidence;
 import com.sap.oss.phosphor.fosstars.model.Interval;
 import com.sap.oss.phosphor.fosstars.model.Score;
 import com.sap.oss.phosphor.fosstars.model.Value;
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.ArtifactVersion;
 import com.sap.oss.phosphor.fosstars.model.value.ArtifactVersions;
 import com.sap.oss.phosphor.fosstars.model.value.CVSS;
@@ -54,6 +57,8 @@ import com.sap.oss.phosphor.fosstars.model.value.Languages;
 import com.sap.oss.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReview;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
 import com.sap.oss.phosphor.fosstars.model.value.VersionRange;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerability;
@@ -74,6 +79,8 @@ import java.util.stream.Collectors;
 public class TestUtils {
 
   private static final double DELTA = 0.01;
+
+  public static final GitHubProject PROJECT = new GitHubProject("org", "test");
 
   /**
    * The method checks if a score calculates an expected score value for a specified set of values.
@@ -173,7 +180,8 @@ public class TestUtils {
         USES_FIND_SEC_BUGS.value(true),
         OWASP_DEPENDENCY_CHECK_USAGE.value(MANDATORY),
         OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.value(7.0),
-        PACKAGE_MANAGERS.value(PackageManagers.from(MAVEN)));
+        PACKAGE_MANAGERS.value(PackageManagers.from(MAVEN)),
+        SECURITY_REVIEWS.value(noReviews()));
   }
 
   /**
@@ -232,7 +240,8 @@ public class TestUtils {
         USES_FIND_SEC_BUGS.value(true),
         OWASP_DEPENDENCY_CHECK_USAGE.value(MANDATORY),
         OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.value(4.0),
-        PACKAGE_MANAGERS.value(PackageManagers.from(MAVEN)));
+        PACKAGE_MANAGERS.value(PackageManagers.from(MAVEN)),
+        SECURITY_REVIEWS.value(new SecurityReviews(new SecurityReview(PROJECT, new Date()))));
   }
 
   /**

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSFTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSFTest.java
@@ -1,7 +1,7 @@
-package com.sap.oss.phosphor.fosstars.data.github.experimental;
+package com.sap.oss.phosphor.fosstars.data.github;
 
-import static com.sap.oss.phosphor.fosstars.data.github.experimental.SecurityReviewsFromOpenSSF.DATE_FORMAT;
-import static com.sap.oss.phosphor.fosstars.data.github.experimental.SecurityReviewsFromOpenSSF.SECURITY_REVIEWS_PROJECT;
+import static com.sap.oss.phosphor.fosstars.data.github.SecurityReviewsFromOpenSSF.DATE_FORMAT;
+import static com.sap.oss.phosphor.fosstars.data.github.SecurityReviewsFromOpenSSF.SECURITY_REVIEWS_PROJECT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -11,8 +11,6 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.sap.oss.phosphor.fosstars.data.github.LocalRepository;
-import com.sap.oss.phosphor.fosstars.data.github.TestGitHubDataFetcherHolder;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.SecurityReview;

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssArtifactSecurityScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssArtifactSecurityScoreTest.java
@@ -74,7 +74,7 @@ public class OssArtifactSecurityScoreTest {
         ARTIFACT_VERSION.value(new ArtifactVersion("1.0.0", LocalDateTime.now())));
 
     ScoreValue scoreValue = score.calculate(values);
-    assertTrue(DoubleInterval.closed(5, 6).contains(scoreValue.get()));
+    assertTrue(DoubleInterval.closed(4.5, 5.5).contains(scoreValue.get()));
     assertEquals(CONFIDENCE_NO_VULNERABILITY, scoreValue.confidence(), DELTA);
     checkUsedValues(scoreValue);
   }
@@ -87,7 +87,7 @@ public class OssArtifactSecurityScoreTest {
         ARTIFACT_VERSION.value(new ArtifactVersion("1.2.0", LocalDateTime.now())));
 
     ScoreValue scoreValue = score.calculate(values);
-    assertTrue(DoubleInterval.closed(5.75, 6.25).contains(scoreValue.get()));
+    assertTrue(DoubleInterval.closed(5, 6).contains(scoreValue.get()));
     assertEquals(CONFIDENCE_NO_VULNERABILITY, scoreValue.confidence(), DELTA);
     checkUsedValues(scoreValue);
   }
@@ -100,7 +100,7 @@ public class OssArtifactSecurityScoreTest {
         ARTIFACT_VERSION.value(new ArtifactVersion("2.0.0", LocalDateTime.now())));
 
     ScoreValue scoreValue = score.calculate(values);
-    assertTrue(DoubleInterval.closed(6, 6.5).contains(scoreValue.get()));
+    assertTrue(DoubleInterval.closed(5, 6).contains(scoreValue.get()));
     assertEquals(CONFIDENCE_NO_VULNERABILITY, scoreValue.confidence(), DELTA);
     checkUsedValues(scoreValue);
   }
@@ -116,7 +116,7 @@ public class OssArtifactSecurityScoreTest {
         ARTIFACT_VERSION.value(new ArtifactVersion("2.0.0", LocalDateTime.now())));
 
     ScoreValue scoreValue = score.calculate(values);
-    assertTrue(DoubleInterval.closed(7, 7.5).contains(scoreValue.get()));
+    assertTrue(DoubleInterval.closed(6, 7).contains(scoreValue.get()));
     assertEquals(Confidence.MAX, scoreValue.confidence(), DELTA);
     checkUsedValues(scoreValue);
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
@@ -52,7 +52,6 @@ import com.sap.oss.phosphor.fosstars.model.value.Languages;
 import com.sap.oss.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
-import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
@@ -16,6 +16,7 @@ import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.RUNS_CODEQL_SCANS;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SECURITY_REVIEWS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_ADDRESS_SANITIZER;
@@ -37,6 +38,7 @@ import static com.sap.oss.phosphor.fosstars.model.other.Utils.setOf;
 import static com.sap.oss.phosphor.fosstars.model.value.Language.JAVA;
 import static com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsage.MANDATORY;
 import static com.sap.oss.phosphor.fosstars.model.value.PackageManager.MAVEN;
+import static com.sap.oss.phosphor.fosstars.model.value.SecurityReviews.noReviews;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -50,6 +52,7 @@ import com.sap.oss.phosphor.fosstars.model.value.Languages;
 import com.sap.oss.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.IOException;
@@ -116,7 +119,8 @@ public class OssSecurityScoreTest {
         USES_FIND_SEC_BUGS.value(true),
         OWASP_DEPENDENCY_CHECK_USAGE.value(MANDATORY),
         OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.value(7.0),
-        PACKAGE_MANAGERS.value(PackageManagers.from(MAVEN)));
+        PACKAGE_MANAGERS.value(PackageManagers.from(MAVEN)),
+        SECURITY_REVIEWS.value(noReviews()));
     ScoreValue scoreValue = score.calculate(values);
     assertTrue(Score.INTERVAL.contains(scoreValue.get()));
     assertEquals(Confidence.MAX, scoreValue.confidence(), DELTA);

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ScoreVerificationTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ScoreVerificationTest.java
@@ -70,7 +70,7 @@ public class ScoreVerificationTest {
     }
 
     @Override
-    public void visit(Feature feature) {
+    public void visit(Feature<?> feature) {
       // do nothing
     }
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScoreTest.java
@@ -1,0 +1,96 @@
+package com.sap.oss.phosphor.fosstars.model.score.oss;
+
+import static com.sap.oss.phosphor.fosstars.model.Score.MAX;
+import static com.sap.oss.phosphor.fosstars.model.Score.MIN;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SECURITY_REVIEWS;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReview;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
+import java.sql.Date;
+import java.time.Instant;
+import org.junit.Test;
+
+public class SecurityReviewScoreTest {
+
+  private static final double DELTA = 0.01;
+
+  @Test
+  public void testPointsFor() {
+    GitHubProject project = new GitHubProject("org", "test");
+
+    Instant now = Instant.now();
+    assertEquals(
+        MAX,
+        SecurityReviewScore.pointsFor(new SecurityReview(project, Date.from(now)), now),
+        DELTA);
+
+    Instant lessThanYearAgo = now.minus(180, DAYS);
+    assertEquals(
+        MAX,
+        SecurityReviewScore.pointsFor(new SecurityReview(project, Date.from(lessThanYearAgo)), now),
+        DELTA);
+
+    Instant lastYear = now.minus(400, DAYS);
+    assertEquals(
+        5.0,
+        SecurityReviewScore.pointsFor(new SecurityReview(project, Date.from(lastYear)), now),
+        DELTA);
+
+    Instant twoYearsAgo = now.minus(365 * 2 + 50, DAYS);
+    assertEquals(
+        3.33,
+        SecurityReviewScore.pointsFor(new SecurityReview(project, Date.from(twoYearsAgo)), now),
+        DELTA);
+
+    Instant threeYearsAgo = now.minus(365 * 3 + 50, DAYS);
+    assertEquals(
+        2.5,
+        SecurityReviewScore.pointsFor(new SecurityReview(project, Date.from(threeYearsAgo)), now),
+        DELTA);
+  }
+
+  @Test
+  public void testCalculate() {
+    SecurityReviewScore score = new SecurityReviewScore();
+    Instant now = Instant.now();
+    Instant lastYear = now.minus(400, DAYS);
+    Instant threeYearsAgo = now.minus(365 * 3 + 50, DAYS);
+
+    GitHubProject project = new GitHubProject("org", "test");
+
+    ScoreValue scoreValue = score.calculate(
+        SECURITY_REVIEWS.value(
+            new SecurityReviews(
+                new SecurityReview(project, Date.from(lastYear)),
+                new SecurityReview(project, Date.from(threeYearsAgo)))));
+
+    assertFalse(scoreValue.isUnknown());
+    assertFalse(scoreValue.isNotApplicable());
+    assertEquals(7.5, scoreValue.get(), DELTA);
+    assertEquals(1, scoreValue.usedValues().size());
+    assertEquals(SECURITY_REVIEWS, scoreValue.usedValues().get(0).feature());
+  }
+
+  @Test
+  public void testCalculateWithUnknownReviews() {
+    SecurityReviewScore score = new SecurityReviewScore();
+    ScoreValue scoreValue = score.calculate(SECURITY_REVIEWS.unknown());
+    assertFalse(scoreValue.isUnknown());
+    assertFalse(scoreValue.isNotApplicable());
+    assertEquals(MIN, scoreValue.get(), DELTA);
+  }
+
+  @Test
+  public void testCalculateWithNoReviews() {
+    SecurityReviewScore score = new SecurityReviewScore();
+    ScoreValue scoreValue = score.calculate(SECURITY_REVIEWS.value(new SecurityReviews()));
+    assertFalse(scoreValue.isUnknown());
+    assertFalse(scoreValue.isNotApplicable());
+    assertEquals(MIN, scoreValue.get(), DELTA);
+  }
+}

--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatterTest.java
@@ -17,6 +17,7 @@ import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.RUNS_CODEQL_SCANS;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SECURITY_REVIEWS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_ADDRESS_SANITIZER;
@@ -51,12 +52,16 @@ import com.sap.oss.phosphor.fosstars.model.value.Languages;
 import com.sap.oss.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.oss.phosphor.fosstars.model.value.RatingValue;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReview;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import java.util.Date;
 import java.util.Set;
 import org.junit.Test;
 
 public class OssSecurityRatingMarkdownFormatterTest {
+
+  private static final GitHubProject PROJECT = new GitHubProject("org", "test");
 
   private static final OssSecurityRating RATING
       = RatingRepository.INSTANCE.rating(OssSecurityRating.class);
@@ -95,17 +100,18 @@ public class OssSecurityRatingMarkdownFormatterTest {
       USES_OWASP_JAVA_HTML_SANITIZER.value(false),
       OWASP_DEPENDENCY_CHECK_USAGE.value(NOT_USED),
       OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.notSpecifiedValue(),
-      PACKAGE_MANAGERS.value(new PackageManagers(MAVEN)));
+      PACKAGE_MANAGERS.value(new PackageManagers(MAVEN)),
+      SECURITY_REVIEWS.value(new SecurityReviews(new SecurityReview(PROJECT, new Date())))
+  );
 
   @Test
   public void testWithDefaultTemplate() {
     RatingValue ratingValue = RATING.calculate(TEST_VALUES);
-    GitHubProject project = new GitHubProject("org", "test");
-    project.set(ratingValue);
+    PROJECT.set(ratingValue);
 
     OssSecurityRatingMarkdownFormatter formatter
         = new OssSecurityRatingMarkdownFormatter(new OssSecurityGithubAdvisor());
-    String text = formatter.print(project);
+    String text = formatter.print(PROJECT);
 
     assertNotNull(text);
     assertFalse(text.isEmpty());
@@ -126,6 +132,6 @@ public class OssSecurityRatingMarkdownFormatterTest {
     String text = formatter.print(project);
 
     assertNotNull(text);
-    assertEquals("BAD|4.09|10.0|Max|10.0|10.0|security score for open-source projects||", text);
+    assertEquals("BAD|4.44|10.0|Max|10.0|10.0|security score for open-source projects||", text);
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinterTest.java
@@ -17,6 +17,7 @@ import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.PACKAGE_MANAGERS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.PROJECT_START_DATE;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.RUNS_CODEQL_SCANS;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SECURITY_REVIEWS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SIGNS_ARTIFACTS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SUPPORTED_BY_COMPANY;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_ADDRESS_SANITIZER;
@@ -39,6 +40,7 @@ import static com.sap.oss.phosphor.fosstars.model.score.example.ExampleScores.SE
 import static com.sap.oss.phosphor.fosstars.model.value.Language.C;
 import static com.sap.oss.phosphor.fosstars.model.value.OwaspDependencyCheckUsage.NOT_USED;
 import static com.sap.oss.phosphor.fosstars.model.value.PackageManager.MAVEN;
+import static com.sap.oss.phosphor.fosstars.model.value.SecurityReviews.noReviews;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -54,6 +56,7 @@ import com.sap.oss.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.oss.phosphor.fosstars.model.value.RatingValue;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
+import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import java.util.Date;
 import java.util.Locale;
@@ -101,7 +104,8 @@ public class PrettyPrinterTest {
       USES_OWASP_JAVA_HTML_SANITIZER.value(false),
       OWASP_DEPENDENCY_CHECK_USAGE.value(NOT_USED),
       OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.notSpecifiedValue(),
-      PACKAGE_MANAGERS.value(new PackageManagers(MAVEN)));
+      PACKAGE_MANAGERS.value(new PackageManagers(MAVEN)),
+      SECURITY_REVIEWS.value(noReviews()));
 
   private static Locale savedLocale;
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinterTest.java
@@ -56,7 +56,6 @@ import com.sap.oss.phosphor.fosstars.model.value.LgtmGrade;
 import com.sap.oss.phosphor.fosstars.model.value.PackageManagers;
 import com.sap.oss.phosphor.fosstars.model.value.RatingValue;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
-import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import java.util.Date;
 import java.util.Locale;

--- a/src/test/resources/com/sap/oss/phosphor/fosstars/model/rating/oss/OssArtifactSecurityRatingTestVectors.yml
+++ b/src/test/resources/com/sap/oss/phosphor/fosstars/model/rating/oss/OssArtifactSecurityRatingTestVectors.yml
@@ -191,6 +191,11 @@ defaults:
       type: "PositiveIntegerFeature"
       name: "Number of commits in the last three months"
     number: 1000
+  - type: "SecurityReviewsValue"
+    feature:
+      type: "SecurityReviewsFeature"
+      name: "Security reviews for a project"
+    reviews: []
 
 # test vectors
 elements:
@@ -310,6 +315,19 @@ elements:
               vulnerableVersions:
                 - versionStart: 1.0.0
                   versionEnd: 1.1.0
+      - type: "SecurityReviewsValue"
+        feature:
+          type: "SecurityReviewsFeature"
+          name: "Security reviews for a project"
+        reviews:
+          - subject:
+              type: "GitHubProject"
+              name: "test"
+              url: "https://github.com/org/test"
+              organization:
+                type: "GitHubOrganization"
+                name: "org"
+            date: "2020-01-02"
     expectedScore:
       type: "DoubleInterval"
       from: 8.0
@@ -464,6 +482,19 @@ elements:
               vulnerableVersions:
                 - versionStart: 1.0.0
                   versionEnd: 1.1.0
+      - type: "SecurityReviewsValue"
+        feature:
+          type: "SecurityReviewsFeature"
+          name: "Security reviews for a project"
+        reviews:
+          - subject:
+              type: "GitHubProject"
+              name: "test"
+              url: "https://github.com/org/test"
+              organization:
+                type: "GitHubOrganization"
+                name: "org"
+            date: "2020-01-02"
     expectedScore:
       type: "DoubleInterval"
       from: 5.0

--- a/src/test/resources/com/sap/oss/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
+++ b/src/test/resources/com/sap/oss/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
@@ -97,6 +97,11 @@ defaults:
     type: "BooleanFeature"
     name: "If a project runs CodeQL checks for commits"
   flag: false
+- type: "SecurityReviewsValue"
+  feature:
+    type: "SecurityReviewsFeature"
+    name: "Security reviews for a project"
+  reviews: []
 
 # test vectors
 elements:
@@ -551,6 +556,19 @@ elements:
       type: "BooleanFeature"
       name: "If a project runs CodeQL scans"
     flag: true
+  - type: "SecurityReviewsValue"
+    feature:
+      type: "SecurityReviewsFeature"
+      name: "Security reviews for a project"
+    reviews:
+      - subject:
+          type: "GitHubProject"
+          name: "test"
+          url: "https://github.com/org/test"
+          organization:
+            type: "GitHubOrganization"
+            name: "org"
+        date: "2020-01-02"
   expectedScore:
     type: "DoubleInterval"
     from: 3.0

--- a/src/test/resources/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreTestVectors.yml
+++ b/src/test/resources/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreTestVectors.yml
@@ -10,6 +10,7 @@ elements:
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 0.0
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
       com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 0.0
+      com.sap.oss.phosphor.fosstars.model.score.oss.SecurityReviewScore: 0.0
     expectedScore:
       type: "DoubleInterval"
       from: 0.0
@@ -30,6 +31,7 @@ elements:
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
       com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 0.0
+      com.sap.oss.phosphor.fosstars.model.score.oss.SecurityReviewScore: 0.0
     expectedScore:
       type: "DoubleInterval"
       from: 1.0
@@ -50,6 +52,7 @@ elements:
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 5.0
       com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 5.0
+      com.sap.oss.phosphor.fosstars.model.score.oss.SecurityReviewScore: 5.0
     expectedScore:
       type: "DoubleInterval"
       from: 3.0
@@ -70,6 +73,7 @@ elements:
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 10.0
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
       com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 2.0
+      com.sap.oss.phosphor.fosstars.model.score.oss.SecurityReviewScore: 0.0
     expectedScore:
       type: "DoubleInterval"
       from: 3.0
@@ -90,6 +94,7 @@ elements:
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
       com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 2.0
+      com.sap.oss.phosphor.fosstars.model.score.oss.SecurityReviewScore: 0.0
     expectedScore:
       type: "DoubleInterval"
       from: 3.0
@@ -110,6 +115,7 @@ elements:
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 8.0
       com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 9.0
+      com.sap.oss.phosphor.fosstars.model.score.oss.SecurityReviewScore: 0.0
     expectedScore:
       type: "DoubleInterval"
       from: 6.0
@@ -130,6 +136,7 @@ elements:
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 5.0
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 10.0
       com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 10.0
+      com.sap.oss.phosphor.fosstars.model.score.oss.SecurityReviewScore: 5.0
     expectedScore:
       type: "DoubleInterval"
       from: 8.0
@@ -150,6 +157,7 @@ elements:
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 7.0
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 0.0
       com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 0.0
+      com.sap.oss.phosphor.fosstars.model.score.oss.SecurityReviewScore: 0.0
     expectedScore:
       type: "DoubleInterval"
       from: 3.0
@@ -170,6 +178,7 @@ elements:
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 7.0
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 10.0
       com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 9.0
+      com.sap.oss.phosphor.fosstars.model.score.oss.SecurityReviewScore: 0.0
     expectedScore:
       type: "DoubleInterval"
       from: 8.0
@@ -190,6 +199,7 @@ elements:
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectPopularityScore: 10.0
       com.sap.oss.phosphor.fosstars.model.score.oss.ProjectSecurityAwarenessScore: 10.0
       com.sap.oss.phosphor.fosstars.model.score.oss.VulnerabilityDiscoveryAndSecurityTestingScore: 10.0
+      com.sap.oss.phosphor.fosstars.model.score.oss.SecurityReviewScore: 10.0
     expectedScore:
       type: "DoubleInterval"
       from: 9.9

--- a/src/test/resources/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScoreTestVectors.yml
+++ b/src/test/resources/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScoreTestVectors.yml
@@ -1,0 +1,36 @@
+---
+defaults: []
+elements:
+  - type: "StandardTestVector"
+    values:
+      - type: "UnknownValue"
+        feature:
+          type: "SecurityReviewsFeature"
+          name: "Security reviews for a project"
+    expectedScore:
+      type: "DoubleInterval"
+      from: 0.0
+      openLeft: false
+      negativeInfinity: false
+      to: 0.1
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "unknown_reviews"
+  - type: "StandardTestVector"
+    values:
+      - type: "SecurityReviewsValue"
+        feature:
+          type: "SecurityReviewsFeature"
+          name: "Security reviews for a project"
+        reviews: []
+    expectedScore:
+      type: "DoubleInterval"
+      from: 0.0
+      openLeft: false
+      negativeInfinity: false
+      to: 1.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "no_reviews"

--- a/src/test/resources/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScoreTestVectors.yml
+++ b/src/test/resources/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScoreTestVectors.yml
@@ -34,3 +34,53 @@ elements:
       positiveInfinity: false
     expectedLabel: null
     alias: "no_reviews"
+  - type: "StandardTestVector"
+    values:
+      - type: "SecurityReviewsValue"
+        feature:
+          type: "SecurityReviewsFeature"
+          name: "Security reviews for a project"
+        reviews:
+          - subject:
+              type: "GitHubProject"
+              name: "test"
+              url: "https://github.com/org/test"
+              organization:
+                type: "GitHubOrganization"
+                name: "org"
+            date: "2021-01-02"
+    expectedScore:
+      type: "DoubleInterval"
+      from: 9.5
+      openLeft: false
+      negativeInfinity: false
+      to: 10.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "fresh_review"
+  - type: "StandardTestVector"
+    values:
+      - type: "SecurityReviewsValue"
+        feature:
+          type: "SecurityReviewsFeature"
+          name: "Security reviews for a project"
+        reviews:
+          - subject:
+              type: "GitHubProject"
+              name: "test"
+              url: "https://github.com/org/test"
+              organization:
+                type: "GitHubOrganization"
+                name: "org"
+            date: "2019-02-03"
+    expectedScore:
+      type: "DoubleInterval"
+      from: 3.0
+      openLeft: false
+      negativeInfinity: false
+      to: 5.0
+      openRight: false
+      positiveInfinity: false
+    expectedLabel: null
+    alias: "old_review"


### PR DESCRIPTION
Here is a list of main updates:

- Added `OssFeatures.SECURITY_REVIEWS`.
- Added a score for security reviews. The new score contributes to the OSS security score.
- Promoted `SecurityReviewsFromOpenSSF` data provider to supported ones.
- Added tests and test vectors,
- Updated docs.

Closes #570 