### PR TITLE
Better creating GitHub issues

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/AbstractHandler.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/AbstractHandler.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.cli.CommandLine;
@@ -44,6 +45,11 @@ import org.apache.logging.log4j.Logger;
  * A base class for command-line handlers.
  */
 public abstract class AbstractHandler implements Handler {
+
+  /**
+   * No configuration file.
+   */
+  static final Config NO_CONFIG = null;
 
   /**
    * A set of command-line options that specify subjects.
@@ -413,8 +419,27 @@ public abstract class AbstractHandler implements Handler {
    * @throws IllegalArgumentException If the type is unknown.
    */
   List<Reporter<GitHubProject>> makeReporters(Config config) throws IOException {
-    return emptyList();
+    if (config == NO_CONFIG || config.reportConfigs == null) {
+      return emptyList();
+    }
+
+    List<Reporter<GitHubProject>> reporters = new ArrayList<>();
+    for (ReportConfig reportConfig : config.reportConfigs) {
+      reporterFrom(reportConfig).ifPresent(reporters::add);
+    }
+
+    return reporters;
   }
+
+  /**
+   * Create a reporter from a specified report config.
+   *
+   * @param reportConfig The config.
+   * @return A reporter.
+   * @throws IOException If something went wrong.
+   */
+  abstract Optional<Reporter<GitHubProject>> reporterFrom(ReportConfig reportConfig)
+      throws IOException;
 
   /**
    * Stores a rating of a subject if a user asked about it.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/AbstractHandler.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/AbstractHandler.java
@@ -454,7 +454,7 @@ public abstract class AbstractHandler implements Handler {
    * @return A formatter.
    * @throws IllegalArgumentException If the type is unknown.
    */
-  Formatter createFormatter(String type) throws IOException {
+  Formatter createFormatter(String type) {
     if ("text".equals(type)) {
       return PrettyPrinter.withoutVerboseOutput();
     }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/OssArtifactSecurityRatingHandler.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/OssArtifactSecurityRatingHandler.java
@@ -10,6 +10,7 @@ import com.sap.oss.phosphor.fosstars.model.subject.oss.Artifact;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.MavenArtifact;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.NpmArtifact;
+import com.sap.oss.phosphor.fosstars.tool.report.Reporter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
@@ -118,6 +119,11 @@ public class OssArtifactSecurityRatingHandler extends AbstractHandler {
   @Override
   void processConfig(String filename) {
     throw new UnsupportedOperationException("Oops! I don't support configs!");
+  }
+
+  @Override
+  Optional<Reporter<GitHubProject>> reporterFrom(ReportConfig reportConfig) {
+    return Optional.empty();
   }
 
   @Override

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/OssRulesOfPlayRatingHandler.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/OssRulesOfPlayRatingHandler.java
@@ -5,6 +5,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 import com.sap.oss.phosphor.fosstars.advice.oss.OssRulesOfPlayAdvisor;
+import com.sap.oss.phosphor.fosstars.advice.oss.github.AdviceForGitHubContextFactory;
 import com.sap.oss.phosphor.fosstars.model.RatingRepository;
 import com.sap.oss.phosphor.fosstars.model.rating.oss.OssRulesOfPlayRating;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
@@ -40,7 +41,7 @@ public class OssRulesOfPlayRatingHandler extends AbstractHandler {
    */
   public OssRulesOfPlayRatingHandler() throws IOException {
     super(RatingRepository.INSTANCE.rating(OssRulesOfPlayRating.class));
-    advisor = new OssRulesOfPlayAdvisor();
+    advisor = new OssRulesOfPlayAdvisor(AdviceForGitHubContextFactory.INSTANCE);
     markdownFormatter = new OssRulesOfPlayRatingMarkdownFormatter(advisor);
   }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/OssRulesOfPlayRatingHandler.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/OssRulesOfPlayRatingHandler.java
@@ -70,7 +70,7 @@ public class OssRulesOfPlayRatingHandler extends AbstractHandler {
   void processUrl(String url) throws IOException {
     GitHubProject project = GitHubProject.parse(url);
     process(project);
-    if (!commandLine.hasOption("create-issues")) {
+    if (commandLine.hasOption("create-issues")) {
       new OssRulesOfPlayGitHubIssuesReporter(fetcher, markdownFormatter).createIssuesFor(project);
     }
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/OssRulesOfPlayRatingHandler.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/OssRulesOfPlayRatingHandler.java
@@ -5,18 +5,18 @@ import static java.lang.String.format;
 
 import com.sap.oss.phosphor.fosstars.advice.oss.OssRulesOfPlayAdvisor;
 import com.sap.oss.phosphor.fosstars.model.RatingRepository;
-import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.rating.oss.OssRulesOfPlayRating;
-import com.sap.oss.phosphor.fosstars.model.score.oss.OssRulesOfPlayScore;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.tool.format.Formatter;
 import com.sap.oss.phosphor.fosstars.tool.format.OssRulesOfPlayRatingMarkdownFormatter;
 import com.sap.oss.phosphor.fosstars.tool.format.PrettyPrinter;
+import com.sap.oss.phosphor.fosstars.tool.report.OssRulesOfPlayGitHubIssuesReporter;
+import com.sap.oss.phosphor.fosstars.tool.report.Reporter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.cli.CommandLine;
-import org.kohsuke.github.GHIssue;
 
 /**
  * This handler calculates {@link OssRulesOfPlayRating}.
@@ -69,7 +69,10 @@ public class OssRulesOfPlayRatingHandler extends AbstractHandler {
   void processUrl(String url) throws IOException {
     GitHubProject project = GitHubProject.parse(url);
     process(project);
-    createIssuesIfRequested(project, commandLine);
+    Optional<OssRulesOfPlayGitHubIssuesReporter> reporter = issuesReporter();
+    if (reporter.isPresent()) {
+      reporter.get().createIssuesFor(project);
+    }
   }
 
   @Override
@@ -86,71 +89,23 @@ public class OssRulesOfPlayRatingHandler extends AbstractHandler {
     }
   }
 
-  /**
-   * Creates issues for findings in the respective repositories if a user asked about it.
-   *
-   * @param project The project.
-   * @param commandLine Command-line options.
-   * @throws IOException If something went wrong.
-   */
-  private void createIssuesIfRequested(GitHubProject project, CommandLine commandLine)
-      throws IOException {
-
-    if (commandLine.hasOption("create-issues")) {
-      if (!project.ratingValue().isPresent()) {
-        throw new IOException("Could not calculate a rating!");
-      }
-
-      logger.info("Creating issues for findings on {}", project.toString());
-
-      List<Value<Boolean>> violations
-          = OssRulesOfPlayScore.findViolatedRulesIn(
-              project.ratingValue().get().scoreValue().usedValues());
-
-      for (Value<Boolean> violation : violations) {
-        String issueHeader = printTitle(violation);
-        List<GHIssue> existingGitHubIssues = this.fetcher.gitHubIssuesFor(project, issueHeader);
-        if (existingGitHubIssues.isEmpty()) {
-          fetcher.createGitHubIssue(project, printTitle(violation), printBody(violation));
-          logger.info("New issue: " + issueHeader);
-        } else {
-          logger.info("Issue already existing: " + issueHeader);
-        }
-      }
-    }
+  @Override
+  List<Reporter<GitHubProject>> makeReporters(Config config) throws IOException {
+    List<Reporter<GitHubProject>> reporters = new ArrayList<>(super.makeReporters(config));
+    issuesReporter().ifPresent(reporters::add);
+    return reporters;
   }
 
   /**
-   * Print a title for a value.
+   * Creates a {@link OssRulesOfPlayGitHubIssuesReporter} if possible.
    *
-   * @param value The value.
-   * @return The title.
+   * @return A new {@link OssRulesOfPlayGitHubIssuesReporter} if available.
    */
-  public String printTitle(Value<?> value) {
-    return String.format("%s Violation against OSS Rules of Play",
-        markdownFormatter.identifierOf(value.feature()));
-  }
-
-  /**
-   * Print a body for the value.
-   *
-   * @param value The value.
-   * @return The body.
-   */
-  public String printBody(Value<?> value) {
-    StringBuilder sb = new StringBuilder(
-        "A violation against the OSS Rules of Play has been detected.\n\n");
-
-    sb.append(String.format("Rule ID: %s\nExplanation: %s **%s**\n\n",
-        markdownFormatter.identifierOf(value.feature()).replaceAll("[\\[\\]]", ""),
-        markdownFormatter.nameOf(value.feature()),
-        markdownFormatter.printValueAnswer(value)));
-
-    if (markdownFormatter.ruleDocumentationUrl().isPresent()) {
-      sb.append(String.format("Find more information at: %s",
-          markdownFormatter.ruleDocumentationUrl().get()));
+  private Optional<OssRulesOfPlayGitHubIssuesReporter> issuesReporter() {
+    if (!commandLine.hasOption("create-issues") || fetcher == null) {
+      return Optional.empty();
     }
 
-    return sb.toString();
+    return Optional.of(new OssRulesOfPlayGitHubIssuesReporter(fetcher, markdownFormatter));
   }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/ReportConfig.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/ReportConfig.java
@@ -11,7 +11,7 @@ public class ReportConfig {
    * Types of reports.
    */
   public enum ReportType {
-    MARKDOWN, JSON
+    MARKDOWN, JSON, ISSUES
   }
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/AbstractMarkdownFormatter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/AbstractMarkdownFormatter.java
@@ -99,9 +99,9 @@ public abstract class AbstractMarkdownFormatter extends CommonFormatter {
     sb.append(markdownAdviceHeader()).append("\n\n");
     int i = 1;
     for (Advice advice : adviceList) {
-      sb.append(String.format("%d.  %s", i++, advice.content().text()));
+      sb.append(String.format("%d.  %s%n", i++, advice.content().text()));
       if (!advice.content().links().isEmpty()) {
-        sb.append("\n    More info:").append("\n");
+        sb.append("    More info:").append("\n");
         int j = 1;
         for (Link link : advice.content().links()) {
           sb.append(String.format("    %d.  [%s](%s)%n", j++, link.name, link.url));

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/CommonFormatter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/CommonFormatter.java
@@ -18,6 +18,7 @@ import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SE
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_SECURITY_TEAM;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_TEAM_WITH_PUSH_PRIVILEGES_ON_GITHUB;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.HAS_UNRESOLVED_VULNERABILITY_ALERTS;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.INCOMPLETE_README;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.IS_APACHE;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.IS_ECLIPSE;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.IS_REUSE_COMPLIANT;
@@ -184,6 +185,7 @@ public abstract class CommonFormatter implements Formatter {
     add(ALLOWED_LICENSE, "Does it use an allowed license?");
     add(LICENSE_HAS_DISALLOWED_CONTENT, "Does the license have disallowed content?");
     add(HAS_README, "Does it have a README file?");
+    add(INCOMPLETE_README, "Is README incomplete?");
     add(HAS_CONTRIBUTING_GUIDELINE, "Does it have a contributing guideline?");
     add(HAS_REQUIRED_TEXT_IN_CONTRIBUTING_GUIDELINE,
         "Does the contributing guideline have required text?");

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssRulesOfPlayRatingMarkdownFormatter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/format/OssRulesOfPlayRatingMarkdownFormatter.java
@@ -246,9 +246,11 @@ public class OssRulesOfPlayRatingMarkdownFormatter extends AbstractMarkdownForma
    */
   private String passedRulesFrom(ScoreValue scoreValue) {
     List<Value<Boolean>> violatedRules = findViolatedRulesIn(scoreValue.usedValues());
+    List<Value<Boolean>> warnings = findWarningsIn(scoreValue.usedValues());
 
     String content = scoreValue.usedValues().stream()
         .filter(rule -> !violatedRules.contains(rule))
+        .filter(rule -> !warnings.contains(rule))
         .filter(rule -> !rule.isUnknown())
         .map(BooleanValue.class::cast)
         .map(this::formatRuleForList)

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporter.java
@@ -1,0 +1,128 @@
+package com.sap.oss.phosphor.fosstars.tool.report;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+import com.sap.oss.phosphor.fosstars.data.github.GitHubDataFetcher;
+import com.sap.oss.phosphor.fosstars.model.Value;
+import com.sap.oss.phosphor.fosstars.model.score.oss.OssRulesOfPlayScore;
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import com.sap.oss.phosphor.fosstars.tool.format.OssRulesOfPlayRatingMarkdownFormatter;
+import java.io.IOException;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kohsuke.github.GHIssue;
+
+/**
+ * This reporter creates GitHub issues for RoP violations.
+ */
+public class OssRulesOfPlayGitHubIssuesReporter implements Reporter<GitHubProject> {
+
+  /**
+   * A logger.
+   */
+  private static final Logger LOGGER
+      = LogManager.getLogger(OssRulesOfPlayGitHubIssuesReporter.class);
+
+  /**
+   * An interface to GitHub.
+   */
+  private final GitHubDataFetcher fetcher;
+
+  /**
+   * A Markdown formatter.
+   */
+  private final OssRulesOfPlayRatingMarkdownFormatter formatter;
+
+  /**
+   * Create a new reporter.
+   *
+   * @param fetcher An interface to GitHub.
+   * @param formatter A Markdown formatter.
+   */
+  public OssRulesOfPlayGitHubIssuesReporter(
+      GitHubDataFetcher fetcher, OssRulesOfPlayRatingMarkdownFormatter formatter) {
+
+    requireNonNull(fetcher, "Oh no! Fetcher is null!");
+    requireNonNull(formatter, "Oh no! Formatter is null!");
+
+    this.fetcher = fetcher;
+    this.formatter = formatter;
+  }
+
+  @Override
+  public void runFor(List<GitHubProject> projects) {
+    LOGGER.info("Creating issues for OSS RoP violations ...");
+    for (GitHubProject project : projects) {
+      try {
+        createIssuesFor(project);
+      } catch (Exception e) {
+        LOGGER.warn(() -> format("Oops! Could not create issues for %s", project.scm()), e);
+      }
+    }
+  }
+
+  /**
+   * Create issues for RoP violations in a project.
+   *
+   * @param project The project.
+   * @throws IOException If something went wrong.
+   */
+  public void createIssuesFor(GitHubProject project) throws IOException {
+    if (!project.ratingValue().isPresent()) {
+      LOGGER.warn("Oops! No rating calculated for {}", project.scm());
+      return;
+    }
+
+    LOGGER.info("Creating issues for violations on {}", project.toString());
+
+    List<Value<Boolean>> violations
+        = OssRulesOfPlayScore.findViolatedRulesIn(
+            project.ratingValue().get().scoreValue().usedValues());
+
+    for (Value<Boolean> violation : violations) {
+      String issueHeader = printTitle(violation);
+      List<GHIssue> existingGitHubIssues = fetcher.gitHubIssuesFor(project, issueHeader);
+      if (existingGitHubIssues.isEmpty()) {
+        fetcher.createGitHubIssue(project, printTitle(violation), printBody(violation));
+        LOGGER.info("New issue: " + issueHeader);
+      } else {
+        LOGGER.info("Issue already exists: " + issueHeader);
+      }
+    }
+  }
+
+  /**
+   * Print a title for a value.
+   *
+   * @param value The value.
+   * @return The title.
+   */
+  public String printTitle(Value<?> value) {
+    return format(
+        "%s Violation against OSS Rules of Play", formatter.identifierOf(value.feature()));
+  }
+
+  /**
+   * Print a body for the value.
+   *
+   * @param value The value.
+   * @return The body.
+   */
+  public String printBody(Value<?> value) {
+    StringBuilder sb = new StringBuilder(
+        "A violation against the OSS Rules of Play has been detected.\n\n");
+
+    sb.append(format("Rule ID: %s\nExplanation: %s **%s**\n\n",
+        formatter.identifierOf(value.feature()).replaceAll("[\\[\\]]", ""),
+        formatter.nameOf(value.feature()),
+        formatter.printValueAnswer(value)));
+
+    if (formatter.ruleDocumentationUrl().isPresent()) {
+      sb.append(format("Find more information at: %s", formatter.ruleDocumentationUrl().get()));
+    }
+
+    return sb.toString();
+  }
+}

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/report/Reporter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/report/Reporter.java
@@ -1,5 +1,6 @@
 package com.sap.oss.phosphor.fosstars.tool.report;
 
+import com.sap.oss.phosphor.fosstars.model.Subject;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.OpenSourceProject;
 import java.io.IOException;
 import java.util.List;
@@ -9,7 +10,7 @@ import java.util.List;
  *
  * @param <T> A type of projects.
  */
-public interface Reporter<T extends OpenSourceProject> {
+public interface Reporter<T extends Subject> {
 
   /**
    * Runs the reporter for a list of projects.

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/GitHubDataFetcherTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/GitHubDataFetcherTest.java
@@ -385,7 +385,7 @@ public class GitHubDataFetcherTest extends TestGitHubDataFetcherHolder  {
     
     GitHubProject myProject = new GitHubProject("gugl", "hupf");
     when(issueSearchBuilder.isOpen()).thenReturn(issueSearchBuilder);
-    when(issueSearchBuilder.q("apfel")).thenReturn(issueSearchBuilder);
+    when(issueSearchBuilder.q(any())).thenReturn(issueSearchBuilder);
     when(fetcher.github().searchIssues()).thenReturn(issueSearchBuilder);
     
     List<GHIssue> foundIssues = fetcher.gitHubIssuesFor(myProject, "apfel");
@@ -406,7 +406,7 @@ public class GitHubDataFetcherTest extends TestGitHubDataFetcherHolder  {
     
     GitHubProject myProject = new GitHubProject("gugl", "hupf");
     when(issueSearchBuilder.isOpen()).thenReturn(issueSearchBuilder);
-    when(issueSearchBuilder.q("apfel")).thenReturn(issueSearchBuilder);
+    when(issueSearchBuilder.q(any())).thenReturn(issueSearchBuilder);
     when(fetcher.github().searchIssues()).thenReturn(issueSearchBuilder);
     
     List<GHIssue> foundIssues = fetcher.gitHubIssuesFor(myProject, "apfel");

--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporterTest.java
@@ -1,8 +1,11 @@
-package com.sap.oss.phosphor.fosstars.tool;
+package com.sap.oss.phosphor.fosstars.tool.report;
 
 import static junit.framework.TestCase.assertEquals;
 
+import com.sap.oss.phosphor.fosstars.advice.oss.OssRulesOfPlayAdvisor;
+import com.sap.oss.phosphor.fosstars.data.github.TestGitHubDataFetcherHolder;
 import com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures;
+import com.sap.oss.phosphor.fosstars.tool.format.OssRulesOfPlayRatingMarkdownFormatter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -10,7 +13,7 @@ import java.nio.file.Paths;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
-public class OssRulesOfPlayRatingHandlerTest {
+public class OssRulesOfPlayGitHubIssuesReporterTest extends TestGitHubDataFetcherHolder {
 
   private static final Path CONFIG_PATH
       = Paths.get("OssRulesOfPlayRatingMarkdownFormatter.config.yml");
@@ -28,16 +31,17 @@ public class OssRulesOfPlayRatingHandlerTest {
   public void testPrintTitleAndBody() throws IOException {
     Files.write(CONFIG_PATH, RULE_IDS.getBytes());
     try {
-      OssRulesOfPlayRatingHandler handler = new OssRulesOfPlayRatingHandler();
+      OssRulesOfPlayGitHubIssuesReporter reporter = new OssRulesOfPlayGitHubIssuesReporter(
+          fetcher, new OssRulesOfPlayRatingMarkdownFormatter(new OssRulesOfPlayAdvisor()));
 
-      String printedTitle = handler.printTitle(OssFeatures.HAS_LICENSE.value(false));
+      String printedTitle = reporter.printTitle(OssFeatures.HAS_LICENSE.value(false));
       assertEquals("[rl-license_file-1] Violation against OSS Rules of Play", printedTitle);
 
       String stringBuffer = "A violation against the OSS Rules of Play has been detected.\n\n"
           + "Rule ID: rl-license_file-2\n"
           + "Explanation: Does it use an allowed license? **No**\n\n"
           + "Find more information at: https://wiki.local/TestPage";
-      assertEquals(stringBuffer, handler.printBody(OssFeatures.ALLOWED_LICENSE.value(false)));
+      assertEquals(stringBuffer, reporter.printBody(OssFeatures.ALLOWED_LICENSE.value(false)));
     } finally {
       FileUtils.forceDeleteOnExit(CONFIG_PATH.toFile());
     }


### PR DESCRIPTION
Here are main updates:

- Updated the CLI to create issues for RoP violations if a config is used (`--config` command-line option). This closes #599
- Updated the CLI to create reports if a config is used. This closes #603
- Updated the GitHub data fetcher to search for issues in a specific repositories. This closes #614
- Fixed several bugs in the Markdown reporter for RoP.

I tested manually that the CLI creates issues for RoP violations:

- Created two projects for testing
  - https://github.com/artem-smotrakov/test-rop-one
  - https://github.com/artem-smotrakov/test-rop-two
- Updated [workflow](https://github.com/artem-smotrakov/fosstars-rating-core/blob/fosstars-oss-rules-of-play-test-workflow/.github/workflows/fosstars-rules-of-play-test.yml) for testing.
- Config and report are stored in [this branch](https://github.com/artem-smotrakov/fosstars-rating-core/tree/fosstars-oss-rules-of-play-test-report)