### PR TITLE
RoP: Follow symbolic links for REUSE licenses

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UseReuseDataProvider.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UseReuseDataProvider.java
@@ -7,7 +7,6 @@ import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.REGIST
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.USES_REUSE;
 import static com.sap.oss.phosphor.fosstars.model.other.Utils.setOf;
 import static java.lang.String.format;
-import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sap.oss.phosphor.fosstars.model.Feature;
@@ -220,7 +219,7 @@ public class UseReuseDataProvider extends GitHubCachingDataProvider {
    * @return True if the path is a regular file, false otherwise.
    */
   private static boolean isFile(Path path) {
-    return Files.isRegularFile(path, NOFOLLOW_LINKS) && !Files.isSymbolicLink(path);
+    return Files.isRegularFile(path);
   }
 
   /**


### PR DESCRIPTION
This one fixes #639 (without explicit test, but that might be really hard to achieve). However, you probably had your reasons why you explicitly disabled following symlinks in the original commit. So in case you have certain reasons in mind to keep it this way, I'm open to a chat about it. :)