### PR TITLE
Just testing the pipeline with sapmachine17 instead of Adopt OpenJDK 8

### DIFF
--- a/.github/actions/project-security-report-action/Dockerfile
+++ b/.github/actions/project-security-report-action/Dockerfile
@@ -1,17 +1,17 @@
-FROM openjdk:8
+FROM maven:3.9.5-sapmachine-17
 
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y git jq
 
-RUN wget https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz && \
-    HASH=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0 && \
-    echo "$HASH apache-maven-3.6.3-bin.tar.gz" | sha512sum --check --status && \
-    tar xf apache-maven-3.6.3-bin.tar.gz -C /opt
+#RUN wget https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz && \
+#    HASH=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0 && \
+#    echo "$HASH apache-maven-3.6.3-bin.tar.gz" | sha512sum --check --status && \
+#    tar xf apache-maven-3.6.3-bin.tar.gz -C /opt
 
-ENV M2_HOME="/opt/apache-maven-3.6.3"
-ENV MAVEN_HOME="/opt/apache-maven-3.6.3"
-ENV PATH="${MAVEN_HOME}/bin:${PATH}"
+#ENV M2_HOME="/opt/apache-maven-3.6.3"
+#ENV MAVEN_HOME="/opt/apache-maven-3.6.3"
+#ENV PATH="${MAVEN_HOME}/bin:${PATH}"
 
 RUN mvn -version
 

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -15,12 +15,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-    - uses: actions/checkout@v3.5.3
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v3
+    - name: Checkout repository
+      uses: actions/checkout@v3.5.3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        distribution: 'adopt'
-        java-version: 8
+        distribution: 'sapmachine'
+        java-version: '17'
     - name: Build
       run: mvn -B -ntp --file pom.xml -DskipTests package
       env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,9 +23,15 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3.5.3
 
+    - name: Set up SapMachine 17
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'sapmachine'
+        java-version: '17'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
@@ -34,4 +40,4 @@ jobs:
         MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,11 +18,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v3.5.3
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        distribution: 'adopt'
-        java-version: 8
+        distribution: 'sapmachine'
+        java-version: '17'
     - name: Build with Maven
       run: mvn -B -ntp package --file pom.xml
       env:


### PR DESCRIPTION
to see if I can reproduce my local test failures also in the pipeline.

As expected I can reproduce the test failure on a newer Java Distro:
![image](https://github.com/user-attachments/assets/a75749db-bfe7-4780-86d7-69ad12c76bd4)

I suspect the flaky test to be related to access of static global variables during test execution.