### PR TITLE
Rules of Play: Add per-rule statistics to report

### DIFF
--- a/src/main/resources/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayMarkdownReporterTemplate.md
+++ b/src/main/resources/com/sap/oss/phosphor/fosstars/tool/report/OssRulesOfPlayMarkdownReporterTemplate.md
@@ -1,6 +1,6 @@
-# Open source rules of play
+# Open Source Rules of Play
 
-## Projects stats
+## Overall Statistics
 
 |                           | # or projects                    | % or projects                      |
 | :------------------------ | -------------------------------: | ---------------------------------: |
@@ -9,6 +9,9 @@
 | Passed with&nbsp;warnings |  %NUMBER_PROJECTS_WITH_WARNINGS% |  %PERCENT_PROJECTS_WITH_WARNINGS%% |
 | Passed                    |         %NUMBER_PASSED_PROJECTS% |         %PERCENT_PASSED_PROJECTS%% |
 | Unclear                   |        %NUMBER_UNCLEAR_PROJECTS% |        %PERCENT_UNCLEAR_PROJECTS%% |
+
+## Statistics per Rule
+%PER_RULE_STATISTICS%
 
 ## Projects
 


### PR DESCRIPTION
The current OSS rules of play report nicely displays global statistics over the number and percentage of compliant and non-compliant repositories. However, there is no information about the statistics for each single error category. That is added with this change.

This is how the new addition looks like:

### Project statistics for [rl-assigned_teams-5] (Does teams have enough members on GitHub?)

|   | # of projects | % of projects |
| -------  | :----- | :------------------ |
| Passed | 201 | 93.1% |
| Failed | 15 | 6.9% |

**Failed projects:**
- project1
- project2
- ...