### PR TITLE
RoP: Also search for lowercase READMEs

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/ReadmeInfo.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/ReadmeInfo.java
@@ -38,7 +38,8 @@ public class ReadmeInfo extends GitHubCachingDataProvider {
    * A list of known README file names.
    */
   private static final List<String> KNOWN_README_FILES
-      = Arrays.asList("README", "README.txt", "README.md", "README.rst");
+      = Arrays.asList("README", "README.txt", "README.md", "README.rst",
+          "readme", "readme.txt", "readme.md", "readme.rst");
 
   /**
    * A list of patterns that describe required content in README.

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/ReadmeInfoTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/ReadmeInfoTest.java
@@ -122,6 +122,25 @@ public class ReadmeInfoTest extends TestGitHubDataFetcherHolder {
   }
 
   @Test
+  public void testLowercaseReadme() throws IOException {
+    GitHubProject project = new GitHubProject("test", "project");
+
+    LocalRepository localRepository = mock(LocalRepository.class);
+    when(localRepository.hasFile("readme.md")).thenReturn(true);
+    TestGitHubDataFetcher.addForTesting(project, localRepository);
+
+    ReadmeInfo provider = new ReadmeInfo(fetcher);
+    provider.set(NoValueCache.create());
+
+    when(localRepository.readTextFrom("readme.md"))
+        .thenReturn(Optional.of(String.join("\n",
+            "This is readme.md"
+        )));
+    ValueSet values = provider.fetchValuesFor(project);
+    assertTrue(checkValue(values, HAS_README, true).get());
+  }
+
+  @Test
   public void testLoadingDefaultConfig() throws IOException {
     Path config = Paths.get(String.format("%s.config.yml", ReadmeInfo.class.getSimpleName()));
     String content = "---\n"


### PR DESCRIPTION
Fixes #681. 

However, still doesn't capture cases like 'ReadMe.md', but eventually we should migrate to [GitHub's Readme API](https://docs.github.com/en/rest/reference/repos#get-a-repository-readme) anyway. Let's see how it goes... ;)