### PR TITLE
RoP: Add README.rst & check REUSE case-insensitively

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/ReadmeInfo.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/ReadmeInfo.java
@@ -38,7 +38,7 @@ public class ReadmeInfo extends GitHubCachingDataProvider {
    * A list of known README file names.
    */
   private static final List<String> KNOWN_README_FILES
-      = Arrays.asList("README", "README.txt", "README.md");
+      = Arrays.asList("README", "README.txt", "README.md", "README.rst");
 
   /**
    * A list of patterns that describe required content in README.

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UseReuseDataProvider.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UseReuseDataProvider.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -117,7 +118,8 @@ public class UseReuseDataProvider extends GitHubCachingDataProvider {
 
     String reuseUrl = format("https://api.reuse.software/info/github.com/%s/%s",
         project.organization().name(), project.name());
-    return README_HAS_REUSE_INFO.value(content.get().contains(reuseUrl)).explainIf(false,
+    return README_HAS_REUSE_INFO.value(
+        StringUtils.containsIgnoreCase(content.get(), reuseUrl)).explainIf(false,
         "The README does not seem to have a badge that points to REUSE status (%s)", reuseUrl);
   }
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/ReadmeInfoTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/ReadmeInfoTest.java
@@ -20,9 +20,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Pattern;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 public class ReadmeInfoTest extends TestGitHubDataFetcherHolder {
@@ -103,6 +101,24 @@ public class ReadmeInfoTest extends TestGitHubDataFetcherHolder {
     assertFalse(value.explanation().isEmpty());
     value = checkValue(values, INCOMPLETE_README, true);
     assertFalse(value.explanation().isEmpty());
+  }
+  
+  @Test
+  public void testWithRstReadme() throws IOException {
+    GitHubProject project = new GitHubProject("test", "project");
+    LocalRepository localRepository = mock(LocalRepository.class);
+    when(localRepository.hasFile("README.rst")).thenReturn(true);
+    TestGitHubDataFetcher.addForTesting(project, localRepository);
+    
+    ReadmeInfo provider = new ReadmeInfo(fetcher);
+    provider.set(NoValueCache.create());
+
+    when(localRepository.readTextFrom("README.rst"))
+        .thenReturn(Optional.of(String.join("\n",
+            "This is README.rst"
+        )));
+    ValueSet values = provider.fetchValuesFor(project);
+    assertTrue(checkValue(values, HAS_README, true).get());
   }
 
   @Test

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/UseReuseDataProviderTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/UseReuseDataProviderTest.java
@@ -95,6 +95,17 @@ public class UseReuseDataProviderTest extends TestGitHubDataFetcherHolder {
     assertFalse(value.isUnknown());
     assertTrue(value.get());
     assertTrue(value.explanation().isEmpty());
+    
+    when(localRepository.hasFile("README.md")).thenReturn(true);
+    when(localRepository.file("README.md"))
+        .thenReturn(Optional.of(format(
+            "Yes, README has a link to REUSE: https://api.reuse.software/info/github.com/%s/%s",
+            PROJECT.organization().name().toUpperCase(), PROJECT.name().toUpperCase())));
+    value = UseReuseDataProvider.readmeHasReuseInfo(PROJECT);
+    assertEquals(README_HAS_REUSE_INFO, value.feature());
+    assertFalse(value.isUnknown());
+    assertTrue(value.get());
+    assertTrue(value.explanation().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
- Checks REUSE references ignoring cases in URLs, fixes #631 
- Adds restructured text (rst) READMEs to readme data provider, fixes #632 