### PR TITLE
Use number of dependents in the project popularity score

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <version.dependency-check-core>6.2.2</version.dependency-check-core>
     <version.slf4j-simple>1.7.32</version.slf4j-simple>
     <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
+    <version.jsoup>1.14.1</version.jsoup>
   </properties>
 
   <build>
@@ -359,6 +360,11 @@
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>${version.javax.annotation-api}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>${version.jsoup}</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/DataProviderSelector.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/DataProviderSelector.java
@@ -19,6 +19,7 @@ import com.sap.oss.phosphor.fosstars.data.github.LgtmDataProvider;
 import com.sap.oss.phosphor.fosstars.data.github.LicenseInfo;
 import com.sap.oss.phosphor.fosstars.data.github.NumberOfCommits;
 import com.sap.oss.phosphor.fosstars.data.github.NumberOfContributors;
+import com.sap.oss.phosphor.fosstars.data.github.NumberOfDependentProjectOnGitHub;
 import com.sap.oss.phosphor.fosstars.data.github.NumberOfStars;
 import com.sap.oss.phosphor.fosstars.data.github.NumberOfWatchers;
 import com.sap.oss.phosphor.fosstars.data.github.OwaspSecurityLibraries;
@@ -107,6 +108,7 @@ public class DataProviderSelector {
         new ContributingGuidelineInfo(fetcher),
         new VulnerabilityAlertsInfo(fetcher),
         new SecurityReviewsFromOpenSSF(fetcher),
+        new NumberOfDependentProjectOnGitHub(fetcher),
 
         // currently interactive data provider have to be added to the end, see issue #133
         new AskAboutSecurityTeam(),

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/NumberOfDependentProjectOnGitHub.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/NumberOfDependentProjectOnGitHub.java
@@ -1,0 +1,107 @@
+package com.sap.oss.phosphor.fosstars.data.github;
+
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB;
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
+import com.sap.oss.phosphor.fosstars.model.Feature;
+import com.sap.oss.phosphor.fosstars.model.Value;
+import com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures;
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import java.io.IOException;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+
+/**
+ * This data provider looks for a number of projects that use a specified project on GitHub.
+ * It fills out the {@link OssFeatures#NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB} feature.
+ */
+public class NumberOfDependentProjectOnGitHub
+    extends CachedSingleFeatureGitHubDataProvider<Integer> {
+
+  /**
+   * Initializes a data provider.
+   *
+   * @param fetcher An interface to GitHub.
+   * @throws IOException If something went wrong.
+   */
+  public NumberOfDependentProjectOnGitHub(GitHubDataFetcher fetcher) throws IOException {
+    super(fetcher);
+  }
+
+  @Override
+  protected Feature<Integer> supportedFeature() {
+    return NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB;
+  }
+
+  @Override
+  protected Value<Integer> fetchValueFor(GitHubProject project) throws IOException {
+    logger.info("Figuring out how many projects on GitHub uses this project ...");
+
+    Element page = loadFrontPageOf(project);
+    for (Element link : page.getElementsByTag("a")) {
+      if (!link.hasAttr("href") || !link.attr("href").contains("/network/dependents")) {
+        continue;
+      }
+
+      for (Element span : link.getElementsByTag("span")) {
+        if (span.hasAttr("title")) {
+          try {
+            return NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(numberFrom(span.attr("title")));
+          } catch (NumberFormatException e) {
+            // no luck
+          }
+        }
+
+        try {
+          return NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(numberFrom(span.text()));
+        } catch (NumberFormatException e) {
+          // no luck
+        }
+      }
+    }
+
+    return NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.unknown();
+  }
+
+  /**
+   * Load a front page of a project on GitHub.
+   *
+   * @param project The project.
+   * @return A front page of the project.
+   * @throws IOException If the front page could not be loaded.
+   */
+  Element loadFrontPageOf(GitHubProject project) throws IOException {
+    String url = format("https://github.com/%s/%s", project.organization().name(), project.name());
+    return Jsoup.connect(url).get();
+  }
+
+  /**
+   * Try to extract an integer from a string.
+   *
+   * @param s The string.
+   * @return An integer.
+   * @throws NumberFormatException If the string doesn't have an integer.
+   */
+  static int numberFrom(String s) throws NumberFormatException {
+    return Integer.parseInt(s.replaceAll("[,+\\s+]", EMPTY));
+  }
+
+  /**
+   * This is for testing and demo purposes.
+   *
+   * @param args Command-line options (option 1: API token, option 2: project URL).
+   * @throws Exception If something went wrong.
+   */
+  public static void main(String... args) throws Exception {
+    String token = args.length > 0 ? args[0] : "";
+    String url = args.length > 1 ? args[1] : "https://github.com/FasterXML/jackson-databind";
+    GitHubProject project = GitHubProject.parse(url);
+    GitHub github = new GitHubBuilder().withOAuthToken(token).build();
+    NumberOfDependentProjectOnGitHub provider
+        = new NumberOfDependentProjectOnGitHub(new GitHubDataFetcher(github, token));
+    System.out.println(provider.fetchValueFor(project));
+  }
+}

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/oss/OssFeatures.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/feature/oss/OssFeatures.java
@@ -432,4 +432,10 @@ public class OssFeatures {
    */
   public static final SecurityReviewsFeature SECURITY_REVIEWS
       = new SecurityReviewsFeature("Security reviews for a project");
+
+  /**
+   * Shows how many projects use a project on GitHub.
+   */
+  public static final PositiveIntegerFeature NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB
+      = new PositiveIntegerFeature("Number of projects on GitHub that use an open source project");
 }

--- a/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectPopularityScore.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectPopularityScore.java
@@ -1,24 +1,21 @@
 package com.sap.oss.phosphor.fosstars.model.score.oss;
 
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_WATCHERS_ON_GITHUB;
 import static com.sap.oss.phosphor.fosstars.model.other.Utils.findValue;
 
 import com.sap.oss.phosphor.fosstars.model.Value;
-import com.sap.oss.phosphor.fosstars.model.math.MathHelper;
 import com.sap.oss.phosphor.fosstars.model.score.FeatureBasedScore;
 import com.sap.oss.phosphor.fosstars.model.value.ScoreValue;
-import java.util.function.Function;
 
 /**
  * <p>The project popularity score is currently based on two features.</p>
  * <ul>
  *   <li>Number of stars on GitHub</li>
  *   <li>Number of watchers on GitHub</li>
+ *   <li>Number of projects that use the project</li>
  * </ul>
- * <p>First, it calculates a stars sub-score. Next, it calculates a watchers sub-score.
- * It uses linear functions to transform the numbers to sub-scores.
- * Then, the sub-scores are added to each other.</p>
  */
 public class ProjectPopularityScore extends FeatureBasedScore {
 
@@ -28,113 +25,66 @@ public class ProjectPopularityScore extends FeatureBasedScore {
   private static final int BEST_STARS_AMOUNT = 10000;
 
   /**
-   * Defines the linear growth for the stars sub-score
-   * in case a number of stars is less than bestStarsAmount.
-   */
-  private static final double STARS_SCORE_FACTOR = MAX / BEST_STARS_AMOUNT;
-
-  /**
    * If a number of watchers is more than this value, then the maximum score is returned.
    */
   private static final int BEST_WATCHERS_AMOUNT = 3000;
 
   /**
-   * Defines the linear growth for the watchers sub-score
-   * in case a number of watchers is less than bestWatchersAmount.
+   * If a number of dependents is more than this value, then the maximum score is returned.
    */
-  private static final double WATCHERS_SCORE_FACTOR = MAX / BEST_WATCHERS_AMOUNT;
+  private static final int BEST_DEPENDENTS_AMOUNT = 15000;
 
   /**
    * A description of the score.
    */
-  private static final String DESCRIPTION;
-
-  static {
-    StringBuilder sb = new StringBuilder();
-
-    sb.append("The score is based on number of stars and watchers.\n");
-
-    Function<Integer, Double> starsSubScore = n -> starsSubScore(NUMBER_OF_GITHUB_STARS.value(n));
-    sb.append("Here is how a number of stars contributes to the score:\n");
-    sb.append(String.format("%d -> %2.2f (min), ", 0, starsSubScore.apply(0)));
-    sb.append(String.format("%d -> %2.2f, %d -> %2.2f, ",
-        MathHelper.invert(starsSubScore, 0, BEST_STARS_AMOUNT, 2.5, 0.01), 2.5,
-        MathHelper.invert(starsSubScore, 0, BEST_STARS_AMOUNT, 5.0, 0.01), 5.0));
-    sb.append(String.format("%d -> %2.2f (max)",
-        BEST_STARS_AMOUNT, starsSubScore.apply(BEST_STARS_AMOUNT)));
-    sb.append("\n");
-
-    Function<Integer, Double> watchersSubScore
-        = n -> watchersSubScore(NUMBER_OF_WATCHERS_ON_GITHUB.value(n));
-    sb.append("Here is how a number of watchers contributes to the score:\n");
-    sb.append(String.format("%d -> %2.2f (min), ",
-        0, watchersSubScore.apply(0)));
-    sb.append(String.format("%d -> %2.2f, %d -> %2.2f, ",
-        MathHelper.invert(watchersSubScore, 0, BEST_WATCHERS_AMOUNT, 1.5, 0.01), 1.5,
-        MathHelper.invert(watchersSubScore, 0, BEST_WATCHERS_AMOUNT, 2.5, 0.01), 2.5));
-    sb.append(String.format("%d -> %2.2f (max)",
-        BEST_WATCHERS_AMOUNT, watchersSubScore.apply(BEST_WATCHERS_AMOUNT)));
-
-    DESCRIPTION = sb.toString();
-  }
+  private static final String DESCRIPTION
+      = "This scoring function is based on number of stars, watchers and dependent projects.";
 
   /**
    * Initializes a new score.
    */
   ProjectPopularityScore() {
     super("Open-source project popularity score", DESCRIPTION,
-        NUMBER_OF_GITHUB_STARS, NUMBER_OF_WATCHERS_ON_GITHUB);
+        NUMBER_OF_GITHUB_STARS,
+        NUMBER_OF_WATCHERS_ON_GITHUB,
+        NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB);
   }
 
   @Override
   public ScoreValue calculate(Value<?>... values) {
-    Value<Integer> n = findValue(values, NUMBER_OF_GITHUB_STARS,
+    Value<Integer> stars = findValue(values, NUMBER_OF_GITHUB_STARS,
         "Hey! You have to give me a number of stars!");
-    Value<Integer> m = findValue(values, NUMBER_OF_WATCHERS_ON_GITHUB,
+    Value<Integer> watchers = findValue(values, NUMBER_OF_WATCHERS_ON_GITHUB,
         "Hey! You have to give me a number of watchers!");
+    Value<Integer> dependents = findValue(values, NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB,
+        "Hey! You have to give me a number of dependents!");
 
-    return scoreValue(starsSubScore(n) + watchersSubScore(m), n, m);
+    return scoreValue(MIN, stars, watchers, dependents)
+        .increase(subScoreFor(stars, BEST_STARS_AMOUNT))
+        .increase(subScoreFor(watchers, BEST_WATCHERS_AMOUNT))
+        .increase(subScoreFor(dependents, BEST_DEPENDENTS_AMOUNT));
   }
 
   /**
-   * Calculates a stars sub-score.
+   * Calculates a sub-score for a value.
    *
-   * @param stars A number of stars.
-   * @throws IllegalArgumentException if a number of stars is negative.
+   * @param value A number of stars.
+   * @param threshold If the value is greater than the threshold,
+   *                  then the max score value is returned.
+   * @throws IllegalArgumentException If the value is negative.
    */
-  private static double starsSubScore(Value<Integer> stars) {
-    if (stars.isUnknown()) {
-      return 0.0;
+  private static double subScoreFor(Value<Integer> value, int threshold) {
+    if (value.isUnknown()) {
+      return MIN;
     }
-    int n = stars.get();
+
+    int n = value.get();
     if (n < 0) {
-      throw new IllegalArgumentException("Number of stars is negative! How can it be possible?");
+      throw new IllegalArgumentException("Oops! Expected a non-negative value!");
     }
 
-    if (n < BEST_STARS_AMOUNT) {
-      return STARS_SCORE_FACTOR * n;
-    }
-
-    return MAX;
-  }
-
-  /**
-   * Calculates a watchers sub-score.
-   *
-   * @param watchers A number of watchers.
-   * @throws IllegalArgumentException if a number of watchers is negative.
-   */
-  private static double watchersSubScore(Value<Integer> watchers) {
-    if (watchers.isUnknown()) {
-      return 0.0;
-    }
-    int m = watchers.get();
-    if (m < 0) {
-      throw new IllegalArgumentException("Number of watchers is negative! How can it be possible?");
-    }
-
-    if (m < BEST_WATCHERS_AMOUNT) {
-      return WATCHERS_SCORE_FACTOR * m;
+    if (n < threshold) {
+      return MAX * n / threshold;
     }
 
     return MAX;

--- a/src/main/jupyter/oss/security/SecurityRatingAnalysis.ipynb
+++ b/src/main/jupyter/oss/security/SecurityRatingAnalysis.ipynb
@@ -4390,7 +4390,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/src/main/jupyter/oss/security/SecurityRatingAnalysis.ipynb
+++ b/src/main/jupyter/oss/security/SecurityRatingAnalysis.ipynb
@@ -4390,7 +4390,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/src/test/java/com/sap/oss/phosphor/fosstars/TestUtils.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/TestUtils.java
@@ -10,6 +10,7 @@ import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.IS_ECL
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_COMMITS_LAST_THREE_MONTHS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_WATCHERS_ON_GITHUB;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD;
@@ -176,6 +177,7 @@ public class TestUtils {
         NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS.value(3),
         NUMBER_OF_GITHUB_STARS.value(10),
         NUMBER_OF_WATCHERS_ON_GITHUB.value(5),
+        NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(10),
         HAS_SECURITY_TEAM.value(false),
         HAS_SECURITY_POLICY.value(false),
         HAS_BUG_BOUNTY_PROGRAM.value(false),
@@ -226,6 +228,7 @@ public class TestUtils {
         NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS.value(30),
         NUMBER_OF_GITHUB_STARS.value(100000),
         NUMBER_OF_WATCHERS_ON_GITHUB.value(50),
+        NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(50000),
         HAS_SECURITY_TEAM.value(true),
         HAS_SECURITY_POLICY.value(true),
         HAS_BUG_BOUNTY_PROGRAM.value(true),

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/NumberOfDependentProjectOnGitHubTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/NumberOfDependentProjectOnGitHubTest.java
@@ -1,0 +1,95 @@
+package com.sap.oss.phosphor.fosstars.data.github;
+
+import static com.sap.oss.phosphor.fosstars.TestUtils.PROJECT;
+import static com.sap.oss.phosphor.fosstars.data.github.NumberOfDependentProjectOnGitHub.numberFrom;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.sap.oss.phosphor.fosstars.model.Value;
+import com.sap.oss.phosphor.fosstars.model.subject.oss.GitHubProject;
+import java.io.IOException;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+import org.junit.Test;
+
+public class NumberOfDependentProjectOnGitHubTest extends TestGitHubDataFetcherHolder {
+
+  private static class TestProvider extends NumberOfDependentProjectOnGitHub {
+
+    private String content;
+
+    public TestProvider(GitHubDataFetcher fetcher) throws IOException {
+      super(fetcher);
+    }
+
+    void set(String content) {
+      this.content = content;
+    }
+
+    @Override
+    Element loadFrontPageOf(GitHubProject project) {
+      return Jsoup.parse(content);
+    }
+  }
+
+  @Test
+  public void testSupportedFeature() throws IOException {
+    assertEquals(
+        NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB,
+        new NumberOfDependentProjectOnGitHub(fetcher).supportedFeature());
+  }
+
+  @Test
+  public void testNumberFrom() {
+    assertEquals(123, numberFrom("123"));
+    assertEquals(1234567, numberFrom("1,234,567"));
+    assertEquals(1234567, numberFrom("+ 1,234,567"));
+    assertThrows(NumberFormatException.class, () -> numberFrom(""));
+    assertThrows(NumberFormatException.class, () -> numberFrom("wrong"));
+  }
+
+  @Test
+  public void testFetchValueFor() throws IOException {
+    TestProvider provider = new TestProvider(fetcher);
+
+    provider.set("<a href=\"/not/interesting\"><span title=\"42\"/></a>");
+    Value<Integer> value = provider.fetchValueFor(PROJECT);
+    assertTrue(value.isUnknown());
+
+    provider.set(
+        "<a href=\"/test/project/network/dependents?package_id=xyz\">nothing</a>");
+    value = provider.fetchValueFor(PROJECT);
+    assertTrue(value.isUnknown());
+
+    provider.set(
+        "<h2 class=\"h4 mb-3\">\n"
+            + "<a href=\"/test/project/network/dependents?package_id=xyz\" "
+            + "data-view-component=\"true\" class=\"Link--primary no-underline\">\n"
+            + "Used by "
+            + "<span title=\"423,038\" data-view-component=\"true\" class=\"Counter\">423k</span>\n"
+            + "</a>"
+            + "</h2>");
+    value = provider.fetchValueFor(PROJECT);
+    assertFalse(value.isUnknown());
+    assertEquals(423038, (int) value.get());
+
+    provider.set(
+        "<a class=\"d-flex flex-items-center\" "
+            + "href=\"/test/project/network/dependents?package_id=xyz\">\n"
+            + "<ul class=\"hx_flex-avatar-stack list-style-none min-width-0\">\n"
+            + "  <li class=\"hx_flex-avatar-stack-item\">\n"
+            + "    <img class=\"avatar avatar-user\" height=\"32\" width=\"32\" />\n"
+            + "  </li>\n"
+            + "</ul>\n"
+            + "<span class=\"px-2 text-bold text-small no-wrap\">\n"
+            + "  + 423,030\n"
+            + "</span>\n"
+            + "</a>");
+    value = provider.fetchValueFor(PROJECT);
+    assertFalse(value.isUnknown());
+    assertEquals(423030, (int) value.get());
+  }
+}

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/OssSecurityScoreTest.java
@@ -9,6 +9,7 @@ import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.IS_ECL
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_COMMITS_LAST_THREE_MONTHS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_WATCHERS_ON_GITHUB;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD;
@@ -93,6 +94,7 @@ public class OssSecurityScoreTest {
         NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS.value(3),
         NUMBER_OF_GITHUB_STARS.value(10),
         NUMBER_OF_WATCHERS_ON_GITHUB.value(5),
+        NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(20),
         HAS_SECURITY_TEAM.value(false),
         HAS_SECURITY_POLICY.value(false),
         HAS_BUG_BOUNTY_PROGRAM.value(false),

--- a/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectPopularityScoreTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectPopularityScoreTest.java
@@ -1,6 +1,8 @@
 package com.sap.oss.phosphor.fosstars.model.score.oss;
 
 import static com.sap.oss.phosphor.fosstars.TestUtils.assertScore;
+import static com.sap.oss.phosphor.fosstars.model.Score.MAX;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_WATCHERS_ON_GITHUB;
 import static com.sap.oss.phosphor.fosstars.model.other.Utils.setOf;
@@ -16,28 +18,35 @@ import org.junit.Test;
 public class ProjectPopularityScoreTest {
 
   private static final ProjectPopularityScore PROJECT_POPULARITY = new ProjectPopularityScore();
-  private static final double delta = 0.001;
 
   @Test(expected = IllegalArgumentException.class)
   public void negativeStars() {
     PROJECT_POPULARITY.calculate(
-        NUMBER_OF_GITHUB_STARS.value(-1), NUMBER_OF_WATCHERS_ON_GITHUB.value(1));
+        NUMBER_OF_GITHUB_STARS.value(-1),
+        NUMBER_OF_WATCHERS_ON_GITHUB.value(1),
+        NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(10));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void negativeWatchers() {
     PROJECT_POPULARITY.calculate(
-        NUMBER_OF_GITHUB_STARS.value(1), NUMBER_OF_WATCHERS_ON_GITHUB.value(-1));
+        NUMBER_OF_GITHUB_STARS.value(1),
+        NUMBER_OF_WATCHERS_ON_GITHUB.value(-1),
+        NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(10));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void noStars() {
-    PROJECT_POPULARITY.calculate(NUMBER_OF_WATCHERS_ON_GITHUB.value(1));
+    PROJECT_POPULARITY.calculate(
+        NUMBER_OF_WATCHERS_ON_GITHUB.value(1),
+        NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(10));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void noWatchers() {
-    PROJECT_POPULARITY.calculate(NUMBER_OF_GITHUB_STARS.value(1));
+    PROJECT_POPULARITY.calculate(
+        NUMBER_OF_GITHUB_STARS.value(1),
+        NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(10));
   }
 
   @Test
@@ -45,51 +54,54 @@ public class ProjectPopularityScoreTest {
     assertScore(Score.MIN,
         PROJECT_POPULARITY, setOf(
             UnknownValue.of(NUMBER_OF_GITHUB_STARS),
-            UnknownValue.of(NUMBER_OF_WATCHERS_ON_GITHUB)));
+            UnknownValue.of(NUMBER_OF_WATCHERS_ON_GITHUB),
+            UnknownValue.of(NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB)));
 
     assertScore(Score.MIN,
         PROJECT_POPULARITY, setOf(
             NUMBER_OF_GITHUB_STARS.value(0),
-            NUMBER_OF_WATCHERS_ON_GITHUB.value(0)));
+            NUMBER_OF_WATCHERS_ON_GITHUB.value(0),
+            NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(0)));
 
-    assertScore(Score.MAX,
+    assertScore(MAX,
         PROJECT_POPULARITY, setOf(
             NUMBER_OF_GITHUB_STARS.value(Integer.MAX_VALUE),
-            NUMBER_OF_WATCHERS_ON_GITHUB.value(Integer.MAX_VALUE)));
+            NUMBER_OF_WATCHERS_ON_GITHUB.value(Integer.MAX_VALUE),
+            NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(Integer.MAX_VALUE)));
 
     // no watchers
-    assertScore(0.001, PROJECT_POPULARITY, values(1, 0));
-    assertScore(0.010, PROJECT_POPULARITY, values(10, 0));
-    assertScore(0.100, PROJECT_POPULARITY, values(100, 0));
-    assertScore(1.000, PROJECT_POPULARITY, values(1000, 0));
-    assertScore(5.000, PROJECT_POPULARITY, values(5000, 0));
-    assertScore(Score.MAX, PROJECT_POPULARITY, values(10000, 0));
-    assertScore(Score.MAX, PROJECT_POPULARITY, values(15000, 0));
+    assertScore(0.03, PROJECT_POPULARITY, values(1, 0, 50));
+    assertScore(0.04, PROJECT_POPULARITY, values(10, 0, 50));
+    assertScore(0.13, PROJECT_POPULARITY, values(100, 0, 50));
+    assertScore(1.03, PROJECT_POPULARITY, values(1000, 0, 50));
+    assertScore(5.03, PROJECT_POPULARITY, values(5000, 0, 50));
+    assertScore(MAX, PROJECT_POPULARITY, values(10000, 0, 50));
+    assertScore(MAX, PROJECT_POPULARITY, values(15000, 0, 50));
 
     // no stars
-    assertScore(0.003, PROJECT_POPULARITY, values(0, 1));
-    assertScore(0.033, PROJECT_POPULARITY, values(0, 10));
-    assertScore(0.333, PROJECT_POPULARITY, values(0, 100));
-    assertScore(3.333, PROJECT_POPULARITY, values(0, 1000));
-    assertScore(6.666, PROJECT_POPULARITY, values(0, 2000));
-    assertScore(8.333, PROJECT_POPULARITY, values(0, 2500));
-    assertScore(Score.MAX, PROJECT_POPULARITY, values(0, 3000));
-    assertScore(Score.MAX, PROJECT_POPULARITY, values(0, 5000));
+    assertScore(0.003, PROJECT_POPULARITY, values(0, 1, 10));
+    assertScore(0.033, PROJECT_POPULARITY, values(0, 10, 10));
+    assertScore(0.333, PROJECT_POPULARITY, values(0, 100, 10));
+    assertScore(3.333, PROJECT_POPULARITY, values(0, 1000, 10));
+    assertScore(6.666, PROJECT_POPULARITY, values(0, 2000, 10));
+    assertScore(8.333, PROJECT_POPULARITY, values(0, 2500, 10));
+    assertScore(MAX, PROJECT_POPULARITY, values(0, 3000, 10));
+    assertScore(MAX, PROJECT_POPULARITY, values(0, 5000, 10));
 
-    // both stars and watchers
-    assertScore(0.133, PROJECT_POPULARITY, values(100, 10));
-    assertScore(1.100, PROJECT_POPULARITY, values(100, 300));
-    assertScore(2.666, PROJECT_POPULARITY, values(2000, 200));
-    assertScore(3.833, PROJECT_POPULARITY, values(500, 1000));
-    assertScore(4.000, PROJECT_POPULARITY, values(3000, 300));
-    assertScore(4.333, PROJECT_POPULARITY, values(1000, 1000));
-    assertScore(4.333, PROJECT_POPULARITY, values(1000, 1000));
-    assertScore(6.000, PROJECT_POPULARITY, values(5000, 300));
-    assertScore(6.000, PROJECT_POPULARITY, values(1000, 1500));
-    assertScore(8.333, PROJECT_POPULARITY, values(5000, 1000));
-    assertScore(8.666, PROJECT_POPULARITY, values(2000, 2000));
-    assertScore(Score.MAX, PROJECT_POPULARITY, values(5000, 4000));
-    assertScore(Score.MAX, PROJECT_POPULARITY, values(11000, 1000));
+    // a project have stars, watchers and dependents
+    assertScore(0.13, PROJECT_POPULARITY, values(100, 10, 10));
+    assertScore(1.12, PROJECT_POPULARITY, values(100, 300, 30));
+    assertScore(2.80, PROJECT_POPULARITY, values(2000, 200, 200));
+    assertScore(4.16, PROJECT_POPULARITY, values(500, 1000, 500));
+    assertScore(4.33, PROJECT_POPULARITY, values(3000, 300, 500));
+    assertScore(5.66, PROJECT_POPULARITY, values(1000, 1000, 2000));
+    assertScore(6.33, PROJECT_POPULARITY, values(1000, 1000, 3000));
+    assertScore(8.66, PROJECT_POPULARITY, values(1000, 1500, 4000));
+    assertScore(MAX, PROJECT_POPULARITY, values(5000, 300, 7000));
+    assertScore(MAX, PROJECT_POPULARITY, values(5000, 1000, 6000));
+    assertScore(MAX, PROJECT_POPULARITY, values(2000, 2000, 5000));
+    assertScore(MAX, PROJECT_POPULARITY, values(5000, 4000, 10000));
+    assertScore(MAX, PROJECT_POPULARITY, values(11000, 1000, 10000));
   }
 
   @Test
@@ -98,9 +110,10 @@ public class ProjectPopularityScoreTest {
     assertFalse(PROJECT_POPULARITY.description().isEmpty());
   }
 
-  private static Set<Value<?>> values(int stars, int watchers) {
+  private static Set<Value<?>> values(int stars, int watchers, int dependents) {
     return setOf(
         NUMBER_OF_GITHUB_STARS.value(stars),
-        NUMBER_OF_WATCHERS_ON_GITHUB.value(watchers));
+        NUMBER_OF_WATCHERS_ON_GITHUB.value(watchers),
+        NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(dependents));
   }
 }

--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/OssSecurityRatingMarkdownFormatterTest.java
@@ -10,6 +10,7 @@ import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.IS_ECL
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_COMMITS_LAST_THREE_MONTHS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_WATCHERS_ON_GITHUB;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD;
@@ -75,6 +76,7 @@ public class OssSecurityRatingMarkdownFormatterTest {
       NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS.value(3),
       NUMBER_OF_GITHUB_STARS.value(10),
       NUMBER_OF_WATCHERS_ON_GITHUB.value(5),
+      NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(50),
       HAS_SECURITY_TEAM.value(false),
       HAS_SECURITY_POLICY.value(false),
       HAS_BUG_BOUNTY_PROGRAM.value(false),

--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/format/PrettyPrinterTest.java
@@ -10,6 +10,7 @@ import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.IS_ECL
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.LANGUAGES;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_COMMITS_LAST_THREE_MONTHS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS;
+import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_GITHUB_STARS;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.NUMBER_OF_WATCHERS_ON_GITHUB;
 import static com.sap.oss.phosphor.fosstars.model.feature.oss.OssFeatures.OWASP_DEPENDENCY_CHECK_FAIL_CVSS_THRESHOLD;
@@ -75,6 +76,7 @@ public class PrettyPrinterTest {
       IS_ECLIPSE.value(false),
       NUMBER_OF_COMMITS_LAST_THREE_MONTHS.value(50),
       NUMBER_OF_CONTRIBUTORS_LAST_THREE_MONTHS.value(3),
+      NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB.value(42),
       NUMBER_OF_GITHUB_STARS.value(10),
       NUMBER_OF_WATCHERS_ON_GITHUB.value(5),
       HAS_SECURITY_TEAM.value(false),

--- a/src/test/resources/com/sap/oss/phosphor/fosstars/model/rating/oss/OssArtifactSecurityRatingTestVectors.yml
+++ b/src/test/resources/com/sap/oss/phosphor/fosstars/model/rating/oss/OssArtifactSecurityRatingTestVectors.yml
@@ -196,6 +196,11 @@ defaults:
       type: "SecurityReviewsFeature"
       name: "Security reviews for a project"
     reviews: []
+  - type: "IntegerValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of projects on GitHub that use an open source project"
+    number: 5
 
 # test vectors
 elements:
@@ -269,6 +274,10 @@ elements:
         feature:
           type: "PositiveIntegerFeature"
           name: "Number of commits in the last three months"
+      - type: "UnknownValue"
+        feature:
+          type: "PositiveIntegerFeature"
+          name: "Number of projects on GitHub that use an open source project"
       - type: "UnknownValue"
         feature:
           type: "BooleanFeature"

--- a/src/test/resources/com/sap/oss/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
+++ b/src/test/resources/com/sap/oss/phosphor/fosstars/model/rating/oss/OssSecurityRatingTestVectors.yml
@@ -102,6 +102,11 @@ defaults:
     type: "SecurityReviewsFeature"
     name: "Security reviews for a project"
   reviews: []
+- type: "IntegerValue"
+  feature:
+    type: "PositiveIntegerFeature"
+    name: "Number of projects on GitHub that use an open source project"
+  number: 5
 
 # test vectors
 elements:
@@ -151,6 +156,10 @@ elements:
     feature:
       type: "VulnerabilitiesInProject"
       name: "Info about vulnerabilities in open-source project"
+  - type: "UnknownValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of projects on GitHub that use an open source project"
   - type: "UnknownValue"
     feature:
       type: "PositiveIntegerFeature"

--- a/src/test/resources/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectPopularityScoreTestVectors.yml
+++ b/src/test/resources/com/sap/oss/phosphor/fosstars/model/score/oss/ProjectPopularityScoreTestVectors.yml
@@ -11,6 +11,10 @@ elements:
     feature:
       type: "PositiveIntegerFeature"
       name: "Number of watchers for a GitHub repository"
+  - type: "UnknownValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of projects on GitHub that use an open source project"
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -32,6 +36,11 @@ elements:
     feature:
       type: "PositiveIntegerFeature"
       name: "Number of watchers for a GitHub repository"
+    number: 0
+  - type: "IntegerValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of projects on GitHub that use an open source project"
     number: 0
   expectedScore:
     type: "DoubleInterval"
@@ -55,6 +64,11 @@ elements:
       type: "PositiveIntegerFeature"
       name: "Number of watchers for a GitHub repository"
     number: 0
+  - type: "IntegerValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of projects on GitHub that use an open source project"
+    number: 100
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -77,6 +91,11 @@ elements:
       type: "PositiveIntegerFeature"
       name: "Number of watchers for a GitHub repository"
     number: 0
+  - type: "IntegerValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of projects on GitHub that use an open source project"
+    number: 1000
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -99,6 +118,11 @@ elements:
       type: "PositiveIntegerFeature"
       name: "Number of watchers for a GitHub repository"
     number: 0
+  - type: "IntegerValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of projects on GitHub that use an open source project"
+    number: 50
   expectedScore:
     type: "DoubleInterval"
     from: 1.0
@@ -121,6 +145,11 @@ elements:
       type: "PositiveIntegerFeature"
       name: "Number of stars for a GitHub repository"
     number: 10
+  - type: "IntegerValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of projects on GitHub that use an open source project"
+    number: 15
   expectedScore:
     type: "DoubleInterval"
     from: 0.0
@@ -143,12 +172,17 @@ elements:
       type: "PositiveIntegerFeature"
       name: "Number of watchers for a GitHub repository"
     number: 10
+  - type: "IntegerValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of projects on GitHub that use an open source project"
+    number: 800
   expectedScore:
     type: "DoubleInterval"
-    from: 0.0
+    from: 0.5
     openLeft: false
     negativeInfinity: false
-    to: 2.0
+    to: 1.5
     openRight: false
     positiveInfinity: false
   expectedLabel: null
@@ -165,12 +199,17 @@ elements:
       type: "PositiveIntegerFeature"
       name: "Number of stars for a GitHub repository"
     number: 1000
+  - type: "IntegerValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of projects on GitHub that use an open source project"
+    number: 5400
   expectedScore:
     type: "DoubleInterval"
-    from: 1.0
+    from: 4.5
     openLeft: false
     negativeInfinity: false
-    to: 2.0
+    to: 5.0
     openRight: false
     positiveInfinity: false
   expectedLabel: null
@@ -187,9 +226,14 @@ elements:
       type: "PositiveIntegerFeature"
       name: "Number of stars for a GitHub repository"
     number: 5000
+  - type: "IntegerValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of projects on GitHub that use an open source project"
+    number: 100
   expectedScore:
     type: "DoubleInterval"
-    from: 4.0
+    from: 5.0
     openLeft: false
     negativeInfinity: false
     to: 6.0
@@ -208,13 +252,18 @@ elements:
     feature:
       type: "PositiveIntegerFeature"
       name: "Number of stars for a GitHub repository"
-    number: 10000
+    number: 5000
+  - type: "IntegerValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of projects on GitHub that use an open source project"
+    number: 4000
   expectedScore:
     type: "DoubleInterval"
     from: 8.0
     openLeft: false
     negativeInfinity: false
-    to: 10.0
+    to: 9.0
     openRight: false
     positiveInfinity: false
   expectedLabel: null
@@ -231,6 +280,11 @@ elements:
       type: "PositiveIntegerFeature"
       name: "Number of stars for a GitHub repository"
     number: 20000
+  - type: "IntegerValue"
+    feature:
+      type: "PositiveIntegerFeature"
+      name: "Number of projects on GitHub that use an open source project"
+    number: 5000
   expectedScore:
     type: "DoubleInterval"
     from: 9.0


### PR DESCRIPTION
Here are main updates:

- Added `NUMBER_OF_DEPENDENT_PROJECTS_ON_GITHUB` feature.
- Added `NumberOfDependentProjectOnGitHub` provider.
- Updated the popularity score to use the new feature.
- Updated tests and test vectors.

Closes #630