### PR TITLE
Address Non-Deterministic Behavior in Unit Test

### DIFF
--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/artifact/VulnerabilitiesFromOwaspDependencyCheckTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/artifact/VulnerabilitiesFromOwaspDependencyCheckTest.java
@@ -11,11 +11,12 @@ import com.sap.oss.phosphor.fosstars.data.owasp.model.OwaspDependencyCheckEntry;
 import com.sap.oss.phosphor.fosstars.model.subject.oss.MavenArtifact;
 import com.sap.oss.phosphor.fosstars.model.value.ValueHashSet;
 import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
-import com.sap.oss.phosphor.fosstars.model.value.Vulnerability;
 import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.File;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.Test;
 
 public class VulnerabilitiesFromOwaspDependencyCheckTest {
@@ -49,8 +50,9 @@ public class VulnerabilitiesFromOwaspDependencyCheckTest {
     Vulnerabilities vulnerabilities = values.of(VULNERABILITIES_IN_ARTIFACT).get().get();
     assertEquals(3, vulnerabilities.size());
 
-    Vulnerability vulnerability = vulnerabilities.entries().iterator().next();
-    assertEquals("CVE-2018-11307", vulnerability.id());
+    Set<String> vulnerabilityIds = new HashSet<>();
+    vulnerabilities.entries().forEach((vulnerability) -> vulnerabilityIds.add(vulnerability.id()));
+    assertTrue(vulnerabilityIds.contains("CVE-2018-11307"));
   }
 
   @Test

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/artifact/VulnerabilitiesFromOwaspDependencyCheckTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/artifact/VulnerabilitiesFromOwaspDependencyCheckTest.java
@@ -14,9 +14,7 @@ import com.sap.oss.phosphor.fosstars.model.value.Vulnerabilities;
 import com.sap.oss.phosphor.fosstars.util.Json;
 import java.io.File;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.Test;
 
 public class VulnerabilitiesFromOwaspDependencyCheckTest {

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/artifact/VulnerabilitiesFromOwaspDependencyCheckTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/artifact/VulnerabilitiesFromOwaspDependencyCheckTest.java
@@ -48,9 +48,8 @@ public class VulnerabilitiesFromOwaspDependencyCheckTest {
     Vulnerabilities vulnerabilities = values.of(VULNERABILITIES_IN_ARTIFACT).get().get();
     assertEquals(3, vulnerabilities.size());
 
-    Set<String> vulnerabilityIds = new HashSet<>();
-    vulnerabilities.entries().forEach((vulnerability) -> vulnerabilityIds.add(vulnerability.id()));
-    assertTrue(vulnerabilityIds.contains("CVE-2018-11307"));
+    assertTrue(vulnerabilities.entries().stream()
+        .anyMatch(vulnerability -> "CVE-2018-11307".equals(vulnerability.id())));
   }
 
   @Test


### PR DESCRIPTION
**Description**
This PR addresses the issue described here: https://github.com/SAP/fosstars-rating-core/issues/817. 
Essentially, the problem lies in assuming a specific iteration order for a `HashSet` in the test `com.sap.oss.phosphor.fosstars.data.artifact.VulnerabilitiesFromOwaspDependencyCheckTest.testVulnerabilitiesAvailable`. 

**Solution**
We can add all of the vulnerability ids into a `HashSet`. Then, we can just assert that this `HashSet` contains the specific vulnerability id. This way, we make no assumptions about iteration order.
