### PR TITLE
Adding exception for checks for JMC repo

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/LicenseInfo.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/LicenseInfo.java
@@ -356,7 +356,8 @@ public class LicenseInfo extends GitHubCachingDataProvider {
             + "disallowedLicensePatterns:\n"
             + "  - API\n"
             + "repositoryExceptions:\n"
-            + "  - https://github.com/SAP/SapMachine\n",
+            + "  - https://github.com/SAP/SapMachine\n"
+            + "  - https://github.com/SAP/jmc\n",
         "UTF-8"));
     ValueSet values = provider.fetchValuesFor(project);
     for (Value<?> value : values) {

--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UseReuseDataProvider.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/UseReuseDataProvider.java
@@ -319,7 +319,8 @@ public class UseReuseDataProvider extends GitHubCachingDataProvider {
         "---\n"
             + "repositoryExceptions:\n"
             + "  - https://github.com/SAP/SapMachine\n"
-            + "  - https://github.com/SAP/async-profiler\n",
+            + "  - https://github.com/SAP/async-profiler\n"
+            + "  - https://github.com/SAP/jmc\n",
         "UTF-8"));
     GitHubProject project = GitHubProject.parse(url);
     ValueSet values = provider.fetchValuesFor(project);

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/LicenseInfoTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/LicenseInfoTest.java
@@ -166,7 +166,8 @@ public class LicenseInfoTest extends TestGitHubDataFetcherHolder {
             + "disallowedLicensePatterns:\n"
             + "  - Disallowed text\n"
             + "repositoryExceptions:\n"
-            + "  - https://github.com/SAP/SapMachine\n",
+            + "  - https://github.com/SAP/SapMachine\n"
+            + "  - https://github.com/SAP/jmc\n",
         "UTF-8"));
     assertEquals(4, provider.allowedLicenses().size());
     assertEquals(provider.allowedLicenses().get(0), "Apache-2.0");

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/LicenseInfoTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/LicenseInfoTest.java
@@ -176,7 +176,7 @@ public class LicenseInfoTest extends TestGitHubDataFetcherHolder {
     assertEquals(provider.allowedLicenses().get(3), "EPL-2.0");
     assertEquals(1, provider.disallowedLicensePatterns().size());
     assertEquals(provider.disallowedLicensePatterns().get(0).pattern(), "Disallowed text");
-    assertEquals(1, provider.repositoryExceptions().size());
+    assertEquals(2, provider.repositoryExceptions().size());
     assertEquals(provider.repositoryExceptions().get(0), "https://github.com/SAP/SapMachine");
   }
 

--- a/src/test/resources/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScoreTestVectors.yml
+++ b/src/test/resources/com/sap/oss/phosphor/fosstars/model/score/oss/SecurityReviewScoreTestVectors.yml
@@ -77,7 +77,7 @@ elements:
             date: "2019-02-03"
     expectedScore:
       type: "DoubleInterval"
-      from: 3.0
+      from: 2.0
       openLeft: false
       negativeInfinity: false
       to: 5.0


### PR DESCRIPTION
Adding the JMC repository in the exception list for the License and Reuse checks, As it is a fork of openjdk/jmc repository.