### PR TITLE
addition of readme file type

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/ReadmeInfo.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/ReadmeInfo.java
@@ -39,7 +39,8 @@ public class ReadmeInfo extends GitHubCachingDataProvider {
    */
   private static final List<String> KNOWN_README_FILES
       = Arrays.asList("README", "README.txt", "README.md", "README.rst",
-          "README.adoc", "readme", "readme.txt", "readme.md", "readme.rst", "readme.adoc");
+          "README.adoc", "readme", "readme.txt", "readme.md", "readme.rst", 
+          "readme.adoc", "README.MD", "readme.MD");
 
   /**
    * A list of patterns that describe required content in README.

--- a/src/test/java/com/sap/oss/phosphor/fosstars/data/github/ReadmeInfoTest.java
+++ b/src/test/java/com/sap/oss/phosphor/fosstars/data/github/ReadmeInfoTest.java
@@ -151,6 +151,12 @@ public class ReadmeInfoTest extends TestGitHubDataFetcherHolder {
   }  
 
   @Test
+  public void testReadmeCapital() throws IOException {
+    readMeTestGen("README.MD");
+    readMeTestGen("readme.MD");
+  } 
+
+  @Test
   public void testLoadingDefaultConfig() throws IOException {
     Path config = Paths.get(String.format("%s.config.yml", ReadmeInfo.class.getSimpleName()));
     String content = "---\n"


### PR DESCRIPTION
As per the issue - https://github.com/sap-tutorials/Tutorials/issues/18895
The repository has the README.MD but fosstars does not understand it, so adding the new file type.