### PR TITLE
SecurityReviewScore can consider changes in projects

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -50,7 +50,7 @@
     lines="11"/>
   <suppress checks="AbbreviationAsWordInName"
     files="SecurityReviewsFromOpenSSF.java"
-    lines="40"/>
+    lines="41"/>
   <suppress checks="AbbreviationAsWordInName"
     files="GAV.java"
     lines="12"/>

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -50,7 +50,7 @@
     lines="11"/>
   <suppress checks="AbbreviationAsWordInName"
     files="SecurityReviewsFromOpenSSF.java"
-    lines="35,14"/>
+    lines="40"/>
   <suppress checks="AbbreviationAsWordInName"
     files="GAV.java"
     lines="12"/>

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/GitCommit.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/GitCommit.java
@@ -81,4 +81,13 @@ public class GitCommit implements Commit {
     return Arrays.stream(revCommit.getFullMessage().split("\\r?\\n"))
         .map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toList());
   }
+
+  /**
+   * Get an underlying {@link RevCommit}.
+   *
+   * @return An underlying {@link RevCommit}.
+   */
+  RevCommit raw() {
+    return revCommit;
+  }
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/LocalRepository.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/LocalRepository.java
@@ -1,6 +1,9 @@
 package com.sap.oss.phosphor.fosstars.data.github;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -11,7 +14,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -21,13 +27,14 @@ import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ResetCommand.ResetType;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 
 /**
  * The class holds information about repository that was cloned with JGit.
  */
