### PR TITLE
GitHub issue creation: Use identifer only for existence check

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporter.java
@@ -91,7 +91,7 @@ public class OssRulesOfPlayGitHubIssuesReporter implements Reporter<GitHubProjec
       String issueHeader = printTitle(violation);
       List<GHIssue> existingGitHubIssues = fetcher.gitHubIssuesFor(project, issueHeader.substring(issueHeader.indexOf("["), issueHeader.indexOf("]") + 1));
       if (existingGitHubIssues.isEmpty()) {
-        fetcher.createGitHubIssue(project, printTitle(violation), printBody(violation));
+        fetcher.createGitHubIssue(project, issueHeader, printBody(violation));
         LOGGER.info("New issue: " + issueHeader);
       } else {
         LOGGER.info("Issue already exists: " + issueHeader);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporter.java
@@ -89,7 +89,8 @@ public class OssRulesOfPlayGitHubIssuesReporter implements Reporter<GitHubProjec
 
     for (Value<Boolean> violation : violations) {
       String issueHeader = printTitle(violation);
-      List<GHIssue> existingGitHubIssues = fetcher.gitHubIssuesFor(project, issueHeader.substring(issueHeader.indexOf("["), issueHeader.indexOf("]") + 1));
+      List<GHIssue> existingGitHubIssues = fetcher.gitHubIssuesFor(project,
+          issueHeader.substring(issueHeader.indexOf("["), issueHeader.indexOf("]") + 1));
       if (existingGitHubIssues.isEmpty()) {
         fetcher.createGitHubIssue(project, issueHeader, printBody(violation));
         LOGGER.info("New issue: " + issueHeader);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporter.java
@@ -89,7 +89,7 @@ public class OssRulesOfPlayGitHubIssuesReporter implements Reporter<GitHubProjec
 
     for (Value<Boolean> violation : violations) {
       String issueHeader = printTitle(violation);
-      List<GHIssue> existingGitHubIssues = fetcher.gitHubIssuesFor(project, issueHeader);
+      List<GHIssue> existingGitHubIssues = fetcher.gitHubIssuesFor(project, issueHeader.substring(issueHeader.indexOf("["), issueHeader.indexOf("]") + 1));
       if (existingGitHubIssues.isEmpty()) {
         fetcher.createGitHubIssue(project, printTitle(violation), printBody(violation));
         LOGGER.info("New issue: " + issueHeader);

--- a/src/main/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporter.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporter.java
@@ -89,8 +89,8 @@ public class OssRulesOfPlayGitHubIssuesReporter implements Reporter<GitHubProjec
 
     for (Value<Boolean> violation : violations) {
       String issueHeader = printTitle(violation);
-      List<GHIssue> existingGitHubIssues = fetcher.gitHubIssuesFor(project,
-          issueHeader.substring(issueHeader.indexOf("["), issueHeader.indexOf("]") + 1));
+      String withIssueTitle = formatter.identifierOf(violation.feature()).orElse(issueHeader);
+      List<GHIssue> existingGitHubIssues = fetcher.gitHubIssuesFor(project, withIssueTitle);
       if (existingGitHubIssues.isEmpty()) {
         fetcher.createGitHubIssue(project, issueHeader, printBody(violation));
         LOGGER.info("New issue: " + issueHeader);

--- a/src/test/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporterTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayGitHubIssuesReporterTest.java
@@ -118,6 +118,8 @@ public class OssRulesOfPlayGitHubIssuesReporterTest extends TestGitHubDataFetche
 
     reporter.createIssuesFor(project);
     verify(repository, times(1)).hasIssues();
+    verify(ghDataFetcher, times(1)).gitHubIssuesFor(project, "[rl-license_file-1]");
+    verify(ghDataFetcher, times(1)).gitHubIssuesFor(project, "[rl-readme_file-1]");
     verify(ghDataFetcher, times(2)).createGitHubIssue(any(), any(), any());
   }
 


### PR DESCRIPTION
Our regular RoP check runs lead to duplicate issues (see e.g. https://github.com/SAP/styleguides/issues/226 and https://github.com/SAP/styleguides/issues/207) because we don't seem to check the issue identifier only, but use the complete title. As the other issues might have the same ID, but different title texts, the detection fails. This PR fixes that.