### PR TITLE
Change in the accept header for vulnerability alerts

### DIFF
--- a/src/main/java/com/sap/oss/phosphor/fosstars/data/github/VulnerabilityAlertsInfo.java
+++ b/src/main/java/com/sap/oss/phosphor/fosstars/data/github/VulnerabilityAlertsInfo.java
@@ -77,7 +77,7 @@ public class VulnerabilityAlertsInfo extends GitHubCachingDataProvider {
       String url = String.format("https://api.github.com/repos/%s/%s/vulnerability-alerts",
           project.organization().name(), project.name());
       HttpGet request = new HttpGet(url);
-      request.addHeader(HttpHeaders.ACCEPT, "application/vnd.github.dorian-preview+json");
+      request.addHeader(HttpHeaders.ACCEPT, "application/vnd.github+json");
       request.addHeader(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", fetcher.token()));
       try (CloseableHttpResponse response = client.execute(request)) {
         return ENABLED_VULNERABILITY_ALERTS_ON_GITHUB


### PR DESCRIPTION
The code seems to be raising false GH issues so I checked the updated github api doc - https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#check-if-vulnerability-alerts-are-enabled-for-a-repository