-// TODO: make sure that all methods accept and expect relative paths from the repository root
 public class LocalRepository implements AutoCloseable {
 
   /**
@@ -38,7 +45,7 @@ public class LocalRepository implements AutoCloseable {
   /**
    * A list of commits in the repository.
    */
-  private final List<Commit> commits = new ArrayList<>();
+  private final List<GitCommit> commits = new ArrayList<>();
 
   /**
    * An instance of {@link Repository} from JGit.
@@ -81,7 +88,7 @@ public class LocalRepository implements AutoCloseable {
    * @throws IOException If something went wrong.
    */
   @JsonIgnore
-  public List<Commit> commits() throws IOException {
+  public List<GitCommit> commits() throws IOException {
     loadCommitsIfNecessary();
     return new ArrayList<>(commits);
   }
@@ -196,7 +203,7 @@ public class LocalRepository implements AutoCloseable {
     }
 
     try (InputStream is = Files.newInputStream(path)) {
-      return Optional.of(IOUtils.toString(is));
+      return Optional.of(IOUtils.toString(is, UTF_8));
     }
   }
 
@@ -260,7 +267,7 @@ public class LocalRepository implements AutoCloseable {
     Optional<InputStream> content = read(file);
     if (content.isPresent()) {
       try (InputStream is = content.get()) {
-        return Optional.of(IOUtils.toString(is));
+        return Optional.of(IOUtils.toString(is, UTF_8));
       }
     }
 
@@ -293,7 +300,7 @@ public class LocalRepository implements AutoCloseable {
     }
 
     try (InputStream is = Files.newInputStream(path)) {
-      return Optional.of(IOUtils.readLines(is));
+      return Optional.of(IOUtils.readLines(is, UTF_8));
     }
   }
 
@@ -332,6 +339,79 @@ public class LocalRepository implements AutoCloseable {
   @Override
   public void close() {
     repository.close();
+  }
+
+  /**
+   * Estimate how much the project has changed since a specified data.
+   * The method inspects the commit history after the specified data,
+   * and looks for updated files.
+   * The method doesn't take into account what was exactly updated in the files.
+   *
+   * @param date The date.
+   * @param toConsider Defines which files should be considered.
+   * @return An estimated amount of changes in the project.
+   * @throws IOException If something went wrong.
+   */
+  public Double changedSince(Date date, Predicate<Path> toConsider) throws IOException {
+    loadCommitsIfNecessary();
+
+    GitCommit head = commits.get(0);
+    Optional<GitCommit> target = firstCommitAfter(date);
+
+    if (!target.isPresent() || target.get().equals(head)) {
+      return 0.0;
+    }
+
+    Map<Path, Boolean> fileMap = new HashMap<>();
+    files(toConsider).forEach(path -> fileMap.put(path, false));
+
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+         DiffFormatter diffFormatter = new DiffFormatter(out)) {
+
+      diffFormatter.setRepository(repository);
+      for (DiffEntry entry : diffFormatter.scan(target.get().raw(), head.raw())) {
+        validEntryPath(entry.getNewPath(), toConsider).ifPresent(path -> fileMap.put(path, true));
+        validEntryPath(entry.getOldPath(), toConsider).ifPresent(path -> fileMap.put(path, true));
+      }
+    }
+
+    long updates = fileMap.entrySet().stream().filter(Entry::getValue).count();
+    return (double) updates / (double) fileMap.size();
+  }
+
+  /**
+   * Looks for the first commit after a specified date.
+   *
+   * @param date The date.
+   * @return The first commit after the specified date if found.
+   */
+  Optional<GitCommit> firstCommitAfter(Date date) {
+    int i = 0;
+    GitCommit target = null;
+    while (i < commits.size()) {
+      if (commits.get(i).date().before(date)) {
+        break;
+      }
+      target = commits.get(i++);
+    }
+    return Optional.ofNullable(target);
+  }
+
+  /**
+   * Resolve a path from a diff entry against the repository's root
+   * if the path satisfies a specified criteria.
+   *
+   * @param entryPath The path.
+   * @param criteria The criteria.
+   * @return A resolved path if all the conditions are met.
+   */
+  private Optional<Path> validEntryPath(String entryPath, Predicate<Path> criteria) {
+    if (entryPath == null || entryPath.equals(DiffEntry.DEV_NULL)) {
+      return Optional.empty();
+    }
+
+    Path path = info.path().resolve(Paths.get(entryPath));
+    return criteria.test(path) ? Optional.of(path) : Optional.empty();
   }
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/LocalRepository.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/LocalRepository.java
@@ -38,6 +38,11 @@ import org.eclipse.jgit.revwalk.RevCommit;
 public class LocalRepository implements AutoCloseable {
 
   /**
+   * No changes in the repository.
+   */
+  private static final double NO_CHANGES = 0.0;
+
+  /**
    * Info about the repository.
    */
   private final LocalRepositoryInfo info;
@@ -342,8 +347,8 @@ public class LocalRepository implements AutoCloseable {
   }
 
   /**
-   * Estimate how much the project has changed since a specified data.
-   * The method inspects the commit history after the specified data,
+   * Estimate how much the project has changed since a specified date.
+   * The method inspects the commit history after the specified date,
    * and looks for updated files.
    * The method doesn't take into account what was exactly updated in the files.
    *
@@ -355,11 +360,15 @@ public class LocalRepository implements AutoCloseable {
   public Double changedSince(Date date, Predicate<Path> toConsider) throws IOException {
     loadCommitsIfNecessary();
 
+    if (commits.isEmpty()) {
+      return NO_CHANGES;
+    }
+
     GitCommit head = commits.get(0);
     Optional<GitCommit> target = firstCommitAfter(date);
 
     if (!target.isPresent() || target.get().equals(head)) {
-      return 0.0;
+      return NO_CHANGES;
     }
 
     Map<Path, Boolean> fileMap = new HashMap<>();

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSF.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSF.java
@@ -15,6 +15,7 @@ import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
 import com.sap.oss.phosphor.fosstars.model.value.SecurityReviewsValue;
 import com.sap.oss.phosphor.fosstars.util.Yaml;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -58,7 +59,7 @@ public class SecurityReviewsFromOpenSSF
       Files.isRegularFile(path)
           && Stream.of(".md", ".txt", ".html", ".rst")
                   .noneMatch(ext -> path.getFileName().endsWith(ext))
-          && Stream.of("/.git", "docs", "test", "demo", "sample", "example")
+          && Stream.of(File.separator + ".git", "docs", "test", "demo", "sample", "example")
                   .noneMatch(string -> path.toString().contains(string));
 
   /**

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSF.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSF.java
@@ -8,6 +8,7 @@ import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.sap.oss.phosphor.fosstars.model.Feature;
 import com.sap.oss.phosphor.fosstars.model.Value;
+import com.sap.oss.phosphor.fosstars.model.ValueSet;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.SecurityReview;
 import com.sap.oss.phosphor.fosstars.model.value.SecurityReviews;
@@ -25,7 +26,11 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
 
 /**
  * This data provider gather information about security reviews collected by OpenSSF.
@@ -45,6 +50,16 @@ public class SecurityReviewsFromOpenSSF
    * A parser for dates.
    */
   static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+  /**
+   * Defines a set of files that should be in scope of security review.
+   */
+  private static final Predicate<Path> INTERESTING_FOR_REVIEW = path ->
+      Files.isRegularFile(path)
+          && Stream.of(".md", ".txt", ".html", ".rst")
+                  .noneMatch(ext -> path.getFileName().endsWith(ext))
+          && Stream.of("/.git", "docs", "test", "demo", "sample", "example")
+                  .noneMatch(string -> path.toString().contains(string));
 
   /**
    * Initializes a data provider.
@@ -83,7 +98,11 @@ public class SecurityReviewsFromOpenSSF
         if (!reviewDate.isPresent()) {
           continue;
         }
-        reviews.add(new SecurityReview(reviewDate.get()));
+
+        Double changed = GitHubDataFetcher.localRepositoryFor(project)
+            .changedSince(reviewDate.get(), INTERESTING_FOR_REVIEW);
+        SecurityReview review = new SecurityReview(reviewDate.get(), changed);
+        reviews.add(review);
       }
     }
 
@@ -195,6 +214,31 @@ public class SecurityReviewsFromOpenSSF
    */
   private static boolean isReview(Path path) {
     return Files.isRegularFile(path) && path.getFileName().toString().endsWith(".md");
+  }
+
+  /**
+   * This is for testing and demo purposes.
+   *
+   * @param args Command-line options (option 1: API token, option 2: project URL).
+   * @throws Exception If something went wrong.
+   */
+  public static void main(String... args) throws Exception {
+    String token = args.length > 0 ? args[0] : "";
+    String url = args.length > 1 ? args[1] : "https://github.com/madler/zlib";
+    GitHubProject project = GitHubProject.parse(url);
+    GitHub github = new GitHubBuilder().withOAuthToken(token).build();
+    SecurityReviewsFromOpenSSF provider
+        = new SecurityReviewsFromOpenSSF(new GitHubDataFetcher(github, token));
+
+    ValueSet values = provider.fetchValuesFor(project);
+    Optional<Value<SecurityReviews>> securityReviews = values.of(SECURITY_REVIEWS);
+    if (!securityReviews.isPresent()) {
+      throw new RuntimeException("Could not find security reviews!");
+    }
+
+    for (SecurityReview review : securityReviews.get().get()) {
+      System.out.println(review);
+    }
   }
 }
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScore.java
@@ -39,7 +39,7 @@ public class SecurityReviewScore extends FeatureBasedScore {
       return score.explain("No security reviews have been done");
     }
 
-    double value = 0.0;
+    double value = MIN;
     Instant now = Instant.now();
     for (SecurityReview review : reviews.get()) {
       value += pointsFor(review, now);
@@ -56,6 +56,9 @@ public class SecurityReviewScore extends FeatureBasedScore {
    * @return Points for the security review.
    */
   static double pointsFor(SecurityReview review, Instant now) {
+    if (review.projectChanged().isPresent()) {
+      return MAX * (1.0 - review.projectChanged().get());
+    }
     long years = (Duration.between(review.date().toInstant(), now).toDays() / 365) + 1;
     return MAX / years;
   }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReview.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReview.java
@@ -19,6 +19,11 @@ import javax.annotation.Nullable;
 public class SecurityReview {
 
   /**
+   * No info about changes since a review.
+   */
+  public static final Double NO_INFO_ABOUT_CHANGES = null;
+
+  /**
    * A valid interval for amount of changes returned by {@link #changes()}.
    */
   private static final Interval CHANGES_INTERVAL = DoubleInterval.closed(0.0, 1.0);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReview.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReview.java
@@ -1,10 +1,17 @@
 package com.sap.oss.phosphor.fosstars.model.value;
 
+import static java.lang.String.format;
+
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.sap.oss.phosphor.fosstars.model.Subject;
+import com.sap.oss.phosphor.fosstars.model.Interval;
+import com.sap.oss.phosphor.fosstars.model.math.DoubleInterval;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * A security review.
@@ -12,17 +19,41 @@ import java.util.Objects;
 public class SecurityReview {
 
   /**
+   * A valid interval for amount of changes returned by {@link #changes()}.
+   */
+  private static final Interval CHANGES_INTERVAL = DoubleInterval.closed(0.0, 1.0);
+
+  /**
+   * A parser for dates.
+   */
+  static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+  /**
    * When the review was done.
    */
   private final Date date;
 
   /**
+   * An amount of changes in the project since the review date.
+   */
+  private final Double changes;
+
+  /**
    * Create a new review.
    *
    * @param date When the review was done.
+   * @param changes An amount of changes in the project since the review date.
    */
-  public SecurityReview(@JsonProperty("date") Date date) {
+  public SecurityReview(
+      @JsonProperty("date") Date date,
+      @Nullable @JsonProperty("changes") Double changes) {
+
+    if (changes != null && !CHANGES_INTERVAL.contains(changes)) {
+      throw new IllegalArgumentException(format("Oops! Wrong value for changes %s!", changes));
+    }
+
     this.date = Objects.requireNonNull(date, "Date can't be null!");
+    this.changes = changes;
   }
 
   /**
@@ -35,6 +66,26 @@ public class SecurityReview {
     return date;
   }
 
+  /**
+   * Get an amount of changes in the project since the review date.
+   *
+   * @return An amount of changes in the project since the review date if available.
+   */
+  public Optional<Double> projectChanged() {
+    return Optional.ofNullable(changes);
+  }
+
+  /**
+   * An amount of changes in the project since the review date.
+   * This method is necessary for serialization with Jackson.
+   *
+   * @return An amount of changes in the project since the review date.
+   */
+  @JsonGetter
+  private Double changes() {
+    return changes;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -44,11 +95,19 @@ public class SecurityReview {
       return false;
     }
     SecurityReview that = (SecurityReview) o;
-    return Objects.equals(date, that.date);
+    return Objects.equals(date, that.date)
+        && Objects.equals(changes, that.changes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(date);
+    return Objects.hash(date, changes);
+  }
+
+  @Override
+  public String toString() {
+    return format("Security review at %s, %s of the project files has changed since than",
+        DATE_FORMAT.format(date),
+        projectChanged().map(n -> format("%d%%", (int) (n * 100.0))).orElse("unknown part"));
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/LocalRepositoryTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/LocalRepositoryTest.java
@@ -174,7 +174,8 @@ public class LocalRepositoryTest {
 
       localRepository = spy(localRepository);
       Date reviewDate = new Date();
-      Predicate<Path> forAllFiles = p -> Files.isRegularFile(p) && !p.toString().contains("/.git");
+      Predicate<Path> forAllFiles = p -> Files.isRegularFile(p)
+          && !p.toString().contains(File.separator + ".git");
 
       when(localRepository.firstCommitAfter(reviewDate)).thenReturn(Optional.of(commits.get(0)));
       Double changes = localRepository.changedSince(reviewDate, forAllFiles);

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSFTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSFTest.java
@@ -167,7 +167,7 @@ public class SecurityReviewsFromOpenSSFTest extends TestGitHubDataFetcherHolder 
         = Files.createTempDirectory(SecurityReviewsFromOpenSSFTest.class.getName());
     Path directory = Files.createTempDirectory(getClass().getName());
     try (Repository repository = FileRepositoryBuilder.create(directory.resolve(".git").toFile());
-        Git git = new Git(repository)) {
+         Git git = new Git(repository)) {
 
       repository.create();
 

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSFTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/SecurityReviewsFromOpenSSFTest.java
@@ -1,5 +1,7 @@
 package com.sap.oss.phosphor.fosstars.data.github;
 
+import static com.sap.oss.phosphor.fosstars.TestUtils.DELTA;
+import static com.sap.oss.phosphor.fosstars.TestUtils.PROJECT;
 import static com.sap.oss.phosphor.fosstars.data.github.SecurityReviewsFromOpenSSF.DATE_FORMAT;
 import static com.sap.oss.phosphor.fosstars.data.github.SecurityReviewsFromOpenSSF.SECURITY_REVIEWS_PROJECT;
 import static org.junit.Assert.assertEquals;
@@ -7,10 +9,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sap.oss.phosphor.fosstars.TestUtils;
 import com.sap.oss.phosphor.fosstars.model.Value;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
 import com.sap.oss.phosphor.fosstars.model.value.SecurityReview;
@@ -21,10 +25,17 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.text.ParseException;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.junit.Test;
 
 public class SecurityReviewsFromOpenSSFTest extends TestGitHubDataFetcherHolder {
@@ -151,17 +162,53 @@ public class SecurityReviewsFromOpenSSFTest extends TestGitHubDataFetcherHolder 
   }
 
   @Test
-  public void testFetchValueFor() throws IOException {
-    Path repositoryDirectory
+  public void testFetchValueFor() throws IOException, GitAPIException, ParseException {
+    Path securityReviewDirectory
         = Files.createTempDirectory(SecurityReviewsFromOpenSSFTest.class.getName());
-    try {
-      LocalRepository repository = mock(LocalRepository.class);
-      TestGitHubDataFetcher.addForTesting(SECURITY_REVIEWS_PROJECT, repository);
+    Path directory = Files.createTempDirectory(getClass().getName());
+    try (Repository repository = FileRepositoryBuilder.create(directory.resolve(".git").toFile());
+        Git git = new Git(repository)) {
 
-      Path reviewFile = repositoryDirectory.resolve("reviews").resolve("github").resolve("test.md");
+      repository.create();
+
+      TestUtils.commit(
+          new HashMap<String, String>() {
+            {
+              put("App.java", "public class App {}");
+              put("One.java", "public class One {}");
+              put("Two.java", "public class Two {}");
+            }
+            }, "First commit: init", git);
+
+      TestUtils.commit(
+          new HashMap<String, String>() {
+            {
+              put("App.java", "public class App { /* something new */ }");
+            }
+            }, "Second commit: updated App", git);
+
+      TestUtils.commit(
+          new HashMap<String, String>() {
+            {
+              put("Other.java", "public class Other {}");
+              put("One.java", "public class One { /* something new */ }");
+            }
+            }, "Third commit: added Other, updated One", git);
+
+      LocalRepository localRepository = new LocalRepository(
+          new LocalRepositoryInfo(directory, new Date(), PROJECT.scm()),
+          repository);
+      localRepository = spy(localRepository);
+      TestGitHubDataFetcher.addForTesting(PROJECT, localRepository);
+
+      LocalRepository securityReviewLocalRepository = mock(LocalRepository.class);
+      TestGitHubDataFetcher.addForTesting(SECURITY_REVIEWS_PROJECT, securityReviewLocalRepository);
+
+      Path reviewFile
+          = securityReviewDirectory.resolve("reviews").resolve("github").resolve("test.md");
       Files.createDirectories(reviewFile.getParent());
 
-      SecurityReviewsFromOpenSSF provider = new SecurityReviewsFromOpenSSF(fetcher);
+      final SecurityReviewsFromOpenSSF provider = new SecurityReviewsFromOpenSSF(fetcher);
 
       String content = "---\n"
           + "Publication-State: Active\n"
@@ -186,25 +233,34 @@ public class SecurityReviewsFromOpenSSFTest extends TestGitHubDataFetcherHolder 
           + "\n"
           + "Some text here.\n";
       Files.write(reviewFile, content.getBytes());
-      when(repository.files(any(), any())).thenReturn(Collections.singletonList(reviewFile));
+      when(securityReviewLocalRepository.files(any(), any()))
+          .thenReturn(Collections.singletonList(reviewFile));
 
-      GitHubProject project = new GitHubProject("org", "test");
+      Date reviewDate = DATE_FORMAT.parse("2020-12-25");
+      List<GitCommit> commits = localRepository.commits();
 
-      Value<SecurityReviews> value = provider.fetchValueFor(project);
+      when(localRepository.firstCommitAfter(reviewDate))
+          .thenReturn(Optional.of(commits.get(1)));
+      Value<SecurityReviews> value = provider.fetchValueFor(PROJECT);
       assertFalse(value.isUnknown());
       assertFalse(value.isNotApplicable());
       SecurityReviews reviews = value.get();
       assertEquals(1, reviews.size());
       SecurityReview review = reviews.iterator().next();
       assertEquals("2020-12-25", DATE_FORMAT.format(review.date()));
+      assertEquals(0.5,
+          review.projectChanged()
+              .orElseThrow(() -> new Error("Could not figure out how much of code has changes!")),
+          DELTA);
 
-      when(repository.files(any(), any())).thenReturn(Collections.emptyList());
-      value = provider.fetchValueFor(project);
+      when(securityReviewLocalRepository.files(any(), any())).thenReturn(Collections.emptyList());
+      value = provider.fetchValueFor(PROJECT);
       assertFalse(value.isUnknown());
       assertFalse(value.isNotApplicable());
       assertTrue(value.get().isEmpty());
     } finally {
-      FileUtils.forceDeleteOnExit(repositoryDirectory.toFile());
+      FileUtils.forceDeleteOnExit(securityReviewDirectory.toFile());
+      FileUtils.forceDeleteOnExit(directory.toFile());
     }
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScoreTest.java
@@ -1,5 +1,6 @@
 package com.sap.oss.phosphor.fosstars.model.score.oss;
 
+import static com.sap.oss.phosphor.fosstars.TestUtils.DELTA;
 import static com.sap.oss.phosphor.fosstars.model.Score.MAX;
 import static com.sap.oss.phosphor.fosstars.model.Score.MIN;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SECURITY_REVIEWS;
@@ -16,38 +17,46 @@ import org.junit.Test;
 
 public class SecurityReviewScoreTest {
 
-  private static final double DELTA = 0.01;
-
   @Test
   public void testPointsFor() {
     Instant now = Instant.now();
     assertEquals(
         MAX,
-        SecurityReviewScore.pointsFor(new SecurityReview(Date.from(now)), now),
+        SecurityReviewScore.pointsFor(
+            new SecurityReview(Date.from(now), 0.0),
+            now),
         DELTA);
 
     Instant lessThanYearAgo = now.minus(180, DAYS);
     assertEquals(
         MAX,
-        SecurityReviewScore.pointsFor(new SecurityReview(Date.from(lessThanYearAgo)), now),
+        SecurityReviewScore.pointsFor(
+            new SecurityReview(Date.from(lessThanYearAgo), 0.1),
+            now),
         DELTA);
 
     Instant lastYear = now.minus(400, DAYS);
     assertEquals(
         5.0,
-        SecurityReviewScore.pointsFor(new SecurityReview(Date.from(lastYear)), now),
+        SecurityReviewScore.pointsFor(
+            new SecurityReview(Date.from(lastYear), 0.2),
+            now),
         DELTA);
 
     Instant twoYearsAgo = now.minus(365 * 2 + 50, DAYS);
     assertEquals(
         3.33,
-        SecurityReviewScore.pointsFor(new SecurityReview(Date.from(twoYearsAgo)), now),
+        SecurityReviewScore.pointsFor(
+            new SecurityReview(Date.from(twoYearsAgo), 0.3),
+            now),
         DELTA);
 
     Instant threeYearsAgo = now.minus(365 * 3 + 50, DAYS);
     assertEquals(
         2.5,
-        SecurityReviewScore.pointsFor(new SecurityReview(Date.from(threeYearsAgo)), now),
+        SecurityReviewScore.pointsFor(
+            new SecurityReview(Date.from(threeYearsAgo), 0.5),
+            now),
         DELTA);
   }
 
@@ -61,8 +70,8 @@ public class SecurityReviewScoreTest {
     ScoreValue scoreValue = score.calculate(
         SECURITY_REVIEWS.value(
             new SecurityReviews(
-                new SecurityReview(Date.from(lastYear)),
-                new SecurityReview(Date.from(threeYearsAgo)))));
+                new SecurityReview(Date.from(lastYear), 0.1),
+                new SecurityReview(Date.from(threeYearsAgo), 0.4))));
 
     assertFalse(scoreValue.isUnknown());
     assertFalse(scoreValue.isNotApplicable());

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScoreTest.java
@@ -4,6 +4,7 @@ import static com.sap.oss.phosphor.fosstars.TestUtils.DELTA;
 import static com.sap.oss.phosphor.fosstars.model.Score.MAX;
 import static com.sap.oss.phosphor.fosstars.model.Score.MIN;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.SECURITY_REVIEWS;
+import static com.sap.oss.phosphor.fosstars.model.value.SecurityReview.NO_INFO_ABOUT_CHANGES;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -26,36 +27,66 @@ public class SecurityReviewScoreTest {
             new SecurityReview(Date.from(now), 0.0),
             now),
         DELTA);
-
-    Instant lessThanYearAgo = now.minus(180, DAYS);
     assertEquals(
         MAX,
         SecurityReviewScore.pointsFor(
+            new SecurityReview(Date.from(now), NO_INFO_ABOUT_CHANGES),
+            now),
+        DELTA);
+
+    Instant lessThanYearAgo = now.minus(180, DAYS);
+    assertEquals(
+        9.0,
+        SecurityReviewScore.pointsFor(
             new SecurityReview(Date.from(lessThanYearAgo), 0.1),
+            now),
+        DELTA);
+    assertEquals(
+        MAX,
+        SecurityReviewScore.pointsFor(
+            new SecurityReview(Date.from(lessThanYearAgo), NO_INFO_ABOUT_CHANGES),
             now),
         DELTA);
 
     Instant lastYear = now.minus(400, DAYS);
     assertEquals(
-        5.0,
+        8.0,
         SecurityReviewScore.pointsFor(
             new SecurityReview(Date.from(lastYear), 0.2),
+            now),
+        DELTA);
+    assertEquals(
+        5.0,
+        SecurityReviewScore.pointsFor(
+            new SecurityReview(Date.from(lastYear), NO_INFO_ABOUT_CHANGES),
             now),
         DELTA);
 
     Instant twoYearsAgo = now.minus(365 * 2 + 50, DAYS);
     assertEquals(
-        3.33,
+        7.0,
         SecurityReviewScore.pointsFor(
             new SecurityReview(Date.from(twoYearsAgo), 0.3),
+            now),
+        DELTA);
+    assertEquals(
+        3.33,
+        SecurityReviewScore.pointsFor(
+            new SecurityReview(Date.from(twoYearsAgo), NO_INFO_ABOUT_CHANGES),
             now),
         DELTA);
 
     Instant threeYearsAgo = now.minus(365 * 3 + 50, DAYS);
     assertEquals(
-        2.5,
+        5.0,
         SecurityReviewScore.pointsFor(
             new SecurityReview(Date.from(threeYearsAgo), 0.5),
+            now),
+        DELTA);
+    assertEquals(
+        2.5,
+        SecurityReviewScore.pointsFor(
+            new SecurityReview(Date.from(threeYearsAgo), NO_INFO_ABOUT_CHANGES),
             now),
         DELTA);
   }
@@ -75,9 +106,17 @@ public class SecurityReviewScoreTest {
 
     assertFalse(scoreValue.isUnknown());
     assertFalse(scoreValue.isNotApplicable());
-    assertEquals(7.5, scoreValue.get(), DELTA);
+    assertEquals(MAX, scoreValue.get(), DELTA);
     assertEquals(1, scoreValue.usedValues().size());
     assertEquals(SECURITY_REVIEWS, scoreValue.usedValues().get(0).feature());
+
+    scoreValue = score.calculate(
+        SECURITY_REVIEWS.value(
+            new SecurityReviews(
+                new SecurityReview(Date.from(lastYear), NO_INFO_ABOUT_CHANGES),
+                new SecurityReview(Date.from(threeYearsAgo), NO_INFO_ABOUT_CHANGES))));
+
+    assertEquals(7.5, scoreValue.get(), DELTA);
   }
 
   @Test

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewTest.java
@@ -2,19 +2,52 @@ package com.sap.oss.phosphor.fosstars.model.value;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.sap.oss.phosphor.fosstars.util.Json;
+import com.sap.oss.phosphor.fosstars.util.Yaml;
 import java.io.IOException;
 import java.util.Date;
 import org.junit.Test;
 
 public class SecurityReviewTest {
 
+  private static final Date TEST_REVIEW_DATE = new Date();
+
+  @Test
+  public void testWrongChanges() {
+    for (Double value : new double[] { -1.0, 2.0 }) {
+      try {
+        new SecurityReview(TEST_REVIEW_DATE, value);
+        fail("No exception thrown!");
+      } catch (IllegalArgumentException e) {
+        // expected
+      }
+    }
+  }
+
   @Test
   public void testJsonSerialization() throws IOException {
-    Date reviewDate = new Date();
-    SecurityReview review = new SecurityReview(reviewDate);
+    SecurityReview review = new SecurityReview(TEST_REVIEW_DATE, 0.0);
     SecurityReview clone = Json.read(Json.toBytes(review), SecurityReview.class);
+    assertTrue(review.equals(clone) && clone.equals(review));
+    assertEquals(review.hashCode(), clone.hashCode());
+
+    review = new SecurityReview(TEST_REVIEW_DATE, null);
+    clone = Json.read(Json.toBytes(review), SecurityReview.class);
+    assertTrue(review.equals(clone) && clone.equals(review));
+    assertEquals(review.hashCode(), clone.hashCode());
+  }
+
+  @Test
+  public void testYamlSerialization() throws IOException {
+    SecurityReview review = new SecurityReview(TEST_REVIEW_DATE, 0.0);
+    SecurityReview clone = Yaml.read(Json.toBytes(review), SecurityReview.class);
+    assertTrue(review.equals(clone) && clone.equals(review));
+    assertEquals(review.hashCode(), clone.hashCode());
+
+    review = new SecurityReview(TEST_REVIEW_DATE, null);
+    clone = Yaml.read(Json.toBytes(review), SecurityReview.class);
     assertTrue(review.equals(clone) && clone.equals(review));
     assertEquals(review.hashCode(), clone.hashCode());
   }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewsTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewsTest.java
@@ -13,8 +13,8 @@ public class SecurityReviewsTest {
 
   @Test
   public void testClone() {
-    SecurityReview firstReview = new SecurityReview(new Date(1));
-    SecurityReview secondReview = new SecurityReview(new Date(2));
+    SecurityReview firstReview = new SecurityReview(new Date(1), 0.0);
+    SecurityReview secondReview = new SecurityReview(new Date(2), 1.0);
     SecurityReviews securityReviews = new SecurityReviews(firstReview, secondReview);
     assertEquals(2, securityReviews.size());
     assertTrue(securityReviews.contains(firstReview));
@@ -28,8 +28,8 @@ public class SecurityReviewsTest {
 
   @Test
   public void testJsonSerialization() throws IOException {
-    SecurityReview firstReview = new SecurityReview(new Date(1));
-    SecurityReview secondReview = new SecurityReview(new Date(2));
+    SecurityReview firstReview = new SecurityReview(new Date(1), 0.0);
+    SecurityReview secondReview = new SecurityReview(new Date(2), 1.0);
     SecurityReviews securityReviews = new SecurityReviews(firstReview, secondReview);
 
     SecurityReviews clone = Json.read(Json.toBytes(securityReviews), SecurityReviews.class);

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewsValueTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/value/SecurityReviewsValueTest.java
@@ -13,8 +13,8 @@ public class SecurityReviewsValueTest {
 
   @Test
   public void testJsonSerialization() throws IOException {
-    SecurityReview firstReview = new SecurityReview(new Date(1));
-    SecurityReview secondReview = new SecurityReview(new Date(2));
+    SecurityReview firstReview = new SecurityReview(new Date(1), 0.0);
+    SecurityReview secondReview = new SecurityReview(new Date(2), 1.0);
     SecurityReviews reviews = new SecurityReviews(firstReview, secondReview);
     SecurityReviewsFeature feature = new SecurityReviewsFeature("feature");
     SecurityReviewsValue value = new SecurityReviewsValue(feature, reviews);

--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatterTest.java
@@ -102,7 +102,7 @@ public class OssSecurityRatingMarkdownFormatterTest {
       OWASP_DEPENDENCY_CHECK_USAGE.value(NOT_USED),
       OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD.notSpecifiedValue(),
       PACKAGE_MANAGERS.value(new PackageManagers(MAVEN)),
-      SECURITY_REVIEWS.value(new SecurityReviews(new SecurityReview(new Date())))
+      SECURITY_REVIEWS.value(new SecurityReviews(new SecurityReview(new Date(), 0.0)))
   );
 
   @Test


### PR DESCRIPTION
Here are main updates:

- Updated `SecurityReview` to hold info about amount of changes in the project since the review was done.
- Updated `SecurityReviewsFromOpenSSF` provider to calculate amount of changes in the project since a specific date.
- Updated `SecurityReviewScore` to take into account amount of changes in the project since the review was done.

Closes #586